### PR TITLE
Fail if the leaf name of an object in the policy environment differs from the last element of the path

### DIFF
--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -358,9 +358,9 @@ def environment_is_invalid(
     if paths_with_incorrect_leaf_names:
         formatted_paths = "\n".join(paths_with_incorrect_leaf_names)
         msg = format_errors_and_warnings(
-            "The name of the last branch element of the policy environment must be the "
-            "same as the leaf name of the PolicyFunction. The following tree paths are "
-            "not compatible with the PolicyFunction: "
+            "The last element of the object's path must be the same as the leaf name "
+            "of that object. The following tree paths are not compatible with the "
+            "corresponding object in the policy environment: "
             f"\n\n{formatted_paths}"
         )
         raise ValueError(msg)

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -350,6 +350,21 @@ def environment_is_invalid(
         tree_name="policy_environment",
     )
 
+    flat_policy_environment = dt.flatten_to_tree_paths(policy_environment)
+    paths_with_incorrect_leaf_names = []
+    for p, f in flat_policy_environment.items():
+        if hasattr(f, "leaf_name") and p[-1] != f.leaf_name:
+            paths_with_incorrect_leaf_names.append(str(p))
+    if paths_with_incorrect_leaf_names:
+        formatted_paths = "\n".join(paths_with_incorrect_leaf_names)
+        msg = format_errors_and_warnings(
+            "The name of the last branch element of the policy environment must be the "
+            "same as the leaf name of the PolicyFunction. The following tree paths are "
+            "not compatible with the PolicyFunction: "
+            f"\n\n{formatted_paths}"
+        )
+        raise ValueError(msg)
+
 
 @fail_function()
 def foreign_keys_are_invalid_in_data(

--- a/src/ttsim/interface_dag_elements/policy_environment.py
+++ b/src/ttsim/interface_dag_elements/policy_environment.py
@@ -68,15 +68,22 @@ def policy_environment(
     """
     return {
         "policy_year": ScalarParam(
+            leaf_name="policy_year",
             value=policy_date.year,
             start_date=policy_date,
             end_date=policy_date,
         ),
         "policy_month": ScalarParam(
-            value=policy_date.month, start_date=policy_date, end_date=policy_date
+            leaf_name="policy_month",
+            value=policy_date.month,
+            start_date=policy_date,
+            end_date=policy_date,
         ),
         "policy_day": ScalarParam(
-            value=policy_date.day, start_date=policy_date, end_date=policy_date
+            leaf_name="policy_day",
+            value=policy_date.day,
+            start_date=policy_date,
+            end_date=policy_date,
         ),
         "evaluation_year": PolicyInput(
             leaf_name="evaluation_year",

--- a/tests/interface_dag_elements/test_data_converters.py
+++ b/tests/interface_dag_elements/test_data_converters.py
@@ -42,6 +42,11 @@ def int_policy_function() -> int:
     return 1
 
 
+@policy_function()
+def another_int_policy_function() -> int:
+    return 1
+
+
 @param_function()
 def int_param_function() -> int:
     return 1
@@ -130,12 +135,12 @@ def test_df_with_mapped_columns_to_flat_data(
         # Two policy functions
         (
             {
-                "some_policy_function": int_policy_function,
-                "another_policy_function": int_policy_function,
+                "int_policy_function": int_policy_function,
+                "another_int_policy_function": another_int_policy_function,
             },
             {
-                "some_policy_function": "res1",
-                "another_policy_function": "res2",
+                "int_policy_function": "res1",
+                "another_int_policy_function": "res2",
             },
             pd.DataFrame(
                 {"res1": numpy.array([1, 1, 1]), "res2": numpy.array([1, 1, 1])},
@@ -145,10 +150,10 @@ def test_df_with_mapped_columns_to_flat_data(
         # One policy function
         (
             {
-                "some_policy_function": int_policy_function,
+                "int_policy_function": int_policy_function,
             },
             {
-                "some_policy_function": "res1",
+                "int_policy_function": "res1",
             },
             pd.DataFrame(
                 {"res1": numpy.array([1, 1, 1])},
@@ -158,10 +163,10 @@ def test_df_with_mapped_columns_to_flat_data(
         # One param function
         (
             {
-                "some_param_function": int_param_function,
+                "int_param_function": int_param_function,
             },
             {
-                "some_param_function": "res1",
+                "int_param_function": "res1",
             },
             pd.DataFrame(
                 {"res1": numpy.array([1, 1, 1])},
@@ -171,12 +176,12 @@ def test_df_with_mapped_columns_to_flat_data(
         # One param function and one policy function
         (
             {
-                "some_param_function": int_param_function,
-                "some_policy_function": int_policy_function,
+                "int_param_function": int_param_function,
+                "int_policy_function": int_policy_function,
             },
             {
-                "some_param_function": "res1",
-                "some_policy_function": "res2",
+                "int_param_function": "res1",
+                "int_policy_function": "res2",
             },
             pd.DataFrame(
                 {"res1": numpy.array([1, 1, 1]), "res2": numpy.array([1, 1, 1])},
@@ -198,11 +203,11 @@ def test_df_with_mapped_columns_to_flat_data(
         (
             {
                 "some_scalar_param": _SOME_SCALAR_PARAM,
-                "some_policy_function": int_policy_function,
+                "int_policy_function": int_policy_function,
             },
             {
                 "some_scalar_param": "res1",
-                "some_policy_function": "res2",
+                "int_policy_function": "res2",
             },
             pd.DataFrame(
                 {"res1": numpy.array([1, 1, 1]), "res2": numpy.array([1, 1, 1])},

--- a/tests/interface_dag_elements/test_failures.py
+++ b/tests/interface_dag_elements/test_failures.py
@@ -73,8 +73,8 @@ _GENERIC_PARAM_SPEC = {
     **_GENERIC_PARAM_HEADER,
 }
 
-_SOME_CONSECUTIVE_INT_LOOKUP_TABLE_PARAM = ConsecutiveIntLookupTableParam(
-    leaf_name="some_consecutive_int_nd_lookup_table_param",
+some_consecutive_int_lookup_table_param = ConsecutiveIntLookupTableParam(
+    leaf_name="some_consecutive_int_lookup_table_param",
     value=ConsecutiveIntLookupTableParamValue(
         bases_to_subtract=numpy.array([1]),
         xnp=numpy,
@@ -83,14 +83,14 @@ _SOME_CONSECUTIVE_INT_LOOKUP_TABLE_PARAM = ConsecutiveIntLookupTableParam(
     **_GENERIC_PARAM_SPEC,
 )
 
-_SOME_DICT_PARAM = DictParam(
+some_dict_param = DictParam(
     leaf_name="some_dict_param",
     value={"a": 1, "b": 2},
     **_GENERIC_PARAM_SPEC,
 )
 
 
-_SOME_PIECEWISE_POLYNOMIAL_PARAM = PiecewisePolynomialParam(
+some_piecewise_polynomial_param = PiecewisePolynomialParam(
     leaf_name="some_piecewise_polynomial_param",
     value=PiecewisePolynomialParamValue(
         thresholds=numpy.array([1, 2, 3]),
@@ -535,7 +535,7 @@ def test_fail_if_active_periods_overlap_raises(
     [
         (
             {
-                "some_dict_param": _SOME_DICT_PARAM,
+                "some_dict_param": some_dict_param,
             },
             {"some_dict_param": "res1"},
         ),
@@ -727,7 +727,7 @@ def test_fail_if_input_df_mapper_has_incorrect_format(
     [
         (
             {
-                "some_piecewise_polynomial_param": _SOME_PIECEWISE_POLYNOMIAL_PARAM,
+                "some_piecewise_polynomial_param": some_piecewise_polynomial_param,
             },
             {"some_piecewise_polynomial_param": "res1"},
             "The data contains objects that cannot be cast to a pandas.DataFrame",
@@ -735,7 +735,7 @@ def test_fail_if_input_df_mapper_has_incorrect_format(
         (
             {
                 "some_consecutive_int_lookup_table_param": (
-                    _SOME_CONSECUTIVE_INT_LOOKUP_TABLE_PARAM
+                    some_consecutive_int_lookup_table_param
                 ),
             },
             {"some_consecutive_int_lookup_table_param": "res1"},
@@ -1332,13 +1332,12 @@ def test_fail_if_environment_is_invalid(policy_environment, match):
         },
         # Valid environment with param functions
         {
-            "valid_param": some_param_func_returning_array_of_length_2,
-            "another_param": some_param_func_returning_list_of_length_2,
+            "some_param_func_returning_array_of_length_2": some_param_func_returning_array_of_length_2,
         },
         # Valid environment with param objects
         {
-            "valid_param_obj": _SOME_DICT_PARAM,
-            "another_param_obj": _SOME_PIECEWISE_POLYNOMIAL_PARAM,
+            "some_dict_param": some_dict_param,
+            "some_piecewise_polynomial_param": some_piecewise_polynomial_param,
         },
         # Valid environment with module types
         {
@@ -1349,16 +1348,16 @@ def test_fail_if_environment_is_invalid(policy_environment, match):
         # Valid environment with nested structure
         {
             "nested": {
-                "valid_func": policy_function(leaf_name="nested_func")(identity),
-                "valid_param": some_param_func_returning_array_of_length_2,
+                "nested_func": policy_function(leaf_name="nested_func")(identity),
+                "some_param_func_returning_array_of_length_2": some_param_func_returning_array_of_length_2,
             },
-            "top_level": _SOME_DICT_PARAM,
+            "some_dict_param": some_dict_param,
         },
         # Valid environment with mixed types
         {
             "func": policy_function(leaf_name="func")(identity),
-            "param": some_param_func_returning_array_of_length_2,
-            "param_obj": _SOME_DICT_PARAM,
+            "some_param_func_returning_array_of_length_2": some_param_func_returning_array_of_length_2,
+            "some_dict_param": some_dict_param,
             "module": numpy,
             "backend": "jax",
         },
@@ -1377,6 +1376,29 @@ def test_invalid_input_data_as_object_via_main(backend: Literal["jax", "numpy"])
             input_data=InputData.tree(tree=object()),
             orig_policy_objects={"root": METTSIM_ROOT},
             policy_date_str="2025-01-01",
+        )
+
+
+@pytest.mark.parametrize(
+    "policy_environment",
+    [
+        {"foo": policy_function(leaf_name="bar")(return_one)},
+    ],
+)
+def test_fail_if_name_of_last_branch_element_is_not_the_functions_leaf_name(
+    policy_environment: PolicyEnvironment,
+    xnp: ModuleType,
+):
+    with pytest.raises(
+        ValueError,
+        match="must be the same\nas the leaf name of the PolicyFunction",
+    ):
+        main(
+            main_target=MainTarget.results.df_with_nested_columns,
+            policy_date_str="2025-01-01",
+            orig_policy_objects=OrigPolicyObjects(root=METTSIM_ROOT),
+            input_data=InputData.tree(tree={"p_id": xnp.array([0, 1, 2])}),
+            policy_environment=policy_environment,
         )
 
 
@@ -1541,7 +1563,7 @@ def some_policy_input() -> int:
             "some_policy_function": some_policy_function,
             "policy_input": some_policy_input,
             "some_scalar": 42,
-            "some_dict_param": _SOME_DICT_PARAM,
+            "some_dict_param": some_dict_param,
         },
     ],
 )
@@ -1593,7 +1615,7 @@ def test_param_function_depends_on_column_objects_via_main(
 
     with pytest.raises(
         ValueError,
-        match="`invalid_param` depends on `some_policy_function`",
+        match="`invalid_param_function` depends on `some_policy_function`",
     ):
         main(
             policy_date_str="2025-01-01",
@@ -1611,7 +1633,7 @@ def test_param_function_depends_on_column_objects_via_main(
             },
             backend=backend,
             policy_environment={
-                "invalid_param": invalid_param_function,
+                "invalid_param_function": invalid_param_function,
                 "some_policy_function": some_policy_function,
             },
         )

--- a/tests/interface_dag_elements/test_specialized_environment.py
+++ b/tests/interface_dag_elements/test_specialized_environment.py
@@ -300,9 +300,9 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
-                    "f": policy_function(vectorization_strategy="vectorize")(
-                        return_n1__x_kin
-                    ),
+                    "f": policy_function(
+                        leaf_name="f", vectorization_strategy="vectorize"
+                    )(return_n1__x_kin),
                     "x": x,
                 },
             },
@@ -319,9 +319,9 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
-                    "f": policy_function(vectorization_strategy="vectorize")(
-                        return_x_kin
-                    ),
+                    "f": policy_function(
+                        leaf_name="f", vectorization_strategy="vectorize"
+                    )(return_x_kin),
                     "x": x,
                 },
             },
@@ -338,7 +338,9 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
-                    "f": policy_function(vectorization_strategy="vectorize")(some_x),
+                    "f": policy_function(
+                        leaf_name="f", vectorization_strategy="vectorize"
+                    )(some_x),
                     "x": x,
                 },
             },
@@ -355,7 +357,9 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
-                    "f": policy_function(vectorization_strategy="vectorize")(some_x),
+                    "f": policy_function(
+                        leaf_name="f", vectorization_strategy="vectorize"
+                    )(some_x),
                     "x": x,
                 },
                 "y_kin": y_kin,

--- a/tests/interface_dag_elements/test_templates.py
+++ b/tests/interface_dag_elements/test_templates.py
@@ -27,7 +27,7 @@ POLICY_TEST_IDS_AND_CASES = load_policy_test_data(
 
 p1 = ScalarParam(
     value=1,
-    leaf_name="some_int_param",
+    leaf_name="p1",
     start_date="2025-01-01",
     end_date="2025-12-31",
     name="some_int_param",
@@ -40,7 +40,7 @@ p1 = ScalarParam(
 
 p2 = DictParam(
     value={"a": 1, "b": 2},
-    leaf_name="some_dict_param",
+    leaf_name="p2",
     start_date="2025-01-01",
     end_date="2025-12-31",
     name="some_dict_param",

--- a/tests/interface_dag_elements/test_warnings.py
+++ b/tests/interface_dag_elements/test_warnings.py
@@ -34,9 +34,9 @@ def test_warn_if_functions_and_data_columns_overlap(backend):
             },
             policy_environment={
                 "some_func": some_func,
-                "some_target": another_func,
+                "another_func": another_func,
             },
-            tt_targets={"tree": {"some_target": None}},
+            tt_targets={"tree": {"another_func": None}},
             evaluation_date=datetime.date(2025, 1, 1),
             rounding=False,
             include_fail_nodes=False,
@@ -67,14 +67,14 @@ def test_warn_if_functions_and_columns_overlap_no_warning_if_no_overlap(backend)
 
 def test_warn_if_evaluation_date_set_in_multiple_places(backend):
     policy_environment = {
-        "policy_year": ScalarParam(value=2025),
-        "policy_month": ScalarParam(value=1),
-        "policy_day": ScalarParam(value=1),
-        "evaluation_year": ScalarParam(value=2025),
-        "evaluation_month": ScalarParam(value=1),
-        "evaluation_day": ScalarParam(value=1),
+        "policy_year": ScalarParam(value=2025, leaf_name="policy_year"),
+        "policy_month": ScalarParam(value=1, leaf_name="policy_month"),
+        "policy_day": ScalarParam(value=1, leaf_name="policy_day"),
+        "evaluation_year": ScalarParam(value=2025, leaf_name="evaluation_year"),
+        "evaluation_month": ScalarParam(value=1, leaf_name="evaluation_month"),
+        "evaluation_day": ScalarParam(value=1, leaf_name="evaluation_day"),
         "some_func": some_func,
-        "some_target": another_func,
+        "another_func": another_func,
     }
     with pytest.warns(match="You have specified the evaluation date in more than one"):
         main(
@@ -87,14 +87,14 @@ def test_warn_if_evaluation_date_set_in_multiple_places(backend):
 
 def test_warn_if_evaluation_date_set_in_multiple_places_implicitly_added(backend, xnp):
     policy_environment = {
-        "policy_year": ScalarParam(value=2025),
-        "policy_month": ScalarParam(value=1),
-        "policy_day": ScalarParam(value=1),
-        "evaluation_year": ScalarParam(value=2025),
-        "evaluation_month": ScalarParam(value=1),
-        "evaluation_day": ScalarParam(value=1),
+        "policy_year": ScalarParam(value=2025, leaf_name="policy_year"),
+        "policy_month": ScalarParam(value=1, leaf_name="policy_month"),
+        "policy_day": ScalarParam(value=1, leaf_name="policy_day"),
+        "evaluation_year": ScalarParam(value=2025, leaf_name="evaluation_year"),
+        "evaluation_month": ScalarParam(value=1, leaf_name="evaluation_month"),
+        "evaluation_day": ScalarParam(value=1, leaf_name="evaluation_day"),
         "some_func": some_func,
-        "some_target": another_func,
+        "another_func": another_func,
     }
     with pytest.warns(match="You have specified the evaluation date in more than one"):
         main(
@@ -108,11 +108,11 @@ def test_warn_if_evaluation_date_set_in_multiple_places_implicitly_added(backend
 
 def test_do_not_need_to_warn_if_evaluation_date_is_set_only_once(backend, xnp):
     policy_environment = {
-        "policy_year": ScalarParam(value=2025),
-        "policy_month": ScalarParam(value=1),
-        "policy_day": ScalarParam(value=1),
+        "policy_year": ScalarParam(value=2025, leaf_name="policy_year"),
+        "policy_month": ScalarParam(value=1, leaf_name="policy_month"),
+        "policy_day": ScalarParam(value=1, leaf_name="policy_day"),
         "some_func": some_func,
-        "some_target": another_func,
+        "another_func": another_func,
     }
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")


### PR DESCRIPTION
### What problem do you want to solve?

This adds a modifies the `policy_environment_invalid` function such that it raises an error if the object's leaf name differs from the name of the last path element.

@hmgaudecker What I didn't think about when I agreed to add this, is that parameter would need a leaf name too. Having the experience from writing the notebook I think this would be pretty annoying, especially for small changes, e.g. changing a scalar parameter. Maybe we should just throw a warning?