### PR TITLE
Turn on `fail_if` nodes when running policy tests

### DIFF
--- a/src/ttsim/testing_utils.py
+++ b/src/ttsim/testing_utils.py
@@ -113,7 +113,7 @@ def execute_test(
             tt_targets={"tree": test.target_structure},
             rounding=True,
             backend=backend,
-            include_fail_nodes=False,
+            include_fail_nodes=True,
             include_warn_nodes=False,
         )
 


### PR DESCRIPTION
### What problem do you want to solve?

I tried both versions (with/without fail nodes) using GETTSIM's tests with the py13 environment and backend numpy. 52 vs 53 seconds, so should be no big deal turning it on.