### PR TITLE
Add ability to create a pruned DAG plot

### DIFF
--- a/src/ttsim/plot/dag/tt.py
+++ b/src/ttsim/plot/dag/tt.py
@@ -19,8 +19,6 @@ from ttsim.tt import (
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Any
-    from collections.abc import Callable
 
     import plotly.graph_objects as go
 
@@ -79,10 +77,10 @@ def tt(
     output_path
         If provided, the figure is written to the path.
     input_node_paths
-        List of node paths to treat as inputs (i.e., exclude from computation and 
-        show as leaf nodes). Each path is a tuple of strings representing the path 
-        to a node in the policy tree. When provided, these nodes will be excluded 
-        from the DAG computation, effectively "pruning" the graph to show what 
+        List of node paths to treat as inputs (i.e., exclude from computation and
+        show as leaf nodes). Each path is a tuple of strings representing the path
+        to a node in the policy tree. When provided, these nodes will be excluded
+        from the DAG computation, effectively "pruning" the graph to show what
         would be computed if these values were provided as inputs.
 
     Returns
@@ -101,8 +99,8 @@ def tt(
         if node_selector is None:
             node_selector = NodeSelector(
                 node_paths=[],  # Empty list - we only care about the input_node_paths
-                type="nodes",   # Default type
-                input_node_paths=input_node_paths
+                type="nodes",  # Default type
+                input_node_paths=input_node_paths,
             )
         else:
             # Create a new NodeSelector with the input_node_paths added
@@ -116,8 +114,10 @@ def tt(
     if node_selector:
         input_qnames = None
         if node_selector.input_node_paths:
-            input_qnames = [dt.qname_from_tree_path(qn) for qn in node_selector.input_node_paths]
-        
+            input_qnames = [
+                dt.qname_from_tree_path(qn) for qn in node_selector.input_node_paths
+            ]
+
         qname_node_selector = _QNameNodeSelector(
             qnames=[dt.qname_from_tree_path(qn) for qn in node_selector.node_paths],
             type=node_selector.type,
@@ -180,16 +180,16 @@ def _get_tt_dag_with_node_metadata(
     if node_selector and node_selector.input_qnames:
         # Create pruned environment by excluding input nodes before conversion
         env_without_inputs = {
-            qn: n for qn, n in env.items() 
-            if qn not in node_selector.input_qnames
+            qn: n for qn, n in env.items() if qn not in node_selector.input_qnames
         }
         # Also filter targets to exclude input nodes
         targets_without_inputs = [
-            qn for qn in qnames_to_plot 
-            if qn not in node_selector.input_qnames
+            qn for qn in qnames_to_plot if qn not in node_selector.input_qnames
         ]
         all_nodes = convert_all_nodes_to_callables(env_without_inputs)
-        complete_dag = dags.create_dag(functions=all_nodes, targets=targets_without_inputs)  # type: ignore[arg-type]
+        complete_dag = dags.create_dag(
+            functions=all_nodes, targets=targets_without_inputs
+        )  # type: ignore[arg-type]
         # Use the original env for metadata since complete_dag may still reference pruned nodes
         metadata_env = env
     else:

--- a/src/ttsim/plot/dag/tt.py
+++ b/src/ttsim/plot/dag/tt.py
@@ -69,7 +69,7 @@ def tt(
     root
         The root path.
     node_selector
-        A NodeSelector to specify the nodes to plot.
+        The node selector. Default is None, i.e. the entire DAG is plotted.
     title
         The title of the plot.
     include_params

--- a/tests/test_input_node_paths.py
+++ b/tests/test_input_node_paths.py
@@ -1,9 +1,8 @@
 """Test the new input_node_paths feature for TTSIM DAG plotting."""
 
-import pytest
 from pathlib import Path
 
-from ttsim.plot.dag.tt import tt, NodeSelector
+from ttsim.plot.dag.tt import NodeSelector, tt
 
 
 class TestInputNodePaths:
@@ -15,10 +14,10 @@ class TestInputNodePaths:
             policy_date_str="2025-01-01",
             root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
             title="Basic Test",
-            include_params=False
+            include_params=False,
         )
         assert fig is not None
-        assert hasattr(fig, 'data')
+        assert hasattr(fig, "data")
 
     def test_input_node_paths_parameter(self):
         """Test the new input_node_paths parameter."""
@@ -27,10 +26,10 @@ class TestInputNodePaths:
             root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
             title="Test with input_node_paths",
             include_params=False,
-            input_node_paths=[("age",)]  # Use actual function name
+            input_node_paths=[("age",)],  # Use actual function name
         )
         assert fig is not None
-        assert hasattr(fig, 'data')
+        assert hasattr(fig, "data")
 
     def test_multiple_input_node_paths(self):
         """Test with multiple input node paths."""
@@ -39,13 +38,10 @@ class TestInputNodePaths:
             root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
             title="Test with multiple inputs",
             include_params=False,
-            input_node_paths=[
-                ("age",),
-                ("p_id",)
-            ]
+            input_node_paths=[("age",), ("p_id",)],
         )
         assert fig is not None
-        assert hasattr(fig, 'data')
+        assert hasattr(fig, "data")
 
     def test_empty_input_node_paths(self):
         """Test with empty input_node_paths list."""
@@ -54,34 +50,34 @@ class TestInputNodePaths:
             root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
             title="Test with empty input_node_paths",
             include_params=False,
-            input_node_paths=[]
+            input_node_paths=[],
         )
         assert fig is not None
-        assert hasattr(fig, 'data')
+        assert hasattr(fig, "data")
 
     def test_node_selector_with_input_node_paths(self):
         """Test combining NodeSelector with input_node_paths."""
         node_selector = NodeSelector(
             node_paths=[("age",)],  # Use actual function, not module
             type="descendants",
-            input_node_paths=[("age",)]
+            input_node_paths=[("age",)],
         )
         fig = tt(
             policy_date_str="2025-01-01",
             root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
             title="Test NodeSelector with input_node_paths",
             include_params=False,
-            node_selector=node_selector
+            node_selector=node_selector,
         )
         assert fig is not None
-        assert hasattr(fig, 'data')
+        assert hasattr(fig, "data")
 
     def test_input_node_paths_overrides_node_selector(self):
         """Test that input_node_paths parameter overrides NodeSelector's input_node_paths."""
         node_selector = NodeSelector(
             node_paths=[("age",)],  # Use actual function, not module
             type="descendants",
-            input_node_paths=[("p_id",)]  # This should be overridden
+            input_node_paths=[("p_id",)],  # This should be overridden
         )
         fig = tt(
             policy_date_str="2025-01-01",
@@ -89,7 +85,7 @@ class TestInputNodePaths:
             title="Test input_node_paths override",
             include_params=False,
             node_selector=node_selector,
-            input_node_paths=[("age",)]  # This should take precedence
+            input_node_paths=[("age",)],  # This should take precedence
         )
         assert fig is not None
-        assert hasattr(fig, 'data')
+        assert hasattr(fig, "data")

--- a/tests/test_input_node_paths.py
+++ b/tests/test_input_node_paths.py
@@ -1,0 +1,95 @@
+"""Test the new input_node_paths feature for TTSIM DAG plotting."""
+
+import pytest
+from pathlib import Path
+
+from ttsim.plot.dag.tt import tt, NodeSelector
+
+
+class TestInputNodePaths:
+    """Test the input_node_paths feature."""
+
+    def test_basic_plotting_still_works(self):
+        """Ensure basic plotting functionality is unchanged."""
+        fig = tt(
+            policy_date_str="2025-01-01",
+            root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
+            title="Basic Test",
+            include_params=False
+        )
+        assert fig is not None
+        assert hasattr(fig, 'data')
+
+    def test_input_node_paths_parameter(self):
+        """Test the new input_node_paths parameter."""
+        fig = tt(
+            policy_date_str="2025-01-01",
+            root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
+            title="Test with input_node_paths",
+            include_params=False,
+            input_node_paths=[("age",)]  # Use actual function name
+        )
+        assert fig is not None
+        assert hasattr(fig, 'data')
+
+    def test_multiple_input_node_paths(self):
+        """Test with multiple input node paths."""
+        fig = tt(
+            policy_date_str="2025-01-01",
+            root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
+            title="Test with multiple inputs",
+            include_params=False,
+            input_node_paths=[
+                ("age",),
+                ("p_id",)
+            ]
+        )
+        assert fig is not None
+        assert hasattr(fig, 'data')
+
+    def test_empty_input_node_paths(self):
+        """Test with empty input_node_paths list."""
+        fig = tt(
+            policy_date_str="2025-01-01",
+            root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
+            title="Test with empty input_node_paths",
+            include_params=False,
+            input_node_paths=[]
+        )
+        assert fig is not None
+        assert hasattr(fig, 'data')
+
+    def test_node_selector_with_input_node_paths(self):
+        """Test combining NodeSelector with input_node_paths."""
+        node_selector = NodeSelector(
+            node_paths=[("age",)],  # Use actual function, not module
+            type="descendants",
+            input_node_paths=[("age",)]
+        )
+        fig = tt(
+            policy_date_str="2025-01-01",
+            root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
+            title="Test NodeSelector with input_node_paths",
+            include_params=False,
+            node_selector=node_selector
+        )
+        assert fig is not None
+        assert hasattr(fig, 'data')
+
+    def test_input_node_paths_overrides_node_selector(self):
+        """Test that input_node_paths parameter overrides NodeSelector's input_node_paths."""
+        node_selector = NodeSelector(
+            node_paths=[("age",)],  # Use actual function, not module
+            type="descendants",
+            input_node_paths=[("p_id",)]  # This should be overridden
+        )
+        fig = tt(
+            policy_date_str="2025-01-01",
+            root=Path(__file__).parent.parent / "mettsim" / "middle_earth",
+            title="Test input_node_paths override",
+            include_params=False,
+            node_selector=node_selector,
+            input_node_paths=[("age",)]  # This should take precedence
+        )
+        assert fig is not None
+        assert hasattr(fig, 'data')


### PR DESCRIPTION
When users create an input template with `MainTarget.templates.input_data_dtypes` and provide inputs that would normally be calculated endogenously to the `input_data` argument, TTSIM creates a "pruned" DAG in which the ancestors of the `input_data` variables are dropped if they are not required to calculate the desired targets (essentially the  previous `columns_overriding_functions` functionality). Thus, the returned template returns the minimum set of required inputs (ignoring #24 for a second), for example:

```python
TT_TARGETS = {
    "arbeitslosengeld_2": {"betrag_m_bg": "alg2_benefit"}, 
}
PROVIDED_AS_INPUT = {
    "p_id": pd.Series([0]),
    "einnahmen": {"renten": {"gesetzliche_m": pd.Series([0.0])}},
    "elterngeld": {"betrag_m": pd.Series([0.0])},
}
input_data = InputData.tree(tree=PROVIDED_AS_INPUT)

pruned_inputs_template = main(
    main_target=MainTarget.templates.input_data_dtypes,
    policy_date_str="2025-01-01",
    tt_targets=TTTargets(tree=TT_TARGETS),
    input_data=input_data,
    include_warn_nodes=False,
)
```

However, when plotting ancestors of the same target(s), we can currently only get a plot containing _all_ ancestors, even if some of them are not required for calculation given the user inputs. For example, 

```python
  from __future__ import annotations
  from gettsim import plot
  
  fig = plot.dag.tt(
      policy_date_str="2025-01-01",
      node_selector=plot.dag.NodeSelector(
          type="ancestors",
          node_paths=[("arbeitslosengeld_2", "betrag_m_bg"),]
      ),
      include_params=False,
      show_node_description=True,
  )
```

gives 
![test](https://github.com/user-attachments/assets/a9491922-d6be-40a4-ae20-8fb40329784c)
 (Unfortunately, it seems Github doesn't allow to upload the interactive HTML plot.)

including many nodes from. e.g., the pension calculations that are not required if `einnahmen__rente__gesetzliche_m` is provided as input by the user.

This PR introduces a new field `input_node_paths` (the name is probably not optimal) for the `NodeSelector` type that essentially allows to mimick the pruning possible with `MainTarget.templates.input_data_dtypes`. For example, 

```python
fig = plot.dag.tt(
    policy_date_str="2025-01-01",
    node_selector=plot.dag.NodeSelector(
        type="ancestors",
        node_paths=[("arbeitslosengeld_2", "betrag_m_bg"),],
        input_node_paths=[
            ("einnahmen", "renten", "gesetzliche_m"),
            ("elterngeld", "betrag_m"),
            ("arbeitslosengeld_2", "regelbedarf_m"),
            ("arbeitslosengeld_2", "nettoeinkommen_vor_abzug_freibetrag_m"),
            ("wohngeld", "anspruchshöhe_m_wthh"),
        ],
    ),
    include_params=False,
    show_node_description=True,
    output_path="test_pruned.html",
)
```

creates 
![test_pruned](https://github.com/user-attachments/assets/0a3b3f77-b936-4f7d-baa1-bbe70b29055a)


The plot now represents the DAG that is actually used for calculating the target(s) if the variables in `input_node_paths` are provided by the user as inputs. The approach also works if `type="descendants"` is used. In that case, the descendants of the `input_node_paths` are  truncated from the plot.

The implementation is essentially completely ‘vibe-coded’ and should be understood more as a basis for discussion than as an actual PR. I am not even sure if this has any real value for users. My whole motivation for this was "wouldn't it be nice to see a DAG representation that resembles the DAG actually used in the calculations given my inputs?".
