### PR TITLE
Optimize JAX performance in data preparation pipeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ This is a record of all past `ttsim` releases and what went into them in reverse
 chronological order. We follow [semantic versioning](https://semver.org/) and all
 releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim).
 
+## unpublished
+
+- {gh}`34` Optimize JAX performance in data preparation pipeline
+  ({ghuser}`JuergenWiemers`)
+
 ## v1.0a3 — 2025-07-27
 
 - {gh}`23` Remove orphaned policy inputs from the TT DAG. ({ghuser}`MImmesberger`)

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -307,7 +307,7 @@ def input_data_is_invalid(input_data__flat: FlatData, xnp: ModuleType) -> None:
     if p_id.shape[0] == 1:  # Special case for single-row data
         return
 
-    p_id_sorted = xnp.sort(p_id)
+    p_id_sorted = xnp.sort(xnp.asarray(p_id))
     duplicates = xnp.diff(p_id_sorted, append=0) == 0
     if xnp.sum(duplicates) >= 1:
         message = (

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -305,10 +305,9 @@ def input_data_is_invalid(input_data__flat: FlatData) -> None:
 
     # Check for non-unique p_ids
     # Convert to numpy array for performance (avoid slow JAX array iteration)
-    p_id_numpy = numpy.asarray(p_id)
 
     # Use pandas duplicated for efficient duplicate detection
-    p_id_series = pd.Series(p_id_numpy)
+    p_id_series = pd.Series(numpy.asarray(p_id))
     duplicated_mask = p_id_series.duplicated(keep=False)
     non_unique_p_ids = p_id_series[duplicated_mask].unique().tolist()
 

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -304,15 +304,13 @@ def input_data_is_invalid(input_data__flat: FlatData) -> None:
         raise ValueError(msg)
 
     # Check for non-unique p_ids
-    p_id_counts: dict[int, int] = {}
-    # Need the map because Jax loop items are 1-element arrays.
-    for i in map(int, p_id):
-        if i in p_id_counts:
-            p_id_counts[i] += 1
-        else:
-            p_id_counts[i] = 1
+    # Convert to numpy array for performance (avoid slow JAX array iteration)
+    p_id_numpy = numpy.asarray(p_id)
 
-    non_unique_p_ids = [i for i, count in p_id_counts.items() if count > 1]
+    # Use pandas duplicated for efficient duplicate detection
+    p_id_series = pd.Series(p_id_numpy)
+    duplicated_mask = p_id_series.duplicated(keep=False)
+    non_unique_p_ids = p_id_series[duplicated_mask].unique().tolist()
 
     if non_unique_p_ids:
         message = (

--- a/src/ttsim/interface_dag_elements/input_data.py
+++ b/src/ttsim/interface_dag_elements/input_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import dags.tree as dt
 
@@ -55,6 +55,7 @@ def tree() -> NestedData:
 def flat_from_df_and_mapper(
     df_and_mapper__df: pd.DataFrame,
     df_and_mapper__mapper: NestedInputsMapper,
+    backend: Literal["numpy", "jax"],
     xnp: ModuleType,
 ) -> FlatData:
     """The input DataFrame as a flattened data structure.
@@ -72,6 +73,7 @@ def flat_from_df_and_mapper(
     return df_with_mapped_columns_to_flat_data(
         df=df_and_mapper__df,
         mapper=df_and_mapper__mapper,
+        backend=backend,
         xnp=xnp,
     )
 
@@ -82,6 +84,7 @@ def flat_from_df_and_mapper(
 )
 def flat_from_df_with_nested_columns(
     df_with_nested_columns: pd.DataFrame,
+    backend: Literal["numpy", "jax"],
     xnp: ModuleType,
 ) -> FlatData:
     """The input DataFrame as a flattened data structure.
@@ -96,6 +99,7 @@ def flat_from_df_with_nested_columns(
     """
     return df_with_nested_columns_to_flat_data(
         df=df_with_nested_columns,
+        backend=backend,
         xnp=xnp,
     )
 

--- a/tests/interface_dag_elements/test_data_converters.py
+++ b/tests/interface_dag_elements/test_data_converters.py
@@ -109,6 +109,7 @@ def test_df_with_mapped_columns_to_flat_data(
     result = df_with_mapped_columns_to_flat_data(
         mapper=inputs_tree_to_df_columns,
         df=df,
+        backend="numpy",
         xnp=numpy,
     )
 
@@ -261,6 +262,7 @@ def test_nested_data_to_dataframe(
 def test_df_with_nested_columns_to_flat_data(df, expected):
     result = df_with_nested_columns_to_flat_data(
         df=df,
+        backend="numpy",
         xnp=numpy,
     )
 

--- a/tests/interface_dag_elements/test_failures.py
+++ b/tests/interface_dag_elements/test_failures.py
@@ -973,22 +973,15 @@ def test_p_id_can_be_specified_as_jax_array(xnp):
     input_data_is_invalid(data, xnp)
 
 
-def test_single_person_with_p_id_zero_does_not_trigger_duplicate_error(xnp):
-    """Test edge case: single person with p_id=0 should not be flagged as duplicate.
+@pytest.mark.parametrize("p_id_value", [-100, 0, 1, 42, 999])
+def test_input_data_single_person_with_any_p_id_works_correctly(xnp, p_id_value):
+    """Test that single-row data works for any p_id value.
 
-    Without the single-row protection in input_data_is_invalid, this test would fail
-    because the duplicate detection logic incorrectly identifies p_id=0 as a duplicate
-    when using xnp.diff([0], append=0) which gives [0], and 0 == 0 is True.
+    The p_id=0 case is particularly important because this test would fail under the
+    implementation of duplicate detection in place at the time of creation (PR #34).
     """
-    data = {("p_id",): xnp.array([0])}
+    data = {("p_id",): xnp.array([p_id_value])}
     input_data_is_invalid(data, xnp)
-
-
-def test_single_person_with_any_p_id_works_correctly(xnp):
-    """Test that single-row data works for any p_id value."""
-    for p_id_value in [-100, 0, 1, 42, 999]:
-        data = {("p_id",): xnp.array([p_id_value])}
-        input_data_is_invalid(data, xnp)
 
 
 def test_fail_if_input_data_has_different_lengths(backend):


### PR DESCRIPTION
Let me start by letting the numbers speak for themselves:

```python
Benchmark Comparison Report
Generated: 2025-08-06T15:13:33.129062
Main branch file: benchmark_results_20250806_150436.json
PR branch file: benchmark_results_20250806_150643.json

==========================================================================================
JAX BACKEND COMPARISON: Main Branch vs PR Branch
==========================================================================================
Households  JAX hash main  JAX hash PR    JAX main (s)   JAX PR (s)     Speedup     
------------------------------------------------------------------------------------------
32,767      9a97a0ef       9a97a0ef       2.4546         0.7370         3.33x       
32,768      c0a7c7e9       c0a7c7e9       2.0527         0.5846         3.51x       
65,536      f873c7c8       f873c7c8       3.4010         0.6154         5.53x       
131,072     84608262       84608262       6.2885         0.7180         8.76x       
262,144     2fb136ba       2fb136ba       12.1383        1.0488         11.57x      
524,288     dd61a524       dd61a524       23.6647        1.9196         12.33x      
1,048,576   6ed4af0a       6ed4af0a       46.8753        3.8041         12.32x      
2,097,152   ff9f600f       ff9f600f       96.5656        8.0620         11.98x      

==========================================================================================
NUMPY BACKEND COMPARISON: Main Branch vs PR Branch
==========================================================================================
Households  NP hash main   NP hash PR     NP main (s)    NP PR (s)      Speedup     
------------------------------------------------------------------------------------------
32,767      2584ff76       2584ff76       0.1028         0.0907         1.13x       
32,768      a4ec6c3f       a4ec6c3f       0.1031         0.0692         1.49x       
65,536      e18ee207       e18ee207       0.1767         0.1279         1.38x       
131,072     e949fd41       e949fd41       0.4076         0.2277         1.79x       
262,144     a8fe5730       a8fe5730       0.7846         0.4868         1.61x       
524,288     c7c95469       c7c95469       1.3177         0.9271         1.42x       
1,048,576   1fbbd4ff       1fbbd4ff       2.8963         2.1271         1.36x       
2,097,152   81209a75       81209a75       6.0628         4.9379         1.23x       

======================================================================
SUMMARY STATISTICS
======================================================================

NUMPY Backend:
--------------------
  Average speedup: 1.43x
  Maximum speedup: 1.79x
  Minimum speedup: 1.13x
  Successful runs: 8/8
  Hash mismatches: 0/8
  ✓ All results are numerically identical

JAX Backend:
--------------------
  Average speedup: 8.67x
  Maximum speedup: 12.33x
  Minimum speedup: 3.33x
  Successful runs: 8/8
  Hash mismatches: 0/8
  ✓ All results are numerically identical
```

### Package for reproducing the benchmark (thanks, Claude): [benchmark.zip](https://github.com/user-attachments/files/21620776/benchmark.zip)

### Explanation/Remarks: 

- Profiling TTSIM (`main(main_targets=MainTarget.processed_data,...)`) for large datasets with the JAX backend shows that the majority of the runtime is spent in `data_converers.df_with_mapped_columns_to_flat_data` and `fail_if.input_data_is_invalid`
  
  ![gettsim_jax_1_000_000_main](https://github.com/user-attachments/assets/2bb7c6e9-6f7c-4dbb-880e-2f7b1f0d8d65)

- Regarding `data_converers.df_with_mapped_columns_to_flat_data`: For the JAX backend, it is much faster to create NumPy arrays first and then convert them to JAX arrays rather than to immediately create JAX arrays.
- Regarding `fail_if.input_data_is_invalid`: The loop over the JAX array is very slow. I think it should be safe to convert `p_id` to a NumPy array and then use Pandas for the duplicates detection.
- I expected the NumPy backend to be more or less unaffected, but it got a little faster as well...
- In case you are wondering "Why 32,767 and 32,768 households?" I found out by experimenting that `xnp.asarray(numpy_array, copy=False)` still copies for arrays smaller than 1MB; at exactly 1MB, JAX gives up and stops creating copies. The duplicated example household has four members, thus 32,768 * 4 * 8 = 1,048,567 = 1 MB (for a 64 bit int or float column). In the results you can see that 32.767 is (consistently, I checked) slower than 32.768 probably because in the former case arrays still get copied despite setting `xnp.asarray(numpy_array, copy=False)`.
- 🔪 ☠️ : You can use the `copy=False` option to mutate "immutable" JAX arrays by mutating the NumPy array that shares the same memory (if the array is >=1MB)! 😮There was probably a heated debate about this "feature" among the JAX developers...
- After the two optimizations the profile looks like this. The bottlenecks are gone.
  
  ![gettsim_jax_1_000_000_PR](https://github.com/user-attachments/assets/ad29f4e0-93a1-42dc-a7f0-046c54020828)

### TODOs

- [x] I am not really sure if this requires new tests. The code just replaces existing code.
- [x] I would like to know if this also results in better performance for JAX-CUDA and/or Metal, but I don't have the hardware to check this...
