### PR TITLE
Plotting: Replace `nodes` selection type with `all_paths`

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -5,6 +5,8 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ This is a record of all past `ttsim` releases and what went into them in reverse
 chronological order. We follow [semantic versioning](https://semver.org/) and all
 releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim).
 
+## Unreleased
+
+- {gh}`38` Plotting: Replace `nodes` selection type with `all_paths`.
+  ({ghuser}`MImmesberger`)
+
 ## v1.0a4 — 2025-08-09
 
 - {gh}`32` Build inputs template and plotting DAG from specialized environment based on

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,14 +4,12 @@ This is a record of all past `ttsim` releases and what went into them in reverse
 chronological order. We follow [semantic versioning](https://semver.org/) and all
 releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim).
 
-## Unreleased
+## v1.0 — 2025-08-09
 
 - {gh}`38` Plotting: Replace `nodes` selection type with `all_paths`.
 
 - {gh}`37` Make it possible to pass all main args as class methods.
   ({ghuser}`MImmesberger`)
-
-## v1.0a4 — 2025-08-09
 
 - {gh}`32` Build inputs template and plotting DAG from specialized environment based on
   policy_inputs ({ghuser}`MImmesberger`)
@@ -19,15 +17,11 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 - {gh}`34` Optimize JAX performance in data preparation pipeline
   ({ghuser}`JuergenWiemers`)
 
-## v1.0a3 — 2025-07-27
-
 - {gh}`23` Remove orphaned policy inputs from the TT DAG. ({ghuser}`MImmesberger`)
 
 - {gh}`19` Clearer architecture ({ghuser}`hmgaudecker`)
 
 - {gh}`17` Add type for sparse dicts with int keys param. ({ghuser}`MImmesberger`)
-
-## v1.0a2 — 2025-07-26
 
 - {gh}`16` Add fail/warn mechanism to ColumnObjects and ParamFunctions.
   ({ghuser}`hmgaudecker`)
@@ -49,8 +43,6 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 - {gh}`6` Fail if the leaf name of an object in the policy environment differs from the
   last element of the path ({ghuser}`MImmesberger`, {ghuser}`hmgaudecker`)
 
-## v1.0a1 — 2025-07-24
-
-- All development happened in a single GETTSIM repository. See
-  [the GETTSIM changelog](https://gettsim.readthedocs.io/en/latest/changes.html) for all
+- Prior to this, all development happened in a single GETTSIM repository. See
+  [the GETTSIM changelog](https://gettsim.readthedocs.io/en/latest/changes.html) for the
   history.

--- a/src/ttsim/plot/dag/shared.py
+++ b/src/ttsim/plot/dag/shared.py
@@ -141,8 +141,6 @@ def get_figure(
         showlegend=False,
         hovermode="closest",
         margin={"b": 40, "l": 40, "r": 40, "t": 60},
-        width=1800,
-        height=1200,
         annotations=annotations,
         xaxis={
             "showgrid": False,

--- a/src/ttsim/plot/dag/tt.py
+++ b/src/ttsim/plot/dag/tt.py
@@ -297,7 +297,7 @@ def select_nodes_from_dag(
     selection_type: Literal["neighbors", "descendants", "ancestors", "all_paths"],
     selection_depth: int | None = None,
 ) -> nx.DiGraph:
-    """Select nodes based on the node selector."""
+    """Select nodes to plot."""
     if selection_type == "neighbors":
         order = selection_depth or 1
         selected_nodes = {

--- a/src/ttsim/plot/dag/tt.py
+++ b/src/ttsim/plot/dag/tt.py
@@ -73,9 +73,7 @@ def tt(
             - "neighbors": Plot the neighbors of the primary nodes.
             - "descendants": Plot the descendants of the primary nodes.
             - "ancestors": Plot the ancestors of the primary nodes.
-            - "all_paths": Plot all paths that connect primary nodes. Primary nodes are
-              omitted if they are not connected to any other primary nodes. Must provide
-              at least two primary nodes.
+            - "all_paths": Plot all paths that connect primary nodes.
         If not provided, the entire DAG is plotted.
     selection_depth
         The depth of the selection. Only used if selection_type is "neighbors",
@@ -335,6 +333,7 @@ def select_nodes_from_dag(
             for path in nx.all_simple_paths(complete_tt_dag, start_node, end_node)
             for node in path
         }
+        selected_nodes = selected_nodes.union(qnames_primary_nodes)
     else:
         msg = (
             f"Invalid selection type: {selection_type}. "

--- a/src/ttsim/plot/dag/tt.py
+++ b/src/ttsim/plot/dag/tt.py
@@ -66,14 +66,16 @@ def tt(
     primary_nodes
         The qnames or paths of the primary nodes. Primary nodes are used to determine
         which other nodes to include in the plot based on the selection_type. They may
-        be root nodes (for descendants), end nodes (for ancestors), or middle nodes
-        (for neighbors). If not provided, the entire DAG is plotted.
+        be root nodes (for descendants), end nodes (for ancestors), or middle nodes (for
+        neighbors). If not provided, the entire DAG is plotted.
     selection_type
         The type of the DAG to plot. Can be one of:
             - "neighbors": Plot the neighbors of the primary nodes.
             - "descendants": Plot the descendants of the primary nodes.
             - "ancestors": Plot the ancestors of the primary nodes.
-            - "all_paths": Plot all paths that connect the primary nodes.
+            - "all_paths": Plot all paths that connect primary nodes. Primary nodes are
+              omitted if they are not connected to any other primary nodes. Must provide
+              at least two primary nodes.
         If not provided, the entire DAG is plotted.
     selection_depth
         The depth of the selection. Only used if selection_type is "neighbors",
@@ -326,6 +328,7 @@ def select_nodes_from_dag(
             )
         }
     elif selection_type == "all_paths":
+        _fail_if_less_than_two_primary_nodes(qnames_primary_nodes)
         selected_nodes = {
             node
             for start_node, end_node in itertools.permutations(qnames_primary_nodes, 2)
@@ -410,5 +413,14 @@ def _fail_if_primary_nodes_not_specified(qnames: set[str] | None) -> None:
             "You must not specify a selection type when no primary nodes are specified."
             " To fix this, either set 'selection_type' to None (this plots the entire "
             "DAG) or provide 'primary_nodes'."
+        )
+        raise ValueError(msg)
+
+
+def _fail_if_less_than_two_primary_nodes(qnames_primary_nodes: set[str]) -> None:
+    if len(qnames_primary_nodes) < 2:  # noqa: PLR2004
+        msg = format_errors_and_warnings(
+            "When using the 'all_paths' selection type, you must provide at least two "
+            f"primary nodes. Got {len(qnames_primary_nodes)}."
         )
         raise ValueError(msg)

--- a/src/ttsim/plot/dag/tt.py
+++ b/src/ttsim/plot/dag/tt.py
@@ -73,7 +73,9 @@ def tt(
             - "neighbors": Plot the neighbors of the primary nodes.
             - "descendants": Plot the descendants of the primary nodes.
             - "ancestors": Plot the ancestors of the primary nodes.
-            - "all_paths": Plot all paths that connect primary nodes.
+            - "all_paths": All paths between the primary nodes are displayed (including
+              any other nodes lying on these paths). You must pass at least two primary
+              nodes.
         If not provided, the entire DAG is plotted.
     selection_depth
         The depth of the selection. Only used if selection_type is "neighbors",

--- a/tests/test_plot_dag.py
+++ b/tests/test_plot_dag.py
@@ -454,3 +454,15 @@ def test_fail_if_selection_type_is_all_paths_and_less_than_two_primary_nodes():
             selection_type="all_paths",
             policy_date_str="2025-01-01",
         )
+
+
+def test_fail_if_invalid_selection_type():
+    with pytest.raises(
+        ValueError, match="Invalid selection type: invalid_selection_type"
+    ):
+        tt(
+            root=middle_earth.ROOT_PATH,
+            primary_nodes=["payroll_tax__amount_y"],
+            selection_type="invalid_selection_type",
+            policy_date_str="2025-01-01",
+        )

--- a/tests/test_plot_dag.py
+++ b/tests/test_plot_dag.py
@@ -303,7 +303,7 @@ def test_plot_full_interface_dag(include_fail_and_warn_nodes):
         ),
     ],
 )
-def test_node_selector(selection_type, selection_depth, primary_nodes, expected_nodes):
+def test_node_selection(selection_type, selection_depth, primary_nodes, expected_nodes):
     dag = _get_tt_dag_with_node_metadata(
         root=middle_earth.ROOT_PATH,
         primary_nodes=primary_nodes,
@@ -422,7 +422,7 @@ def test_input_data_overrides_nodes_in_plotting_dag():
     assert "wealth" in dag.nodes()
 
 
-def test_can_create_template_with_selector_and_input_data_from_tt():
+def test_can_create_template_with_selection_and_input_data_from_tt():
     tt(
         root=middle_earth.ROOT_PATH,
         primary_nodes=["payroll_tax__amount_y"],

--- a/tests/test_plot_dag.py
+++ b/tests/test_plot_dag.py
@@ -292,6 +292,15 @@ def test_plot_full_interface_dag(include_fail_and_warn_nodes):
                 "payroll_tax__amount_reduced_y",
             ],
         ),
+        (
+            "all_paths",
+            None,
+            {"payroll_tax__income__amount_y", "property_tax__amount_y"},
+            [
+                "payroll_tax__income__amount_y",
+                "property_tax__amount_y",
+            ],
+        ),
     ],
 )
 def test_node_selector(selection_type, selection_depth, primary_nodes, expected_nodes):

--- a/tests/test_plot_dag.py
+++ b/tests/test_plot_dag.py
@@ -442,3 +442,14 @@ def test_can_pass_plotly_kwargs_to_tt():
         showlegend=True,
         hovermode="closest",
     )
+
+
+def test_fail_if_selection_type_is_all_paths_and_less_than_two_primary_nodes():
+    with pytest.raises(ValueError, match="you must provide at least two primary nodes"):
+        tt(
+            root=middle_earth.ROOT_PATH,
+            primary_nodes=["payroll_tax__amount_y"],
+            selection_type="all_paths",
+            selection_depth=None,
+            include_params=True,
+        )

--- a/tests/test_plot_dag.py
+++ b/tests/test_plot_dag.py
@@ -282,12 +282,14 @@ def test_plot_full_interface_dag(include_fail_and_warn_nodes):
             ],
         ),
         (
-            "nodes",
+            "all_paths",
             None,
-            {"payroll_tax__amount_m", "property_tax__amount_m"},
+            {"payroll_tax__income__amount_y", "payroll_tax__amount_y"},
             [
-                "payroll_tax__amount_m",
-                "property_tax__amount_m",
+                "payroll_tax__income__amount_y",
+                "payroll_tax__amount_y",
+                "payroll_tax__amount_standard_y",
+                "payroll_tax__amount_reduced_y",
             ],
         ),
     ],

--- a/tests/test_plot_dag.py
+++ b/tests/test_plot_dag.py
@@ -445,11 +445,12 @@ def test_can_pass_plotly_kwargs_to_tt():
 
 
 def test_fail_if_selection_type_is_all_paths_and_less_than_two_primary_nodes():
-    with pytest.raises(ValueError, match="you must provide at least two primary nodes"):
+    with pytest.raises(
+        ValueError, match="you must provide at least two\nprimary nodes"
+    ):
         tt(
             root=middle_earth.ROOT_PATH,
             primary_nodes=["payroll_tax__amount_y"],
             selection_type="all_paths",
-            selection_depth=None,
-            include_params=True,
+            policy_date_str="2025-01-01",
         )


### PR DESCRIPTION
### What problem do you want to solve?

The `all_paths` selection type shows all paths that connect any primary nodes. There must be at least two primary nodes. Primary nodes that are not connected to any other primary node are omitted. 
