### PR TITLE
Optimize `aggregation_numpy.sum_by_p_id` ...

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ This is a record of all past `ttsim` releases and what went into them in reverse
 chronological order. We follow [semantic versioning](https://semver.org/) and all
 releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim).
 
+## v1.0.1 — unpublished
+
+- {gh}`40` Improve performance of `aggregation_numpy` and `data_converters`
+  ({ghuser}`JuergenWiemers`)
+
 ## v1.0 — 2025-08-09
 
 - {gh}`38` Plotting: Replace `nodes` selection type with `all_paths`.

--- a/src/ttsim/interface_dag_elements/data_converters.py
+++ b/src/ttsim/interface_dag_elements/data_converters.py
@@ -136,7 +136,7 @@ def df_with_mapped_columns_to_flat_data(
         # Use numpy for array creation if JAX backend is chosen
         # Performance optimization for JAX, PR #34
         if numpy.isscalar(mapper_value) and not isinstance(mapper_value, str):
-            numpy_array = numpy.asarray([mapper_value] * len(df))
+            numpy_array = numpy.full(len(df), mapper_value)
         else:
             numpy_array = numpy.asarray(df[mapper_value])
 

--- a/src/ttsim/interface_dag_elements/data_converters.py
+++ b/src/ttsim/interface_dag_elements/data_converters.py
@@ -133,8 +133,8 @@ def df_with_mapped_columns_to_flat_data(
     """
     path_to_array = {}
     for path, mapper_value in dt.flatten_to_tree_paths(mapper).items():
-        # Use numpy for array creation if JAX backend is chosen
-        # Performance optimization for JAX, PR #34
+        # Use numpy for array creation regardless of backend for performance reasons,
+        # see #34.
         if numpy.isscalar(mapper_value) and not isinstance(mapper_value, str):
             numpy_array = numpy.full(len(df), mapper_value)
         else:


### PR DESCRIPTION
... and small optimization of `data_converters.df_with_mapped_columns_to_flat_data`

- I am still trying to pick some low hanging (optimization) fruits. I am reaching the point of diminishing returns (which is good!).
- I tried to be minimally invasive. I only replaced existing code with more efficient implementation, so I don't think new tests are necessary.
- I broke down the benchmark into three stages to better demonstrate what is going on:
  -  1st stage (pre-processing): 
  ```python
              main_targets=[
                MainTarget.specialized_environment.tt_dag,
                MainTarget.processed_data,
                MainTarget.labels.root_nodes,
                MainTarget.input_data.flat,  # Need this for stage 3
            ],
   ```
  - 2nd stage (computation): `main_target=MainTarget.raw_results.columns`
  - 3rd stage (post-processing): `main_target=MainTarget.results.df_with_mapper`
- The optimization in `aggregation_numpy.sum_by_p_id` creates very sizeable speedups for the NumPy backend in the computation stage for large datasets (see below).
- (@mj023 I looked at `aggregation_jax.sum_by_p_id` in the hope to get a similar optimization for JAX, but this already looks pretty optimized to me...)
- The small change to `data_converters.df_with_mapped_columns_to_flat_data` helps both NumPy and JAX in the pre-processing stage.
- This PR makes NumPy competitive with JAX even for very large datasets (up to at least 8 million rows, at least in this benchmark, and on CPU). On the main branch, JAX pulled ahead at around 1 million rows.
- Notes relating to JAX (maybe to future self): 
  - Because of JAX's asynchronous execution, properly timing JAX is a bit tricky. I noticed that the wall clock time for Stage 2 was much longer than the reported time. It seems that Python dispatches pretty quickly to JAX (which then computes in the background) and moves on... until it is forced to synchronize.
  - I forced proper timings by putting `jax.block_until_ready(jax.numpy.array([1.0]))` in between the stages (through the `sync_jax` option in the benchmark script).
  - The difference between wall clock time and measured time does _not_  seem to come from compilation: For example, running 2**21 households with the JAX backend and executing stage 2 twice in a row doesn't make the second run go faster; both runs take roughly ~10s on my machine. (@mj23 can you confirm?)


- Updated code for reproducing the benchmarks: [benchmark.zip](https://github.com/user-attachments/files/21717028/benchmark.zip)


### Benchmark results: NumPy backend

```python
============================================================================================================================================
NUMPY BACKEND COMPARISON: Main Branch vs PR Branch - 3-STAGE BREAKDOWN
============================================================================================================================================
Households  Stage             Main (s)    PR (s)      Speedup     Description              Hash Match  
--------------------------------------------------------------------------------------------------------------------------------------------
32,767      pre-processing    1.0278      0.8885      1.16x       Data preprocessing                   
            computation       1.3302      0.8026      1.66x       Core computation         ✓           
            post-processing   0.6980      0.6997      1/1.00x     DataFrame formatting     ✓           
            total time        3.0560      2.3908      1.28x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
32,768      pre-processing    1.0119      0.8513      1.19x       Data preprocessing                   
            computation       1.4635      0.8262      1.77x       Core computation         ✓           
            post-processing   0.6909      0.6912      1/1.00x     DataFrame formatting     ✓           
            total time        3.1662      2.3687      1.34x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
65,536      pre-processing    0.9795      0.8138      1.20x       Data preprocessing                   
            computation       2.0565      1.0090      2.04x       Core computation         ✓           
            post-processing   0.7143      0.7009      1.02x       DataFrame formatting     ✓           
            total time        3.7503      2.5237      1.49x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
131,072     pre-processing    1.2604      0.9210      1.37x       Data preprocessing                   
            computation       3.2137      1.1445      2.81x       Core computation         ✓           
            post-processing   0.7978      0.8358      1/1.05x     DataFrame formatting     ✓           
            total time        5.2719      2.9012      1.82x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
262,144     pre-processing    1.7918      1.1590      1.55x       Data preprocessing                   
            computation       5.6984      1.6018      3.56x       Core computation         ✓           
            post-processing   0.7004      0.7562      1/1.08x     DataFrame formatting     ✓           
            total time        8.1907      3.5170      2.33x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
524,288     pre-processing    3.1106      1.7406      1.79x       Data preprocessing                   
            computation       14.9648     2.5202      5.94x       Core computation         ✓           
            post-processing   1.1778      0.7267      1.62x       DataFrame formatting     ✓           
            total time        19.2532     4.9875      3.86x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
1,048,576   pre-processing    8.5710      2.8628      2.99x       Data preprocessing                   
            computation       33.3232     4.4851      7.43x       Core computation         ✓           
            post-processing   1.2874      0.7737      1.66x       DataFrame formatting     ✓           
            total time        43.1816     8.1216      5.32x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
2,097,152   pre-processing    16.9643     5.5325      3.07x       Data preprocessing                   
            computation       53.2370     10.5349     5.05x       Core computation         ✓           
            post-processing   1.1345      1.1710      1/1.03x     DataFrame formatting     ✓           
            total time        71.3358     17.2384     4.14x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------

```


### Benchmark results: JAX backend

```python
============================================================================================================================================
JAX BACKEND COMPARISON: Main Branch vs PR Branch - 3-STAGE BREAKDOWN
============================================================================================================================================
Households  Stage             Main (s)    PR (s)      Speedup     Description              Hash Match  
--------------------------------------------------------------------------------------------------------------------------------------------
32,767      pre-processing    4.8583      4.7492      1.02x       Data preprocessing                   
            computation       1.9211      1.9568      1/1.02x     Core computation         ✓           
            post-processing   1.0570      1.0571      1/1.00x     DataFrame formatting     ✓           
            total time        7.8364      7.7631      1.01x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
32,768      pre-processing    1.5875      1.5278      1.04x       Data preprocessing                   
            computation       1.9825      1.8648      1.06x       Core computation         ✓           
            post-processing   0.9603      0.9457      1.02x       DataFrame formatting     ✓           
            total time        4.5303      4.3383      1.04x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
65,536      pre-processing    1.8769      1.7151      1.09x       Data preprocessing                   
            computation       1.9392      1.8944      1.02x       Core computation         ✓           
            post-processing   0.9571      0.9640      1/1.01x     DataFrame formatting     ✓           
            total time        4.7732      4.5734      1.04x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
131,072     pre-processing    2.3600      1.8389      1.28x       Data preprocessing                   
            computation       2.0408      2.0450      1/1.00x     Core computation         ✓           
            post-processing   0.9212      0.9414      1/1.02x     DataFrame formatting     ✓           
            total time        5.3220      4.8252      1.10x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
262,144     pre-processing    2.9779      2.3005      1.29x       Data preprocessing                   
            computation       2.3904      2.4145      1/1.01x     Core computation         ✓           
            post-processing   0.9173      0.9175      1/1.00x     DataFrame formatting     ✓           
            total time        6.2856      5.6324      1.12x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
524,288     pre-processing    4.8278      3.3825      1.43x       Data preprocessing                   
            computation       3.2687      3.2871      1/1.01x     Core computation         ✓           
            post-processing   0.9442      0.9523      1/1.01x     DataFrame formatting     ✓           
            total time        9.0407      7.6219      1.19x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
1,048,576   pre-processing    7.9763      5.5723      1.43x       Data preprocessing                   
            computation       5.0188      5.0625      1/1.01x     Core computation         ✓           
            post-processing   0.9601      1.0395      1/1.08x     DataFrame formatting     ✓           
            total time        13.9552     11.6743     1.20x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
2,097,152   pre-processing    15.6394     10.5245     1.49x       Data preprocessing                   
            computation       10.2817     10.5528     1/1.03x     Core computation         ✓           
            post-processing   1.1153      1.0133      1.10x       DataFrame formatting     ✓           
            total time        27.0364     22.0907     1.22x       Complete execution                   
--------------------------------------------------------------------------------------------------------------------------------------------
```

