### PR TITLE
Optimizations: `tt.shared.join`, several `ttsim.interface_dag_elements.fail_if` functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## v1.0.1 — unpublished
 
+- {gh}`41` Improve performance of `tt.shared.join` and
+  `ttsim.interface_dag_elements.fail_if.foreign_keys_are_invalid_in_data`
+  ({ghuser}`JuergenWiemers`)
+
 - {gh}`40` Improve performance of `aggregation_numpy` and `data_converters`
   ({ghuser}`JuergenWiemers`)
 

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -390,11 +390,15 @@ def foreign_keys_are_invalid_in_data(
         if fk_name in labels__root_nodes:
             path = dt.tree_path_from_qname(fk_name)
             # Referenced `p_id` must exist in the input data
-            if not all(i in valid_ids for i in input_data__flat[path].tolist()):
+            data_array = input_data__flat[path]
+            valid_ids_array = numpy.array(list(valid_ids))
+            valid_mask = numpy.isin(data_array, valid_ids_array)
+            if not numpy.all(valid_mask):
+                invalid_ids = data_array[~valid_mask].tolist()
                 message = format_errors_and_warnings(
                     f"""
                     For {path}, the following are not a valid p_id in the input
-                    data: {[i for i in input_data__flat[path] if i not in valid_ids]}.
+                    data: {invalid_ids}.
                     """,
                 )
                 raise ValueError(message)

--- a/src/ttsim/tt/shared.py
+++ b/src/ttsim/tt/shared.py
@@ -71,8 +71,7 @@ def join(
     sorted_primary_key = primary_key[sort_indices]
     sorted_target = target[sort_indices]
 
-    # Use searchsorted to find where each foreign_key would be inserted
-    # in the sorted primary_key array
+    # Find where each foreign_key would be inserted in the sorted primary_key array
     positions = xnp.searchsorted(sorted_primary_key, foreign_key, side="left")
 
     # Check if the foreign keys actually match the primary keys at those positions
@@ -88,8 +87,6 @@ def join(
         foreign_key, value_if_foreign_key_is_missing, dtype=target.dtype
     )
 
-    # For valid matches, get the corresponding target values
-    valid_indices = xnp.where(
-        matches, positions, 0
-    )  # Use 0 as safe fallback for invalid indices
+    # Get the corresponding target values for valid matches, use 0 for invalid indices
+    valid_indices = xnp.where(matches, positions, 0)
     return xnp.where(matches, sorted_target[valid_indices], result)


### PR DESCRIPTION
- I noticed that in my previous benchmarks (#40) I had chosen Bürgergeld, Wohngeld, and Kinderzuschlag as targets, but I had overwritten them in the mapper. Removing the overrides revealed new bottlenecks in the benchmarks.
- The crucial change is in `tt.shared.join`. It looks like we currently use an NxN lookup table; we really shouldn't do that. 😅With this PR, runtime complexity is $O(log(n))$ instead of $O(n)$ and memory usage is $O(n)$ instead of $O(n^2)$.
- The optimizations in the `fail_if` functions mostly help the "pre-processing stage".
- I can't even show a before<-> after comparison table because with the current `tt.shared.join` even as little as `N=32768` households is too much for my laptop.
- For NumPy, timings look fine with this PR. Note that the timings already include the effects of another optimization PR in the GETTSIM repository ~~, which I will open in a minute~~ (https://github.com/ttsim-dev/gettsim/pull/1076). Without this "twin PR", timings look _much_ worse.
- However, there is another problem. I can run JAX only up to 32,768 households; after that, JAX's memory usage seems to increase quadratically in `N`; with `N=1,048,576` JAX wants to allocate 35TB (!). (@mj023, do you have an idea what is going on? You can find the updated benchmark scripts below.)

    <details><summary>Output for JAX</summary>
    <p>
    
    ```python
    ============================================================
    Testing jax backend
    ============================================================
    Preparing environment for jax backend...
      Resetting session state for jax backend...
      Garbage collection completed
      JAX compilation cache cleared
    Running benchmark: 32,767 households, jax backend
      Generating data...
    Created DataFrame with 131068 rows (32767 households)
      Stage 1: Data preprocessing and DAG creation...
        JAX operations synchronized
      Stage 2: Computation only...
        JAX operations synchronized
      Stage 3: Convert raw results to DataFrame...
        JAX operations synchronized
      ✓ Stage 1 (pre-processing): 4.7734s (10.7%)
      ✓ Stage 2 (computation): 37.5159s (84.3%)
      ✓ Stage 3 (post-processing): 2.2136s (5.0%)
      ✓ Total time: 44.5029 seconds
      Result shape: (131068, 8)
      Memory usage: 169.2 MB → 121.2 MB (Δ-48.0 MB)
      Stage 1 hash: e1ef8c7680e3221b...
      Stage 2 hash: c4185b3248934f48...
      Stage 3 hash: 52f96b14596cceef...
    
    Running benchmark: 32,768 households, jax backend
      Generating data...
    Created DataFrame with 131072 rows (32768 households)
      Stage 1: Data preprocessing and DAG creation...
        JAX operations synchronized
      Stage 2: Computation only...
        JAX operations synchronized
      Stage 3: Convert raw results to DataFrame...
        JAX operations synchronized
      ✓ Stage 1 (pre-processing): 2.2594s (6.8%)
      ✓ Stage 2 (computation): 28.9499s (87.5%)
      ✓ Stage 3 (post-processing): 1.8655s (5.6%)
      ✓ Total time: 33.0747 seconds
      Result shape: (131072, 8)
      Memory usage: 162.1 MB → 105.6 MB (Δ-56.5 MB)
      Stage 1 hash: 3f044e76bf532912...
      Stage 2 hash: c4185b3248934f48...
      Stage 3 hash: 625ff853d37a8962...
    
    Running benchmark: 65,536 households, jax backend
      Generating data...
    Created DataFrame with 262144 rows (65536 households)
      Stage 1: Data preprocessing and DAG creation...
        JAX operations synchronized
      Stage 2: Computation only...
        JAX operations synchronized
      ✗ Failed: INTERNAL: Buffer Definition Event: Error preparing computation: Out of memory allocating 139639391848 bytes.
    
    Running benchmark: 131,072 households, jax backend
      Generating data...
    Created DataFrame with 524288 rows (131072 households)
      Stage 1: Data preprocessing and DAG creation...
        JAX operations synchronized
      Stage 2: Computation only...
        JAX operations synchronized
      ✗ Failed: INTERNAL: Buffer Definition Event: Error preparing computation: Out of memory allocating 558451656296 bytes.
    
    Running benchmark: 262,144 households, jax backend
      Generating data...
    Created DataFrame with 1048576 rows (262144 households)
      Stage 1: Data preprocessing and DAG creation...
        JAX operations synchronized
      Stage 2: Computation only...
        JAX operations synchronized
      ✗ Failed: INTERNAL: Buffer Definition Event: Error preparing computation: Out of memory allocating 2233594807912 bytes.
    
    Running benchmark: 524,288 households, jax backend
      Generating data...
    Created DataFrame with 2097152 rows (524288 households)
      Stage 1: Data preprocessing and DAG creation...
        JAX operations synchronized
      Stage 2: Computation only...
        JAX operations synchronized
      ✗ Failed: INTERNAL: Buffer Definition Event: Error preparing computation: Out of memory allocating 8933947213416 bytes.
    
    Running benchmark: 1,048,576 households, jax backend
      Generating data...
    Created DataFrame with 4194304 rows (1048576 households)
      Stage 1: Data preprocessing and DAG creation...
        JAX operations synchronized
      Stage 2: Computation only...
        JAX operations synchronized
      ✗ Failed: INTERNAL: Buffer Definition Event: Error preparing computation: Out of memory allocating 35734958376552 bytes.
    ```
    
    </p>
    </details> 



- Benchmark scripts: Here are the [benchmark_scripts.zip](https://github.com/user-attachments/files/21738904/benchmark_scripts.zip)


### Timings with this PR

```python
========================================================================================================================
3-STAGE TIMING BREAKDOWN
========================================================================================================================

=====================================================================================================
PERFORMANCE COMPARISON NUMPY <-> JAX
========================================================================================================
Households  Stage             NUMPY hash  JAX hash    NUMPY (s)   JAX (s)     Speedup
--------------------------------------------------------------------------------------------------------
32,767      pre-processing    -           -           0.9343      4.7734      1/5.11x
            computation       c02820a2    c4185b32    0.3726      37.5159     1/100.69x
            post-processing   fc9530ad    52f96b14    0.7784      2.2136      1/2.84x
            total time                                2.0852      44.5029     1/21.34x
--------------------------------------------------------------------------------------------------------
32,768      pre-processing    -           -           0.8053      2.2594      1/2.81x
            computation       84d1cbc8    c4185b32    0.4042      28.9499     1/71.63x
            post-processing   990dc20f    625ff853    0.7996      1.8655      1/2.33x
            total time                                2.0091      33.0747     1/16.46x
--------------------------------------------------------------------------------------------------------
65,536      pre-processing    -           -           0.8748      FAILED      N/A
            computation       a2fd2213    FAILED      0.7240      FAILED      N/A
            post-processing   c1d64a01    FAILED      0.7246      FAILED      N/A
            total time                                2.3234      FAILED      N/A
--------------------------------------------------------------------------------------------------------
131,072     pre-processing    -           -           1.0318      FAILED      N/A
            computation       8e5c852f    FAILED      1.4785      FAILED      N/A
            post-processing   dc3f1ea5    FAILED      0.8463      FAILED      N/A
            total time                                3.3566      FAILED      N/A
--------------------------------------------------------------------------------------------------------
262,144     pre-processing    -           -           1.3009      FAILED      N/A
            computation       a774f14b    FAILED      3.0404      FAILED      N/A
            post-processing   4a6e8c58    FAILED      0.7449      FAILED      N/A
            total time                                5.0862      FAILED      N/A
--------------------------------------------------------------------------------------------------------
524,288     pre-processing    -           -           2.0369      FAILED      N/A
            computation       de8b33a9    FAILED      6.3293      FAILED      N/A
            post-processing   197c7065    FAILED      0.8779      FAILED      N/A
            total time                                9.2441      FAILED      N/A
--------------------------------------------------------------------------------------------------------
1,048,576   pre-processing    -           -           3.3479      FAILED      N/A
            computation       9c6cc63f    FAILED      13.6209     FAILED      N/A
            post-processing   7b025b7b    FAILED      0.9363      FAILED      N/A
            total time                                17.9051     FAILED      N/A
--------------------------------------------------------------------------------------------------------

========================================================================================================================
MEMORY USAGE COMPARISON
========================================================================================================================
Households  NumPy Init  NumPy Final JAX Init    JAX Final   NumPy Δ     JAX Δ
------------------------------------------------------------------------------------------------------------------------
32,767      177.7       240.2       169.2       121.2       62.4        -48.0
32,768      206.6       243.8       162.1       105.6       37.2        -56.5
65,536      251.8       335.5       FAILED      FAILED      83.7        FAILED
131,072     354.4       508.5       FAILED      FAILED      154.1       FAILED
262,144     541.1       859.4       FAILED      FAILED      318.3       FAILED
524,288     926.3       1546.7      FAILED      FAILED      620.4       FAILED
1,048,576   1680.6      2814.8      FAILED      FAILED      1134.3      FAILED
------------------------------------------------------------------------------------------------------------------------

Legend:
  Stage 1: Data preprocessing & DAG creation
  Stage 2: Core computation (tax/transfer calculations)
  Stage 3: DataFrame formatting (JAX → pandas conversion)
  Init/Final: Memory usage before/after execution
  Δ: Memory increase during execution
  ✓/✗: Hash verification (results match/differ)
```