### PR TITLE
Pre-sort user data by p_id for performance

### DIFF
--- a/src/ttsim/interface_dag_elements/data_converters.py
+++ b/src/ttsim/interface_dag_elements/data_converters.py
@@ -131,20 +131,33 @@ def df_with_mapped_columns_to_flat_data(
 
 
     """
+    # Sort DataFrame by p_id to optimize downstream sorting operations
+    sorted_df = df.sort_values("p_id").reset_index(drop=True)
+    # Store which original row positions were moved to create the sorted DataFrame
+    sort_indices = df.sort_values("p_id").index.to_numpy()
+
     path_to_array = {}
     for path, mapper_value in dt.flatten_to_tree_paths(mapper).items():
         # Use numpy for array creation regardless of backend for performance reasons,
         # see #34.
         if numpy.isscalar(mapper_value) and not isinstance(mapper_value, str):
-            numpy_array = numpy.full(len(df), mapper_value)
+            numpy_array = numpy.full(len(sorted_df), mapper_value)
         else:
-            numpy_array = numpy.asarray(df[mapper_value])
+            numpy_array = numpy.asarray(sorted_df[mapper_value])
 
         # Convert numpy array back to JAX array if JAX backend is chosen
         if backend == "jax":
             path_to_array[path] = xnp.asarray(numpy_array)
         else:
             path_to_array[path] = numpy_array
+
+    # Store indices to restore original order in final DataFrame output
+    if backend == "jax":
+        path_to_array[("__original_sort_indices__",)] = xnp.asarray(
+            numpy.asarray(sort_indices)
+        )
+    else:
+        path_to_array[("__original_sort_indices__",)] = numpy.asarray(sort_indices)
 
     return path_to_array
 
@@ -159,8 +172,10 @@ def df_with_nested_columns_to_flat_data(
     Args:
         df:
             The pandas DataFrame with nested columns.
+        backend:
+            The backend to use for computation.
         xnp:
-            The numpy module.
+            The backend module.
 
     Returns
     -------
@@ -169,12 +184,29 @@ def df_with_nested_columns_to_flat_data(
     Examples
     --------
         >>> df = pd.DataFrame({("a", "b"): [1, 2, 3], ("c",): [4, 5, 6]})
-        >>> result = df_with_nested_columns_to_flat_data(df, xnp=np)
+        >>> result = df_with_nested_columns_to_flat_data(df, "numpy", np)
         >>> result
         {("a", "b"): np.array([1, 2, 3]), ("c",): np.array([4, 5, 6])}
     """
+    # Handles Pandas MultiIndex padding with NaN
+    p_id_column = None
+    for col in df.columns:
+        clean_col = tuple(el for el in col if not pd.isna(el))
+        if "p_id" in clean_col:
+            p_id_column = col
+            break
+
+    # Sort DataFrame by original p_id to optimize downstream sorting operations
+    sorted_df = (
+        df.reindex(columns=df.columns.sort_values())
+        .sort_values(p_id_column)
+        .reset_index(drop=True)
+    )
+    # Store which original row positions were moved to create the sorted DataFrame
+    sort_indices = df.sort_values(p_id_column).index.to_numpy()
+
     result = {}
-    for key, value in df.to_dict(orient="list").items():
+    for key, value in sorted_df.to_dict(orient="list").items():
         clean_key = _remove_nan_from_keys(key)
 
         # Use numpy for array creation if JAX backend is chosen and
@@ -184,6 +216,14 @@ def df_with_nested_columns_to_flat_data(
             result[clean_key] = xnp.asarray(numpy.asarray(value))
         else:
             result[clean_key] = numpy.asarray(value)
+
+    # Store indices to restore original order in final DataFrame output
+    if backend == "jax":
+        result[("__original_sort_indices__",)] = xnp.asarray(
+            numpy.asarray(sort_indices)
+        )
+    else:
+        result[("__original_sort_indices__",)] = numpy.asarray(sort_indices)
 
     return result
 

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -49,11 +49,17 @@ class FailIf(MainTargetABC):
     input_df_has_bool_or_numeric_column_names: str = (
         "fail_if__input_df_has_bool_or_numeric_column_names"
     )
+    input_df_and_mapper_p_id_is_invalid: str = (
+        "fail_if__input_df_and_mapper_p_id_is_invalid"
+    )
     input_df_mapper_columns_missing_in_df: str = (
         "fail_if__input_df_mapper_columns_missing_in_df"
     )
     input_df_mapper_has_incorrect_format: str = (
         "fail_if__input_df_mapper_has_incorrect_format"
+    )
+    input_df_with_nested_columns_p_id_is_invalid: str = (
+        "fail_if__input_df_with_nested_columns_p_id_is_invalid"
     )
     non_convertible_objects_in_results_tree: str = (
         "fail_if__non_convertible_objects_in_results_tree"

--- a/tests/interface_dag_elements/test_data_converters.py
+++ b/tests/interface_dag_elements/test_data_converters.py
@@ -75,9 +75,14 @@ def minimal_data_tree():
                 "n1": {
                     "n2": "a",
                 },
+                "p_id": "p_id",
             },
-            pd.DataFrame({"a": [1, 2, 3]}),
-            {("n1", "n2"): pd.Series([1, 2, 3])},
+            pd.DataFrame({"a": [1, 2, 3], "p_id": [0, 1, 2]}),
+            {
+                ("n1", "n2"): pd.Series([1, 2, 3]),
+                ("p_id",): pd.Series([0, 1, 2]),
+                ("__original_sort_indices__",): numpy.array([0, 1, 2]),
+            },
         ),
         (
             {
@@ -85,9 +90,15 @@ def minimal_data_tree():
                     "n2": "a",
                 },
                 "n3": "b",
+                "p_id": "p_id",
             },
-            pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
-            {("n1", "n2"): pd.Series([1, 2, 3]), ("n3",): pd.Series([4, 5, 6])},
+            pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "p_id": [0, 1, 2]}),
+            {
+                ("n1", "n2"): pd.Series([1, 2, 3]),
+                ("n3",): pd.Series([4, 5, 6]),
+                ("p_id",): pd.Series([0, 1, 2]),
+                ("__original_sort_indices__",): numpy.array([0, 1, 2]),
+            },
         ),
         (
             {
@@ -95,9 +106,15 @@ def minimal_data_tree():
                     "n2": "a",
                 },
                 "n3": 3,
+                "p_id": "p_id",
             },
-            pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
-            {("n1", "n2"): pd.Series([1, 2, 3]), ("n3",): pd.Series([3, 3, 3])},
+            pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "p_id": [0, 1, 2]}),
+            {
+                ("n1", "n2"): pd.Series([1, 2, 3]),
+                ("n3",): pd.Series([3, 3, 3]),
+                ("p_id",): pd.Series([0, 1, 2]),
+                ("__original_sort_indices__",): numpy.array([0, 1, 2]),
+            },
         ),
     ],
 )
@@ -114,12 +131,9 @@ def test_df_with_mapped_columns_to_flat_data(
     )
 
     assert set(result.keys()) == set(expected.keys())
-    for key in result:
-        pd.testing.assert_series_equal(
-            pd.Series(result[key]),
-            expected[key],
-            check_names=False,
-        )
+    for key, value in expected.items():
+        assert numpy.array_equal(result[key], value)
+    assert isinstance(result[("p_id",)], numpy.ndarray)
 
 
 @pytest.mark.parametrize(
@@ -250,12 +264,26 @@ def test_nested_data_to_dataframe(
     ),
     [
         (
-            pd.DataFrame({("a", "b"): [1, 2, 3], ("c",): [4, 5, 6]}),
-            {("a", "b"): [1, 2, 3], ("c",): [4, 5, 6]},
+            pd.DataFrame(
+                {("a", "b"): [1, 2, 3], ("c",): [4, 5, 6], ("p_id",): [0, 1, 2]}
+            ),
+            {
+                ("a", "b"): [1, 2, 3],
+                ("c",): [4, 5, 6],
+                ("p_id",): [0, 1, 2],
+                ("__original_sort_indices__",): numpy.array([0, 1, 2]),
+            },
         ),
         (
-            pd.DataFrame({("a", "b"): [1, 2, 3], ("b",): [4, 5, 6]}),
-            {("a", "b"): [1, 2, 3], ("b",): [4, 5, 6]},
+            pd.DataFrame(
+                {("a", "b"): [1, 2, 3], ("b",): [4, 5, 6], ("p_id",): [0, 1, 2]}
+            ),
+            {
+                ("a", "b"): [1, 2, 3],
+                ("b",): [4, 5, 6],
+                ("p_id",): [0, 1, 2],
+                ("__original_sort_indices__",): numpy.array([0, 1, 2]),
+            },
         ),
     ],
 )
@@ -267,5 +295,5 @@ def test_df_with_nested_columns_to_flat_data(df, expected):
     )
 
     assert set(result.keys()) == set(expected.keys())
-    for key in result:
-        assert_array_equal(result[key], expected[key])
+    for key, value in result.items():
+        assert_array_equal(value, expected[key])

--- a/tests/interface_dag_elements/test_processed_data.py
+++ b/tests/interface_dag_elements/test_processed_data.py
@@ -10,17 +10,17 @@ from ttsim.interface_dag_elements.processed_data import processed_data
 @pytest.fixture
 def input_data__flat():
     return {
-        ("p_id",): numpy.array([5, 333, 7, 2]),
-        ("hh_id",): numpy.array([55555, 7, 3, 55555]),
-        ("n0", "p_id_whatever"): numpy.array([-1, 333, 5, -1]),
+        ("p_id",): numpy.array([2, 5, 7, 333]),
+        ("hh_id",): numpy.array([55555, 55555, 3, 7]),
+        ("n0", "p_id_whatever"): numpy.array([-1, -1, 5, 333]),
     }
 
 
 def test_processed_data(input_data__flat, xnp):
     expected = {
-        "p_id": xnp.array([1, 3, 2, 0]),
-        "hh_id": xnp.array([2, 1, 0, 2]),
-        "n0__p_id_whatever": xnp.array([-1, 3, 1, -1]),
+        "p_id": xnp.array([0, 1, 2, 3]),
+        "hh_id": xnp.array([2, 2, 0, 1]),
+        "n0__p_id_whatever": xnp.array([-1, -1, 1, 3]),
     }
     pd.testing.assert_frame_equal(
         pd.DataFrame(processed_data(input_data__flat=input_data__flat, xnp=xnp)),
@@ -32,14 +32,14 @@ def test_processed_data_foreign_key_out_of_bounds(xnp):
     # Add out-of-bounds numbers (-5, 999), in foreign key. Should be unchanged, error
     # will be raised in `fail_if.foreign_keys_are_invalid_in_data`.
     input_data__flat = {
-        ("p_id",): numpy.array([5, 333, 7, 2]),
-        ("hh_id",): numpy.array([55555, 7, 3, 55555]),
-        ("n0", "p_id_whatever"): numpy.array([-1, 333, -5, 999]),
+        ("p_id",): numpy.array([2, 5, 7, 333]),
+        ("hh_id",): numpy.array([55555, 55555, 3, 7]),
+        ("n0", "p_id_whatever"): numpy.array([999, -1, -5, 333]),
     }
     expected = {
-        "p_id": xnp.array([1, 3, 2, 0]),
-        "hh_id": xnp.array([2, 1, 0, 2]),
-        "n0__p_id_whatever": xnp.array([-1, 3, -5, 999]),  # -5, 999 preserved unchanged
+        "p_id": xnp.array([0, 1, 2, 3]),
+        "hh_id": xnp.array([2, 2, 0, 1]),
+        "n0__p_id_whatever": xnp.array([999, -1, -5, 3]),  # -5, 999 preserved unchanged
     }
     pd.testing.assert_frame_equal(
         pd.DataFrame(processed_data(input_data__flat=input_data__flat, xnp=xnp)),
@@ -51,14 +51,14 @@ def test_processed_data_foreign_key_inside_bounds(xnp):
     # Add non-existent foreign key (22). Should be unchanged, error will be raised in
     # `fail_if.foreign_keys_are_invalid_in_data`.
     input_data__flat = {
-        ("p_id",): numpy.array([5, 333, 7, 2]),
-        ("hh_id",): numpy.array([55555, 7, 4444, 55555]),
-        ("n0", "p_id_whatever"): numpy.array([-1, 333, 3, -1]),
+        ("p_id",): numpy.array([2, 5, 7, 333]),
+        ("hh_id",): numpy.array([55555, 55555, 4444, 7]),
+        ("n0", "p_id_whatever"): numpy.array([-1, -1, 3, 333]),
     }
     expected = {
-        "p_id": xnp.array([1, 3, 2, 0]),
-        "hh_id": xnp.array([2, 0, 1, 2]),
-        "n0__p_id_whatever": xnp.array([-1, 3, 3, -1]),
+        "p_id": xnp.array([0, 1, 2, 3]),
+        "hh_id": xnp.array([2, 2, 1, 0]),
+        "n0__p_id_whatever": xnp.array([-1, -1, 3, 3]),
     }
     pd.testing.assert_frame_equal(
         pd.DataFrame(processed_data(input_data__flat=input_data__flat, xnp=xnp)),

--- a/tests/interface_dag_elements/test_results.py
+++ b/tests/interface_dag_elements/test_results.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import numpy
+import pandas as pd
+import pytest
+
+from ttsim.interface_dag_elements.results import _restore_original_row_order
+
+
+@pytest.mark.parametrize(
+    (
+        "df",
+        "input_data__flat",
+        "expected_row_order",
+        "expected_index",
+        "should_be_unchanged",
+    ),
+    [
+        # No sort indices - should return DataFrame unchanged
+        (
+            pd.DataFrame(
+                {"col1": [10, 20, 30], "col2": [100, 200, 300]},
+                index=pd.Index([3, 1, 2], name="p_id"),
+            ),
+            {},  # No sort indices
+            [10, 20, 30],  # Should remain unchanged
+            [3, 1, 2],  # Original index preserved
+            True,  # DataFrame should be identical
+        ),
+        # With sort indices - should restore original order
+        (
+            pd.DataFrame(
+                {"col1": [10, 20, 30], "col2": [100, 200, 300]},
+                index=pd.Index([1, 2, 3], name="p_id"),  # Sorted p_id values
+            ),
+            {
+                ("__original_sort_indices__",): numpy.array([1, 2, 0])
+            },  # Original positions: row 1→0, row 2→1, row 0→2
+            [
+                30,
+                10,
+                20,
+            ],  # Should be reordered to: original row 0, original row 1, original row 2
+            [3, 1, 2],  # Restored original p_id order (not reset index)
+            False,  # DataFrame should be modified
+        ),
+        # More complex reordering
+        (
+            pd.DataFrame(
+                {"col1": [100, 200, 300, 400], "col2": [10, 20, 30, 40]},
+                index=pd.Index([1, 2, 3, 4], name="p_id"),  # Sorted p_id values
+            ),
+            {
+                ("__original_sort_indices__",): numpy.array([3, 0, 2, 1])
+            },  # Complex shuffle: original row 3→0, row 0→1, row 2→2, row 1→3
+            [200, 400, 300, 100],  # Restored order: orig row 0, 1, 2, 3
+            [2, 4, 3, 1],  # Restored original p_id order
+            False,  # DataFrame should be modified
+        ),
+    ],
+)
+def test_restore_original_row_order(
+    df, input_data__flat, expected_row_order, expected_index, should_be_unchanged
+):
+    """Test the _restore_original_row_order helper function."""
+    original_df = df.copy()
+    result_df = _restore_original_row_order(df, input_data__flat)
+
+    # Check that the first column values are in the expected order
+    assert result_df["col1"].tolist() == expected_row_order
+
+    # Check that index name is preserved
+    assert result_df.index.name == "p_id"
+
+    # Check the index values
+    assert result_df.index.tolist() == expected_index
+
+    # If should be unchanged, verify it's identical to original
+    if should_be_unchanged:
+        pd.testing.assert_frame_equal(result_df, original_df)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -17,31 +17,39 @@ if TYPE_CHECKING:
 
 DF_WITH_NESTED_COLUMNS = pd.DataFrame(
     {
-        ("age",): [30, 30, 10],
+        ("age",): [10, 30, 30],  # Reordered to match unsorted p_id
         ("kin_id",): [0, 0, 0],
-        ("p_id",): [0, 1, 2],
-        ("p_id_parent_1",): [-1, -1, 0],
-        ("p_id_parent_2",): [-1, -1, 1],
-        ("p_id_spouse",): [1, 0, -1],
+        ("p_id",): [2, 0, 1],  # Deliberately unsorted: 2, 0, 1
+        ("p_id_parent_1",): [0, -1, -1],  # Adjusted for new order
+        ("p_id_parent_2",): [1, -1, -1],  # Adjusted for new order
+        ("p_id_spouse",): [-1, 1, 0],  # Adjusted for new order
         ("parent_is_noble",): [False, False, False],
         ("wealth",): [0.0, 0.0, 0.0],
-        ("payroll_tax", "child_tax_credit", "p_id_recipient"): [-1, -1, 0],
-        ("payroll_tax", "income", "gross_wage_y"): [10000, 0, 0],
+        ("payroll_tax", "child_tax_credit", "p_id_recipient"): [
+            0,
+            -1,
+            -1,
+        ],  # Adjusted for new order
+        ("payroll_tax", "income", "gross_wage_y"): [
+            0,
+            10000,
+            0,
+        ],  # Adjusted for new order
     },
 )
 
 
 DF_FOR_MAPPER = pd.DataFrame(
     {
-        "age": [30, 30, 10],
+        "age": [10, 30, 30],  # Reordered to match unsorted p_id
         "kin_id": [0, 0, 0],
-        "p_id": [0, 1, 2],
-        "parent_1": [-1, -1, 0],
-        "parent_2": [-1, -1, 1],
-        "spouse": [1, 0, -1],
+        "p_id": [2, 0, 1],  # Deliberately unsorted: 2, 0, 1
+        "parent_1": [0, -1, -1],  # Adjusted for new order
+        "parent_2": [1, -1, -1],  # Adjusted for new order
+        "spouse": [-1, 1, 0],  # Adjusted for new order
         "parent_is_noble": [False, False, False],
-        "child_tax_credit_recipient": [-1, -1, 0],
-        "gross_wage_y": [10000, 0, 0],
+        "child_tax_credit_recipient": [0, -1, -1],  # Adjusted for new order
+        "gross_wage_y": [0, 10000, 0],  # Adjusted for new order
         "wealth": [0.0, 0.0, 0.0],
     },
 )
@@ -79,10 +87,14 @@ TARGETS_TREE = {
 
 EXPECTED_TT_RESULTS = pd.DataFrame(
     {
-        "payroll_tax_amount_y": [2920.0, 0.0, 0.0],
-        "payroll_tax_child_tax_credit_amount_m": [8.333333, 0.0, 0.0],
+        "payroll_tax_amount_y": [0.0, 2920.0, 0.0],  # Results for p_id [2, 0, 1]
+        "payroll_tax_child_tax_credit_amount_m": [
+            0.0,
+            8.333333,
+            0.0,
+        ],  # Results for p_id [2, 0, 1]
     },
-    index=pd.Index([0, 1, 2], name="p_id"),
+    index=pd.Index([2, 0, 1], name="p_id"),  # Matches input order
 )
 
 
@@ -140,9 +152,11 @@ def test_modify_evaluation_date_after_creating_policy_environment(
     )
     input_data = InputData.tree(
         tree={
-            "p_id": xnp.array([0, 1, 2]),
+            "p_id": xnp.array([2, 0, 1]),  # Deliberately unsorted
             "property_tax": {
-                "acre_size_in_hectares": xnp.array([5, 20, 200]),
+                "acre_size_in_hectares": xnp.array(
+                    [200, 5, 20]
+                ),  # Reordered to match p_id [2, 0, 1]
             },
         }
     )
@@ -159,9 +173,13 @@ def test_modify_evaluation_date_after_creating_policy_environment(
     )
     expected = pd.DataFrame(
         {
-            "property_tax_amount_y": [0.0, 1000.0, 1000.0],
+            "property_tax_amount_y": [
+                1000.0,
+                0.0,
+                1000.0,
+            ],  # Results for p_id [2, 0, 1]
         },
-        index=pd.Index([0, 1, 2], name="p_id"),
+        index=pd.Index([2, 0, 1], name="p_id"),  # Matches input order
     )
     pd.testing.assert_frame_equal(
         expected, result, check_dtype=False, check_index_type=False
@@ -182,8 +200,10 @@ def test_different_evaluation_dates_across_data_rows(
         },
         input_data=InputData.tree(
             tree={
-                "p_id": xnp.array([1, 2, 3]),
-                "evaluation_year": xnp.array([2020, 2021, 2022]),
+                "p_id": xnp.array([3, 1, 2]),  # Deliberately unsorted
+                "evaluation_year": xnp.array(
+                    [2022, 2020, 2021]
+                ),  # Reordered to match p_id [3, 1, 2]
             }
         ),
         tt_targets=TTTargets(tree={"f": None}),
@@ -192,9 +212,9 @@ def test_different_evaluation_dates_across_data_rows(
 
     expected = pd.DataFrame(
         {
-            ("f",): [2020, 2021, 2022],
+            ("f",): [2022, 2020, 2021],  # Results for p_id [3, 1, 2]
         },
-        index=pd.Index([1, 2, 3], name="p_id"),
+        index=pd.Index([3, 1, 2], name="p_id"),  # Matches input order
     )
     pd.testing.assert_frame_equal(
         expected, result, check_dtype=False, check_index_type=False
@@ -209,9 +229,11 @@ def test_input_data_as_targets(xnp: ModuleType, backend: Literal["numpy", "jax"]
             {
                 "kin_id": xnp.array([0, 0, 0]),
                 "payroll_tax": {
-                    "amount_y": xnp.array([1000, 0, 0]),
+                    "amount_y": xnp.array(
+                        [0, 1000, 0]
+                    ),  # Reordered to match p_id [2, 0, 1]
                 },
-                "p_id": xnp.array([0, 1, 2]),
+                "p_id": xnp.array([2, 0, 1]),  # Deliberately unsorted
             }
         ),
         tt_targets=TTTargets(tree={"kin_id": None, "payroll_tax": {"amount_y": None}}),
@@ -222,9 +244,9 @@ def test_input_data_as_targets(xnp: ModuleType, backend: Literal["numpy", "jax"]
     expected = pd.DataFrame(
         {
             ("kin_id",): [0, 0, 0],
-            ("payroll_tax", "amount_y"): [1000, 0, 0],
+            ("payroll_tax", "amount_y"): [0, 1000, 0],  # Results for p_id [2, 0, 1]
         },
-        index=pd.Index([0, 1, 2], name="p_id"),
+        index=pd.Index([2, 0, 1], name="p_id"),  # Matches input order
     )
     pd.testing.assert_frame_equal(
         expected, result, check_dtype=False, check_index_type=False


### PR DESCRIPTION
Performance currently suffers if the user input data is not sorted by `p_id`.

### This PR:

- Adds `fail_if` functions that check `p_id` for existence and sanity (+ tests)
- Sorts the input data by the original `p_id` before creating the internal `p_id`. This happens in
  - `ttsim.interface_dag_elements.data_converters.df_with_mapped_columns_to_flat_data` and
  - `ttsim.interface_dag_elements.data_converters.df_with_nested_columns_to_flat_data` 
- Users get back the result DataFrame in the original sort order. This is achieved by storing an index column `__original_sort_indices__` along with the other data columns in the `FlatData` object returned by `df_with_mapped_columns_to_flat_data` and `df_with_nested_columns_to_flat_data`. Corresponding functions in `ttsim.interface_dag_elements.results.py` are adjusted to restore the original order.
- Some tests needed to be adjusted because they assumed that the `FlatData` objects might not be sorted by the original `p_id`.

### Performance effects

- In particular, the computation stage in NumPy strongly benefits from pre-sorting by original `p_id` in large datasets, but the JAX gains are also not too bad (see tables below).
- Performance for user data not sorted by the originial `p_id` is now essentially the same as if the user data had been passed already sorted.
- In the benchmarks, a hash mismatch in the computation stage is expected, since the sort order is different. Third stage hashes must match, however, because the original sort order is restored for the result DataFrames.
- @mj023: I tried to achieve further performance improvements by tinkering with the sort operations throughout the code, but the gains were minimal/non-existent. Sorting already sorted data seems to be basically a no-op.


### Performance main vs. PR: (using randomly ordererd user data)

#### Numpy backend:

```python
============================================================================================================================================
NUMPY BACKEND COMPARISON: Main Branch vs PR Branch - 3-STAGE BREAKDOWN
============================================================================================================================================
Households  Stage             Main (s)    PR (s)      Speedup     Description              Hash Match
--------------------------------------------------------------------------------------------------------------------------------------------
32,767      pre-processing    1.1365      1.1142      1.02x       Data preprocessing
            computation       0.8920      0.6038      1.48x       Core computation         ✗
            post-processing   1.0197      0.7827      1.30x       DataFrame formatting     ✓
            total time        3.0483      2.5007      1.22x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
32,768      pre-processing    1.1740      1.1032      1.06x       Data preprocessing
            computation       0.9136      0.6192      1.48x       Core computation         ✗
            post-processing   1.1063      0.8645      1.28x       DataFrame formatting     ✓
            total time        3.1938      2.5868      1.23x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
65,536      pre-processing    1.3000      1.0494      1.24x       Data preprocessing
            computation       1.7938      1.1627      1.54x       Core computation         ✗
            post-processing   0.8976      0.8177      1.10x       DataFrame formatting     ✓
            total time        3.9914      3.0298      1.32x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
131,072     pre-processing    1.5551      1.3531      1.15x       Data preprocessing
            computation       3.4427      2.3683      1.45x       Core computation         ✗
            post-processing   0.9128      0.9882      1/1.08x     DataFrame formatting     ✓
            total time        5.9106      4.7097      1.25x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
262,144     pre-processing    2.4494      1.9747      1.24x       Data preprocessing
            computation       7.4393      4.9451      1.50x       Core computation         ✗
            post-processing   0.8237      1.2887      1/1.56x     DataFrame formatting     ✓
            total time        10.7124     8.2085      1.31x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
524,288     pre-processing    7.9241      4.0708      1.95x       Data preprocessing
            computation       22.6316     11.3820     1.99x       Core computation         ✗
            post-processing   0.9392      1.8131      1/1.93x     DataFrame formatting     ✓
            total time        31.4949     17.2659     1.82x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
1,048,576   pre-processing    26.6471     8.5632      3.11x       Data preprocessing
            computation       70.6778     26.3814     2.68x       Core computation         ✗
            post-processing   1.6854      3.2799      1/1.95x     DataFrame formatting     ✓
            total time        99.0102     38.2245     2.59x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
```


#### JAX backend:

```python
============================================================================================================================================
JAX BACKEND COMPARISON: Main Branch vs PR Branch - 3-STAGE BREAKDOWN
============================================================================================================================================
Households  Stage             Main (s)    PR (s)      Speedup     Description              Hash Match
--------------------------------------------------------------------------------------------------------------------------------------------
32,767      pre-processing    4.9914      5.2813      1/1.06x     Data preprocessing
            computation       4.7661      4.4377      1.07x       Core computation         ✗
            post-processing   1.1202      1.2799      1/1.14x     DataFrame formatting     ✓
            total time        10.8777     10.9989     1/1.01x     Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
32,768      pre-processing    1.6930      1.8235      1/1.08x     Data preprocessing
            computation       4.5209      4.6488      1/1.03x     Core computation         ✗
            post-processing   0.9756      0.9961      1/1.02x     DataFrame formatting     ✓
            total time        7.1895      7.4684      1/1.04x     Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
65,536      pre-processing    1.9762      2.0121      1/1.02x     Data preprocessing
            computation       5.0280      4.7444      1.06x       Core computation         ✗
            post-processing   0.9757      1.0228      1/1.05x     DataFrame formatting     ✓
            total time        7.9799      7.7793      1.03x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
131,072     pre-processing    2.4043      2.3302      1.03x       Data preprocessing
            computation       6.2018      6.5097      1/1.05x     Core computation         ✗
            post-processing   0.9929      1.3359      1/1.35x     DataFrame formatting     ✓
            total time        9.5990      10.1758     1/1.06x     Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
262,144     pre-processing    3.4237      3.8534      1/1.13x     Data preprocessing
            computation       8.6577      7.3233      1.18x       Core computation         ✗
            post-processing   1.0553      1.1707      1/1.11x     DataFrame formatting     ✓
            total time        13.1367     12.3474     1.06x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
524,288     pre-processing    5.9624      5.7825      1.03x       Data preprocessing
            computation       14.8907     10.8211     1.38x       Core computation         ✗
            post-processing   1.0839      1.3854      1/1.28x     DataFrame formatting     ✓
            total time        21.9369     17.9890     1.22x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
1,048,576   pre-processing    11.9227     11.8409     1.01x       Data preprocessing
            computation       26.1555     17.8325     1.47x       Core computation         ✗
            post-processing   1.1681      2.4116      1/2.06x     DataFrame formatting     ✓
            total time        39.2462     32.0850     1.22x       Complete execution
--------------------------------------------------------------------------------------------------------------------------------------------
```


