### PR TITLE
Fix input data and policy environment `fail_if` checks.

### DIFF
--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -35,6 +35,7 @@ from ttsim.tt.param_objects import (
     PLACEHOLDER_FIELD,
     PLACEHOLDER_VALUE,
     ParamObject,
+    ScalarParam,
 )
 
 if TYPE_CHECKING:
@@ -258,7 +259,7 @@ def input_data_tree_is_invalid(
     input_data__tree: NestedData, backend: Literal["numpy", "jax"], xnp: ModuleType
 ) -> None:
     """Validate the basic structure of the input data tree."""
-    valid_leaf_types = (pd.Series, numpy.ndarray, xnp.ndarray)
+    valid_leaf_types = (pd.Series, numpy.ndarray, xnp.ndarray, int, float, bool)
     if backend == "numpy" and jax is not None:
         valid_leaf_types = (*valid_leaf_types, jax.numpy.ndarray)
     assert_valid_ttsim_pytree(
@@ -303,11 +304,13 @@ def input_data_is_invalid(input_data__flat: FlatData, xnp: ModuleType) -> None:
         )
         raise ValueError(message)
 
+    # Check that all arrays have the same length as the p_id array.
     len_p_id_array = len(input_data__flat[("p_id",)])
     faulty_arrays: list[str] = []
-    for key, arr in input_data__flat.items():
-        if len(arr) != len_p_id_array:
-            faulty_arrays.append(key)
+    for path, inp in input_data__flat.items():
+        if hasattr(inp, "__len__") and len(inp) != len_p_id_array:
+            faulty_arrays.append(path)
+
     if faulty_arrays:
         formatted_faulty_paths = "\n".join(f"    - {p}" for p in faulty_arrays)
         msg = format_errors_and_warnings(
@@ -322,16 +325,46 @@ def environment_is_invalid(
     policy_environment: PolicyEnvironment,
 ) -> None:
     """Validate that the environment is a pytree with supported types."""
-    assert_valid_ttsim_pytree(
-        tree=policy_environment,
-        leaf_checker=lambda leaf: isinstance(
-            leaf,
-            ColumnObject | ParamFunction | ParamObject | ModuleType,
+    if not isinstance(policy_environment, dict):
+        raise TypeError(
+            "policy_environment must be a dict, got {type(policy_environment)}."
         )
-        or (isinstance(leaf, str) and leaf in ["numpy", "jax"]),
+
+    # Check that the policy environment is valid
+    assert_valid_ttsim_pytree(
+        tree={
+            k: v
+            for k, v in policy_environment.items()
+            if k
+            not in ["evaluation_year", "evaluation_month", "evaluation_day", "backend"]
+        },
+        leaf_checker=lambda leaf: (
+            isinstance(leaf, ColumnObject | ParamFunction | ParamObject | ModuleType)
+        ),
         tree_name="policy_environment",
     )
+    # Check special paths explicitly
+    if "backend" in policy_environment and policy_environment.get("backend") not in [
+        "numpy",
+        "jax",
+    ]:
+        raise ValueError(
+            f"backend must be 'numpy' or 'jax', got {policy_environment.get('backend')}"
+        )
+    invalid_evaluation_dates = [
+        field
+        for field in ["evaluation_year", "evaluation_month", "evaluation_day"]
+        if field in policy_environment
+        and not isinstance(
+            policy_environment.get(field), int | PolicyInput | ScalarParam
+        )
+    ]
+    if invalid_evaluation_dates:
+        raise TypeError(
+            f"{', '.join(invalid_evaluation_dates)} must be int, PolicyInput, or a ScalarParam."
+        )
 
+    # Check for incorrect leaf names
     flat_policy_environment = dt.flatten_to_tree_paths(policy_environment)
     paths_with_incorrect_leaf_names = [
         f"    {p}"

--- a/src/ttsim/interface_dag_elements/processed_data.py
+++ b/src/ttsim/interface_dag_elements/processed_data.py
@@ -34,6 +34,10 @@ def processed_data(
         qname = dt.qname_from_tree_path(path)
         if path == ("p_id",):
             continue
+        if not hasattr(data, "__len__"):
+            # Scalars don't need to be sorted.
+            processed_input_data[qname] = data
+            continue
 
         sorted_data = xnp.asarray(data[input_data__sort_indices])
 

--- a/tests/interface_dag_elements/test_policy_environment.py
+++ b/tests/interface_dag_elements/test_policy_environment.py
@@ -30,6 +30,11 @@ if TYPE_CHECKING:
 from mettsim import middle_earth
 
 
+@policy_function()
+def identity(x: int) -> int:
+    return x
+
+
 @pytest.fixture(scope="module")
 def some_params_spec_with_updates_previous():
     return [

--- a/tests/interface_dag_elements/test_specialized_environment.py
+++ b/tests/interface_dag_elements/test_specialized_environment.py
@@ -14,6 +14,8 @@ from ttsim.interface_dag_elements.specialized_environment import (
     with_partialled_params_and_scalars,
     with_processed_params_and_scalars,
 )
+from ttsim.main_args import InputData, TTTargets
+from ttsim.main_target import MainTarget
 from ttsim.tt import (
     AggType,
     DictParam,
@@ -841,3 +843,25 @@ def test_can_override_ttsim_objects_with_data(
     assert flat_actual.keys() == flat_expected.keys()
     for key in flat_expected:
         numpy.testing.assert_array_almost_equal(flat_actual[key], flat_expected[key])
+
+
+def test_scalars_in_input_data_become_part_of_specialized_environment(xnp, backend):
+    policy_environment = {
+        "identity": identity,
+        "identity_plus_one": identity_plus_one,
+    }
+    input_data = {
+        "p_id": xnp.array([1, 2, 3]),
+        "identity": 1,
+    }
+    root_nodes = main(
+        main_target=MainTarget.labels.root_nodes,
+        policy_environment=policy_environment,
+        input_data=InputData.tree(input_data),
+        tt_targets=TTTargets.tree({"identity_plus_one": None}),
+        policy_date=datetime.date(2024, 1, 1),
+        evaluation_date_str="2024-01-01",
+        backend=backend,
+        include_warn_nodes=False,
+    )
+    assert root_nodes == set()


### PR DESCRIPTION
### What problem do you want to solve?

This PR does two things:
- `fail_if__input_data_tree_is_invalid` was too strict because it allowed for array leafs only. It now also allows for float/int/bool. Also fixed some corresponding bugs down the line.
- `fail_if__environment_is_invalid` was too strict because it did not allow for setting `evaluation_year, evaluation_date, evaluation_month` as scalars, even though those are `PolicyInput`s in the policy environment.
