### PR TITLE
Fix loop vectorization for functions with param helpers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ This is a record of all past `ttsim` releases and what went into them in reverse
 chronological order. We follow [semantic versioning](https://semver.org/) and all
 releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim).
 
+## Unreleased
+
+- {gh}`92` Let piecewise polynomials return scalars if the input is a scalar.
+  ({ghuser}`MImmesberger`)
+
 ## v1.2.0 — 2026-03-19
 
 - {gh}`76` Refactor piecewise polynomial (implements GEP 8). ({ghuser}`hmgaudecker`,

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import pytest
 
 from ttsim.interface_dag_elements.backend import dnp as ttsim_dnp
 from ttsim.interface_dag_elements.backend import xnp as ttsim_xnp
+from ttsim.tt.column_objects_param_function import PolicyFunction
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -56,3 +58,43 @@ def skipif_numpy(request, backend):
     """Automatically skip tests marked with skipif_numpy when backend is numpy."""
     if request.node.get_closest_marker("skipif_numpy") and backend == "numpy":
         pytest.skip("Cannot run this test with Numpy")
+
+
+_original_vectorize = PolicyFunction.vectorize
+
+
+def _vectorize_with_loop(self, backend, xnp):
+    """Force 'loop' strategy so coverage.py sees the original function body.
+
+    See https://github.com/ttsim-dev/ttsim/issues/91
+    """
+    if self.vectorization_strategy == "vectorize" and backend == "numpy":
+        self = replace(self, vectorization_strategy="loop")
+    return _original_vectorize(self, backend, xnp)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _force_loop_vectorization_for_coverage(request):
+    """Switch 'vectorize' to 'loop' strategy when running with coverage.
+
+    Only active when pytest-cov is running (``--cov`` is passed).
+
+    Note: 'yield' is used to separate the setup and teardown of the monkey-patch.
+    Everything before 'yield' is setup, everything after 'yield' is teardown. Tests
+    are executed in between the setup and teardown.
+    """
+    try:
+        cov_source = request.config.getoption("--cov")
+    except ValueError:
+        cov_source = None
+    if not cov_source:
+        # Run tests without any monkey-patching.
+        yield
+        return
+
+    # Monkey-patch PolicyFunction.vectorize to force "loop" strategy when running with
+    # coverage.
+    PolicyFunction.vectorize = _vectorize_with_loop  # type: ignore[assignment]
+    yield
+    # Restore the original vectorization strategy.
+    PolicyFunction.vectorize = _original_vectorize

--- a/src/ttsim/tt/column_objects_param_function.py
+++ b/src/ttsim/tt/column_objects_param_function.py
@@ -194,7 +194,13 @@ def _frozen_safe_update_wrapper(
         if hasattr(wrapped, attr):
             object.__setattr__(wrapper, attr, getattr(wrapped, attr))
 
-    getattr(wrapper, "__dict__", {}).update(getattr(wrapped, "__dict__", {}))
+    # Copy remaining __dict__ entries, but exclude __annotate__ to avoid
+    # overriding __annotations__ on Python 3.14+, where setting __annotate__
+    # on a function invalidates its cached __annotations__.
+    wrapped_dict = getattr(wrapped, "__dict__", {})
+    getattr(wrapper, "__dict__", {}).update(
+        {k: v for k, v in wrapped_dict.items() if k != "__annotate__"}
+    )
 
 
 @dataclass(frozen=True)

--- a/src/ttsim/tt/param_objects.py
+++ b/src/ttsim/tt/param_objects.py
@@ -150,11 +150,15 @@ class ConsecutiveIntLookupTableParamValue:
     def look_up(
         self: ConsecutiveIntLookupTableParamValue, *args: int
     ) -> float | int | bool:
+        scalar_input = all(getattr(a, "ndim", 0) == 0 for a in args)
         index = self.xnp.asarray(args)
         corrected_index = self.xnp.dot(
             (index - self.bases_to_subtract).T, self.lookup_multipliers
         )
-        return self.values_to_look_up[corrected_index]
+        result = self.values_to_look_up[corrected_index]
+        if scalar_input:
+            return result.flat[0]
+        return result
 
 
 @dataclass(frozen=True)

--- a/src/ttsim/tt/param_objects.py
+++ b/src/ttsim/tt/param_objects.py
@@ -157,7 +157,7 @@ class ConsecutiveIntLookupTableParamValue:
         )
         result = self.values_to_look_up[corrected_index]
         if scalar_input:
-            return result.flat[0]
+            return result.flatten()[0]
         return result
 
 

--- a/src/ttsim/tt/param_objects.py
+++ b/src/ttsim/tt/param_objects.py
@@ -152,6 +152,8 @@ class ConsecutiveIntLookupTableParamValue:
     ) -> float | int | bool:
         scalar_input = all(getattr(a, "ndim", 0) == 0 for a in args)
         index = self.xnp.asarray(args)
+        if scalar_input:
+            index = index.reshape(-1, 1)
         corrected_index = self.xnp.dot(
             (index - self.bases_to_subtract).T, self.lookup_multipliers
         )

--- a/src/ttsim/tt/piecewise_polynomial.py
+++ b/src/ttsim/tt/piecewise_polynomial.py
@@ -60,7 +60,7 @@ def piecewise_polynomial(
     x: Float[Array, " n_pp_values"] | float,
     parameters: PiecewisePolynomialParamValue,
     xnp: ModuleType,
-) -> Float[Array, " n_pp_values"]:
+) -> Float[Array, " n_pp_values"] | float:
     """Calculate value of the piecewise function at `x`.
 
     Values outside the defined domain return NaN.
@@ -74,6 +74,10 @@ def piecewise_polynomial(
         The value of `x` under the piecewise function.
 
     """
+    scalar_input = getattr(x, "ndim", 0) == 0
+    if scalar_input:
+        x = xnp.asarray([x])
+
     n_intervals = parameters.coefficients.shape[0]
     order = parameters.coefficients.shape[1]
     # Get interval of requested value
@@ -96,7 +100,11 @@ def piecewise_polynomial(
 
     # NaN for out-of-domain values
     out_of_domain = (selected_bin < 0) | (selected_bin >= n_intervals)
-    return xnp.where(out_of_domain, xnp.array(float("nan")), result)
+    result = xnp.where(out_of_domain, xnp.array(float("nan")), result)
+
+    if scalar_input:
+        return result[0]
+    return result
 
 
 def get_piecewise_parameters(

--- a/src/ttsim/tt/vectorization.py
+++ b/src/ttsim/tt/vectorization.py
@@ -47,7 +47,7 @@ def vectorize_function(
         _vectorized = numpy.vectorize(func)
 
         @functools.wraps(func)
-        def vectorized(*args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]  # noqa: ANN401
+        def vectorized(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
             return _vectorized(*args, **kwargs)
     elif vectorization_strategy == "vectorize":
         vectorized = _make_vectorizable(func, backend=backend, xnp=xnp)

--- a/src/ttsim/tt/vectorization.py
+++ b/src/ttsim/tt/vectorization.py
@@ -44,11 +44,13 @@ def vectorize_function(
 
     vectorized: FunctionType[..., Any]
     if vectorization_strategy == "loop":
-        _vectorized = numpy.vectorize(func)
-
-        @functools.wraps(func)
-        def vectorized(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
-            return _vectorized(*args, **kwargs)
+        assigned = (
+            "__signature__",
+            "__globals__",
+            "__closure__",
+            *functools.WRAPPER_ASSIGNMENTS,
+        )
+        vectorized = functools.wraps(func, assigned=assigned)(numpy.vectorize(func))
     elif vectorization_strategy == "vectorize":
         vectorized = _make_vectorizable(func, backend=backend, xnp=xnp)
     else:

--- a/src/ttsim/tt/vectorization.py
+++ b/src/ttsim/tt/vectorization.py
@@ -44,13 +44,11 @@ def vectorize_function(
 
     vectorized: FunctionType[..., Any]
     if vectorization_strategy == "loop":
-        assigned = (
-            "__signature__",
-            "__globals__",
-            "__closure__",
-            *functools.WRAPPER_ASSIGNMENTS,
-        )
-        vectorized = functools.wraps(func, assigned=assigned)(numpy.vectorize(func))
+        _vectorized = numpy.vectorize(func)
+
+        @functools.wraps(func)
+        def vectorized(*args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]  # noqa: ANN401
+            return _vectorized(*args, **kwargs)
     elif vectorization_strategy == "vectorize":
         vectorized = _make_vectorizable(func, backend=backend, xnp=xnp)
     else:

--- a/tests/tt/test_param_objects.py
+++ b/tests/tt/test_param_objects.py
@@ -158,7 +158,14 @@ def test_lookup_table_look_up_array_input(xnp):
     numpy.testing.assert_array_equal(result, xnp.array([10.0, 20.0, 30.0]))
 
 
-def test_lookup_table_look_up_multidim_scalar(xnp):
+@pytest.mark.parametrize(
+    ("row", "col", "expected"),
+    [
+        (0, 1, 20.0),
+        (1, 2, 60.0),
+    ],
+)
+def test_lookup_table_look_up_multidim_scalar(xnp, row, col, expected):
     """Test lookup with multiple scalar args (multi-dimensional table)."""
     values = xnp.array([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]])
     bases = xnp.array([0, 0])
@@ -167,14 +174,7 @@ def test_lookup_table_look_up_multidim_scalar(xnp):
         xnp=xnp, values_to_look_up=values, bases_to_subtract=bases
     )
 
-    # Scalar 2-D lookup: row 0, col 1 → 20.0
-    result = lut.look_up(0, 1)
-    numpy.testing.assert_almost_equal(result, 20.0)
-    assert getattr(result, "ndim", 0) == 0
-
-    # Scalar 2-D lookup: row 1, col 2 → 60.0
-    result = lut.look_up(1, 2)
-    numpy.testing.assert_almost_equal(result, 60.0)
+    numpy.testing.assert_almost_equal(lut.look_up(row, col), expected)
 
 
 def test_lookup_table_look_up_with_nonzero_base(xnp):

--- a/tests/tt/test_param_objects.py
+++ b/tests/tt/test_param_objects.py
@@ -158,6 +158,25 @@ def test_lookup_table_look_up_array_input(xnp):
     numpy.testing.assert_array_equal(result, xnp.array([10.0, 20.0, 30.0]))
 
 
+def test_lookup_table_look_up_multidim_scalar(xnp):
+    """Test lookup with multiple scalar args (multi-dimensional table)."""
+    values = xnp.array([[10.0, 20.0, 30.0], [40.0, 50.0, 60.0]])
+    bases = xnp.array([0, 0])
+
+    lut = ConsecutiveIntLookupTableParamValue(
+        xnp=xnp, values_to_look_up=values, bases_to_subtract=bases
+    )
+
+    # Scalar 2-D lookup: row 0, col 1 → 20.0
+    result = lut.look_up(0, 1)
+    numpy.testing.assert_almost_equal(result, 20.0)
+    assert getattr(result, "ndim", 0) == 0
+
+    # Scalar 2-D lookup: row 1, col 2 → 60.0
+    result = lut.look_up(1, 2)
+    numpy.testing.assert_almost_equal(result, 60.0)
+
+
 def test_lookup_table_look_up_with_nonzero_base(xnp):
     """Test lookup with non-zero base subtraction."""
     values = xnp.array([10.0, 20.0, 30.0])

--- a/tests/tt/test_param_objects.py
+++ b/tests/tt/test_param_objects.py
@@ -145,6 +145,19 @@ def test_lookup_table_look_up_single_dim(xnp):
     numpy.testing.assert_almost_equal(lut.look_up(2), 30.0)
 
 
+def test_lookup_table_look_up_array_input(xnp):
+    """Test lookup with array input returns array."""
+    values = xnp.array([10.0, 20.0, 30.0])
+    bases = xnp.array([0])
+
+    lut = ConsecutiveIntLookupTableParamValue(
+        xnp=xnp, values_to_look_up=values, bases_to_subtract=bases
+    )
+
+    result = lut.look_up(xnp.array([0, 1, 2]))
+    numpy.testing.assert_array_equal(result, xnp.array([10.0, 20.0, 30.0]))
+
+
 def test_lookup_table_look_up_with_nonzero_base(xnp):
     """Test lookup with non-zero base subtraction."""
     values = xnp.array([10.0, 20.0, 30.0])

--- a/tests/tt/test_piecewise_polynomial.py
+++ b/tests/tt/test_piecewise_polynomial.py
@@ -123,6 +123,7 @@ def test_partial_domain_returns_nan(xnp: ModuleType):
 
     x = xnp.array([-10.0, 50.0, 150.0, 300.0])
     result = piecewise_polynomial(x=x, parameters=params, xnp=xnp)
+    assert not isinstance(result, (int, float))
 
     assert numpy.isnan(result[0]), "Value below domain should be NaN"
     numpy.testing.assert_allclose(result[1], 5.0, atol=1e-7)
@@ -154,6 +155,7 @@ def test_neg_inf_to_zero_to_inf(xnp: ModuleType):
 
     x = xnp.array([-10.0, 0.0, 10.0])
     result = piecewise_polynomial(x=x, parameters=params, xnp=xnp)
+    assert not isinstance(result, (int, float))
 
     numpy.testing.assert_allclose(result[0], 0.0, atol=1e-7)
     numpy.testing.assert_allclose(result[1], 0.0, atol=1e-7)

--- a/tests/tt/test_piecewise_polynomial.py
+++ b/tests/tt/test_piecewise_polynomial.py
@@ -89,13 +89,21 @@ def test_typical_evaluation(
     numpy.testing.assert_allclose(xnp.array(actual), expected, atol=0.01)
 
 
-def test_piecewise_polynomial_scalar_input(
+def test_piecewise_polynomial_scalar_input_is_scalar(
     parameters: PiecewisePolynomialParamValue,
     xnp: ModuleType,
 ):
-    """piecewise_polynomial accepts a scalar float and returns a numpy scalar."""
+    """piecewise_polynomial with scalar float returns a 0-d result."""
     result = piecewise_polynomial(x=30_000.0, parameters=parameters, xnp=xnp)
     assert getattr(result, "ndim", -1) == 0, f"Expected 0-d, got {type(result)}"
+
+
+def test_piecewise_polynomial_scalar_input_value(
+    parameters: PiecewisePolynomialParamValue,
+    xnp: ModuleType,
+):
+    """piecewise_polynomial with scalar float returns the correct value."""
+    result = piecewise_polynomial(x=30_000.0, parameters=parameters, xnp=xnp)
     numpy.testing.assert_allclose(result, 5275.825, atol=0.01)
 
 

--- a/tests/tt/test_piecewise_polynomial.py
+++ b/tests/tt/test_piecewise_polynomial.py
@@ -93,10 +93,10 @@ def test_piecewise_polynomial_scalar_input(
     parameters: PiecewisePolynomialParamValue,
     xnp: ModuleType,
 ):
-    """piecewise_polynomial accepts a scalar float and returns a 1-element array."""
+    """piecewise_polynomial accepts a scalar float and returns a numpy scalar."""
     result = piecewise_polynomial(x=30_000.0, parameters=parameters, xnp=xnp)
-    assert result.shape == (1,)
-    numpy.testing.assert_allclose(result[0], 5275.825, atol=0.01)
+    assert getattr(result, "ndim", -1) == 0, f"Expected 0-d, got {type(result)}"
+    numpy.testing.assert_allclose(result, 5275.825, atol=0.01)
 
 
 def test_partial_domain_returns_nan(xnp: ModuleType):


### PR DESCRIPTION
## Summary

Vectorisation strategy `"loop"` failed if functions had piecewise polynomial param inputs. This PR fixes this.

Related to #91 — these fixes enable downstream projects (e.g. GETTSIM) to switch policy functions to the `"loop"` strategy for any (not already natively) vectorised function.

- `look_up()` and `piecewise_polynomial()` now return numpy scalars for scalar input, instead of always returning arrays. This makes them compatible with `numpy.vectorize`, which calls functions per-element and expects scalar returns.
- The `"loop"` path in `vectorize_function` now wraps `numpy.vectorize` in a regular function closure instead of applying `functools.wraps` directly to the `numpy.vectorize` object. This fixes `AnnotationMismatchError` in dags, which could not resolve type annotations on `numpy.vectorize` objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)