### PR TITLE
Canonicalize pandas-nullable and pyarrow input dtypes (closes #94)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
+- {gh}`103` Add `results.df_with_qname_columns` return format with flat qname string
+  columns. ({ghuser}`hmgaudecker`)
 - {gh}`101` Adopt the package-wide beartype claw with a typed exception hierarchy at
   user-facing boundaries (`InputDataError`, `EntryPointError`, `TTTargetsError`,
   `PolicyFunctionDefinitionError`, …) so malformed input is rejected with curated

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
+- {gh}`104` Fix partialling of scalar inputs that drive derived time-conversion
+  functions. ({ghuser}`hmgaudecker`)
 - {gh}`103` Add `results.df_with_qname_columns` return format with flat qname string
   columns. ({ghuser}`hmgaudecker`)
 - {gh}`101` Adopt the package-wide beartype claw with a typed exception hierarchy at

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
+- {gh}`107` Broadcast scalar leaves in `InputData.tree` to length-`n_obs` arrays.
+  `InputData.flat` keeps the scalar-as-input opt-out for users who want
+  partial-application. ({ghuser}`hmgaudecker`)
 - {gh}`106` Document the JAX-optional-runtime-dependency constraint that governs how
   column-type aliases must be imported. ({ghuser}`hmgaudecker`)
 - {gh}`105` Load policy modules under their canonical Python import name so

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
+- {gh}`105` Load policy modules under their canonical Python import name so
+  `cloudpickle.dumps(tt_function)` works. ({ghuser}`hmgaudecker`)
 - {gh}`104` Fix partialling of scalar inputs that drive derived time-conversion
   functions. ({ghuser}`hmgaudecker`)
 - {gh}`103` Add `results.df_with_qname_columns` return format with flat qname string

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
+- {gh}`109` Canonicalize pandas-nullable and pyarrow-backed input dtypes: float-nullable
+  / float-pyarrow columns are converted to `float64` with `pd.NA → NaN`; integer /
+  boolean nullable variants are coerced to `int64` / `bool` when NA-free, and rejected
+  with a per-column + per-row error otherwise. ({ghuser}`hmgaudecker`)
 - {gh}`108` Allow endogenously-computed `p_id_*` columns as targets — the interface DAG
   reverse-translates internal indices back to user-space `p_id` values, preserving the
   `-1` no-link sentinel. ({ghuser}`hmgaudecker`)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
+- {gh}`106` Document the JAX-optional-runtime-dependency constraint that governs how
+  column-type aliases must be imported. ({ghuser}`hmgaudecker`)
 - {gh}`105` Load policy modules under their canonical Python import name so
   `cloudpickle.dumps(tt_function)` works. ({ghuser}`hmgaudecker`)
 - {gh}`104` Fix partialling of scalar inputs that drive derived time-conversion

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
+- {gh}`108` Allow endogenously-computed `p_id_*` columns as targets — the interface DAG
+  reverse-translates internal indices back to user-space `p_id` values, preserving the
+  `-1` no-link sentinel. ({ghuser}`hmgaudecker`)
 - {gh}`107` Broadcast scalar leaves in `InputData.tree` to length-`n_obs` arrays.
   `InputData.flat` keeps the scalar-as-input opt-out for users who want
   partial-application. ({ghuser}`hmgaudecker`)

--- a/pixi.lock
+++ b/pixi.lock
@@ -1265,6 +1265,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/53/c16972708cbb79f2942922571a687c52bd109a7bd51175aeb7558dff2236/coverage-7.13.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -1503,6 +1504,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/a2/cd2e10b880368305d89dd540685b8bdcc136df2b3c76b5ddd72596254539/simplejson-3.20.2-cp311-cp311-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -1742,6 +1744,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5d/02/290f7282eaa6ebe945d35c47e6534348af97472446951dce0d144e013f4c/simplejson-3.20.2-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -1985,6 +1988,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/08/3d9c8613079d2b11c185b865de9a4c1a68850cfda2b357fae365cf609f29/coverage-7.13.4-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -2272,6 +2276,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5d/a0/2ea570925524ef4e00bb6c82649f5682a77fac5ab910a65c9284de422600/coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -2513,6 +2518,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/bf/76f4f1665f6983385938f0e2a5d7efa12a58171b8456c252f3bae8a4cf75/orjson-3.11.7-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -2754,6 +2760,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/bf/76f4f1665f6983385938f0e2a5d7efa12a58171b8456c252f3bae8a4cf75/orjson-3.11.7-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -3000,6 +3007,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/4e/c0a25a425fcf5557d9abd18419c95b63922e897bc86c1f327f155ef234a9/coverage-7.13.4-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -3285,6 +3293,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/fc/753bf69b907652d54b7c6012ccb320d8c1a3161454e415331058b6f04246/optree-0.19.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -3527,6 +3536,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/88/9c598325e89bbed29b37a381ebb2b94f1d9d769c973b879b3e9766b4b16d/optree-0.19.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/25/6e0e52cac5aab51d7b6dcd257e855e1dec1c2060f6b28566c509b4665f62/orjson-3.11.7-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
@@ -3769,6 +3779,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6b/d2/fcba2a1826d362a64cb36ec9f675ed6dcddee47099948913122b0aafbe44/optree-0.19.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/4d/30dfef83b9ac48afae1cf1ab19c2867e27b8d22b5d9f8ca7ce5a0a157d8c/simplejson-3.20.2-cp313-cp313-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/25/6e0e52cac5aab51d7b6dcd257e855e1dec1c2060f6b28566c509b4665f62/orjson-3.11.7-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
@@ -4017,6 +4028,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/10/d42ad61230436735c68af1120622b28a782877146a83d714da7b6a2a1c4e/simplejson-3.20.2-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -4302,6 +4314,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/6aa79ba3570bddd1bf7e951c6123f806751e58e8cce736bad77b2cf348d7/logistro-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -4544,6 +4557,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/6aa79ba3570bddd1bf7e951c6123f806751e58e8cce736bad77b2cf348d7/logistro-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
@@ -4786,6 +4800,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/6aa79ba3570bddd1bf7e951c6123f806751e58e8cce736bad77b2cf348d7/logistro-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -5035,6 +5050,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/c3/587cc9aa8d4742cd690da79460081e7d834499e07e8b2bd2ccc4c66928df/optree-0.19.0-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -5332,6 +5348,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/40/23990a83164aaec2bfeffcee87794299f3cfdbdd7ed024b2af078afb600a/nvidia_cusparse-12.7.9.17-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/74/05adf1f245de3b37518ba1e7e668cdc38ec0291313ab63fc0768089f8baa/jax_cuda13_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
@@ -5629,6 +5646,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5c/6e/5087e0347188f6970aba1ffbd0018754d23c3f3461e9f21785f2f27a02c2/jax-0.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -5877,6 +5895,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -6131,6 +6150,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/c3/587cc9aa8d4742cd690da79460081e7d834499e07e8b2bd2ccc4c66928df/optree-0.19.0-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -6385,6 +6405,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/05/3e39d416fb92b2738a76e8265e6bfc5d10542f90a7c32ad1eb831eea3fa3/jaxtyping-0.3.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/b8/e77c355f179dc89d44e7ca6dbf7a46e650806df1d356a5462e5829fccea5/types_pytz-2026.1.1.20260304-py3-none-any.whl
@@ -20072,6 +20093,11 @@ packages:
   requires_dist:
   - nvidia-nvjitlink
   requires_python: '>=3'
+- pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+  name: cloudpickle
+  version: 3.1.2
+  sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/89/25/6e0e52cac5aab51d7b6dcd257e855e1dec1c2060f6b28566c509b4665f62/orjson-3.11.7-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
   name: orjson
   version: 3.11.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ tests.pypi-dependencies.types-PyYAML = "*"
 tests.pypi-dependencies.types-pytz = "*"
 tests.pypi-dependencies.pytest-cov = "*"
 tests.pypi-dependencies.pytest-xdist = "*"
+tests.pypi-dependencies.cloudpickle = ">=3"
 # Run internal tests with the package-wide beartype claw on. The claw is
 # env-var-gated (see `ttsim/__init__.py`); users of a released package
 # leave `TTSIM_BEARTYPE_CLAW` unset and never see it. The gate stays in

--- a/src/ttsim/entry_point.py
+++ b/src/ttsim/entry_point.py
@@ -470,6 +470,10 @@ def _load_orig_functions() -> dict[tuple[str, ...], InterfaceFunction | Interfac
     ] = {}
     for path in paths:
         module = load_module(path=path, root=root)
+        # Use the file stem (e.g., `warn_if`) for the namespace prefix; the
+        # interface qname structure depends on the short name, independent of
+        # how the module is registered in `sys.modules`.
+        namespace = path.stem
         for qname, obj in inspect.getmembers(module):
             # If nesting happens (e.g., df+mapper), we need to be consistent.
             tree_path = dt.tree_path_from_qname(qname)
@@ -477,7 +481,7 @@ def _load_orig_functions() -> dict[tuple[str, ...], InterfaceFunction | Interfac
                 if obj.in_top_level_namespace:
                     flat_functions[tree_path] = obj
                 else:
-                    flat_functions[(str(module.__name__), *tree_path)] = obj
+                    flat_functions[(namespace, *tree_path)] = obj
 
     return flat_functions
 

--- a/src/ttsim/entry_point.py
+++ b/src/ttsim/entry_point.py
@@ -470,10 +470,6 @@ def _load_orig_functions() -> dict[tuple[str, ...], InterfaceFunction | Interfac
     ] = {}
     for path in paths:
         module = load_module(path=path, root=root)
-        # Use the file stem (e.g., `warn_if`) for the namespace prefix; the
-        # interface qname structure depends on the short name, independent of
-        # how the module is registered in `sys.modules`.
-        namespace = path.stem
         for qname, obj in inspect.getmembers(module):
             # If nesting happens (e.g., df+mapper), we need to be consistent.
             tree_path = dt.tree_path_from_qname(qname)
@@ -481,7 +477,7 @@ def _load_orig_functions() -> dict[tuple[str, ...], InterfaceFunction | Interfac
                 if obj.in_top_level_namespace:
                     flat_functions[tree_path] = obj
                 else:
-                    flat_functions[(namespace, *tree_path)] = obj
+                    flat_functions[(str(module.__name__), *tree_path)] = obj
 
     return flat_functions
 

--- a/src/ttsim/interface_dag_elements/data_converters.py
+++ b/src/ttsim/interface_dag_elements/data_converters.py
@@ -12,6 +12,9 @@ import pandas as pd
 # so beartype sees stringified annotations and resolves them via module
 # globals; names hidden in `TYPE_CHECKING` are invisible at decoration time.
 # All names below are runtime-resolvable in `ttsim.typing`.
+from ttsim.interface_dag_elements.processed_data import (
+    _canonicalize_input_dtype,
+)
 from ttsim.typing import (
     FlatData,
     NestedData,
@@ -165,10 +168,12 @@ def df_with_mapped_columns_to_flat_data(
         if numpy.isscalar(mapper_value) and not isinstance(mapper_value, str):
             numpy_array = numpy.full(len(df), mapper_value)
         else:
-            numpy_array = numpy.asarray(df[mapper_value])
+            numpy_array = _canonicalize_input_dtype(df[mapper_value], numpy)
 
-        # Convert numpy array back to JAX array if JAX backend is chosen
-        if backend == "jax":
+        # Keep NA-containing int/bool columns as numpy object arrays so the
+        # `input_data_has_int_or_bool_missing_values` fail-if can report them;
+        # JAX's `asarray` would crash on `pd.NA` before the fail-if runs.
+        if backend == "jax" and numpy_array.dtype != numpy.dtype(object):
             path_to_array[path] = xnp.asarray(numpy_array)
         else:
             path_to_array[path] = numpy_array
@@ -199,16 +204,19 @@ def df_with_nested_columns_to_flat_data(
         {("a", "b"): np.array([1, 2, 3]), ("c",): np.array([4, 5, 6])}
     """
     result = {}
-    for key, value in df.to_dict(orient="list").items():
-        clean_key = _remove_nan_from_keys(key)
-
-        # Use numpy for array creation if JAX backend is chosen and
-        # immediately convert back to JAX array.
-        # Performance optimization for JAX, PR #34
-        if backend == "jax":
-            result[clean_key] = xnp.asarray(numpy.asarray(value))
+    # `to_dict(orient='list')` strips nullable / pyarrow dtypes — read each
+    # column off the DataFrame as a `pd.Series` so the canonicalizer can see
+    # the dtype and apply the correct NA-aware conversion.
+    for raw_key in df.columns:
+        clean_key = _remove_nan_from_keys(
+            raw_key if isinstance(raw_key, tuple) else (raw_key,)
+        )
+        numpy_array = _canonicalize_input_dtype(df[raw_key], numpy)
+        # See comment in `df_with_mapped_columns_to_flat_data` re: object dtype.
+        if backend == "jax" and numpy_array.dtype != numpy.dtype(object):
+            result[clean_key] = xnp.asarray(numpy_array)
         else:
-            result[clean_key] = numpy.asarray(value)
+            result[clean_key] = numpy_array
 
     return result
 

--- a/src/ttsim/interface_dag_elements/data_converters.py
+++ b/src/ttsim/interface_dag_elements/data_converters.py
@@ -53,6 +53,34 @@ def nested_data_to_df_with_nested_columns(
     )
 
 
+def nested_data_to_df_with_qname_columns(
+    nested_data_to_convert: NestedResults,
+    index: pd.Index,
+) -> pd.DataFrame:
+    """Convert a nested data structure to a DataFrame with qname-string columns.
+
+    Each output column is named with the qualified-name string for its tree path
+    (parts joined by ``__``). The column index is a flat ``str`` index regardless
+    of how deeply nested the input is, so adding or removing targets does not
+    change the column-index depth.
+
+    Args:
+        nested_data_to_convert:
+            A nested data structure.
+        index:
+            The index to use for the DataFrame.
+
+    Returns:
+        A DataFrame with qname-string columns.
+    """
+    flat_data_to_convert = dt.flatten_to_qnames(nested_data_to_convert)
+
+    return pd.DataFrame(
+        flat_data_to_convert,
+        index=index,
+    )
+
+
 def nested_data_to_df_with_mapped_columns(
     nested_data_to_convert: NestedResults,
     nested_outputs_df_column_names: NestedStrings,

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -960,37 +960,6 @@ def param_function_depends_on_column_objects(
 
 
 @fail_function()
-def endogenous_p_id_among_targets(
-    labels__column_targets: OrderedQNames,
-) -> None:
-    """Fail if any p_id_* columns are requested as targets.
-
-    A ValueError is raised if any endogenous target name starts with `p_id_`. These
-    columns contain internal ID mappings that would not be meaningful after reverting
-    the internal `p_id` column to the original `p_id` column.
-    """
-
-    p_id_targets = [
-        str(dt.tree_path_from_qname(target))
-        for target in labels__column_targets
-        if target.startswith("p_id_")
-    ]
-
-    if p_id_targets:
-        formatted = format_list_linewise(p_id_targets)
-        msg = (
-            "The following endogenous p_id_* columns were requested as targets, but "
-            "these contain internal ID mappings that are not meaningful after "
-            "reverting the internal `p_id` column to the original `p_id` column:\n\n"
-            f"{formatted}\n\n"
-            "Please remove these from your targets specification. If you need "
-            "these endogenous person identifiers, please add your request to "
-            "https://github.com/ttsim-dev/ttsim/issues/43"
-        )
-        raise ValueError(msg)
-
-
-@fail_function()
 def passed_scalar_inputs_for_natively_vectorized_functions(
     tt_function_set_annotations: bool,
     specialized_environment__with_processed_params_and_scalars: SpecEnvWithProcessedParamsAndScalars,

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -326,6 +326,47 @@ def input_data_is_invalid(input_data__flat: FlatData, xnp: ModuleType) -> None:
 
 
 @fail_function(include_if_any_element_present=["input_data__flat"])
+def input_data_has_int_or_bool_missing_values(input_data__flat: FlatData) -> None:
+    """Fail when an integer or boolean input column has missing values.
+
+    Float columns map ``pd.NA`` to ``NaN`` silently, but neither numpy
+    integer nor numpy boolean dtypes have a missing-value sentinel. Surface
+    the columns and their first offending row position so the user can
+    either fill the missing values or convert the column to a float type
+    that supports NaN.
+    """
+    offending: list[tuple[tuple[str, ...], int]] = []
+    for path, data in input_data__flat.items():
+        if getattr(data, "dtype", None) != numpy.dtype(object):
+            continue
+        series = pd.Series(data)
+        na_mask = series.isna()
+        if not na_mask.any():
+            continue
+        non_na = series[~na_mask]
+        if non_na.empty:
+            offending.append((path, int(numpy.argmax(na_mask.to_numpy()))))
+            continue
+        sample = non_na.iloc[0]
+        if isinstance(sample, bool | numpy.bool_ | int | numpy.integer):
+            offending.append((path, int(numpy.argmax(na_mask.to_numpy()))))
+    if offending:
+        formatted = "\n".join(
+            f"    - {dt.qname_from_tree_path(path)}: first NA at row {row}"
+            for path, row in offending
+        )
+        msg = format_errors_and_warnings(
+            "The following integer or boolean input columns contain missing "
+            "values, which cannot be represented in numpy integer / bool "
+            "dtypes:\n"
+            f"{formatted}\n\n"
+            "Fill the missing values, or convert the column to a float type "
+            "that supports NaN."
+        )
+        raise ValueError(msg)
+
+
+@fail_function(include_if_any_element_present=["input_data__flat"])
 def input_data_uint64_values_overflow_int64(input_data__flat: FlatData) -> None:
     """Fail when a uint64 input column has any value outside the int64 range.
 

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -325,6 +325,37 @@ def input_data_is_invalid(input_data__flat: FlatData, xnp: ModuleType) -> None:
         raise ValueError(msg)
 
 
+@fail_function(include_if_any_element_present=["input_data__flat"])
+def input_data_uint64_values_overflow_int64(input_data__flat: FlatData) -> None:
+    """Fail when a uint64 input column has any value outside the int64 range.
+
+    Uint columns are coerced to int64 in ``processed_data`` so that signed
+    arithmetic on them stays signed. Values in ``(int64.max, uint64.max]`` cannot
+    be represented as int64 and would silently wrap; surface them as an error.
+    """
+    int64_max = numpy.iinfo(numpy.int64).max
+    offending: list[tuple[tuple[str, ...], Any]] = []
+    for path, data in input_data__flat.items():
+        dtype = getattr(data, "dtype", None)
+        if dtype is None or numpy.dtype(dtype) != numpy.uint64:
+            continue
+        arr = numpy.asarray(data)
+        over = arr[arr > int64_max]
+        if over.size:
+            offending.append((path, int(over[0])))
+    if offending:
+        formatted = "\n".join(
+            f"    - {dt.qname_from_tree_path(path)}: {value}"
+            for path, value in offending
+        )
+        msg = format_errors_and_warnings(
+            "The following uint64 input columns contain values that exceed "
+            f"int64 max ({int64_max}); they cannot be coerced to int64 safely:\n"
+            f"{formatted}"
+        )
+        raise ValueError(msg)
+
+
 @fail_function()
 def policy_environment_is_invalid(
     policy_environment: PolicyEnvironment,

--- a/src/ttsim/interface_dag_elements/input_data.py
+++ b/src/ttsim/interface_dag_elements/input_data.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Literal
 
 import dags.tree as dt
 import numpy
+import pandas as pd
 
 from ttsim.interface_dag_elements.data_converters import (
     df_with_mapped_columns_to_flat_data,
@@ -14,11 +15,12 @@ from ttsim.interface_dag_elements.interface_node_objects import (
     interface_function,
     interface_input,
 )
+from ttsim.interface_dag_elements.processed_data import (
+    _canonicalize_input_dtype,
+)
 
 if TYPE_CHECKING:
     from types import ModuleType
-
-    import pandas as pd
 
     from ttsim.typing import (
         FlatData,
@@ -101,7 +103,9 @@ def flat_from_tree(
     # Broadcast scalar leaves to length-`n_obs` arrays so the tree input
     # path produces the same shape as the df-based paths. Users who want
     # scalars partialled into derived consumers must opt in by supplying
-    # their data via `InputData.flat`, which bypasses this conversion.
+    # their data via `InputData.flat`, which bypasses this conversion. Any
+    # `pd.Series` leaves go through `_canonicalize_input_dtype` so
+    # nullable / pyarrow dtypes are normalised to numpy.
     flat = dt.flatten_to_tree_paths(tree)
     p_id = flat.get(("p_id",))
     # If `p_id` is missing or itself a scalar, we don't know `n_obs`; pass
@@ -110,10 +114,15 @@ def flat_from_tree(
     if p_id is None or not hasattr(p_id, "__len__"):
         return flat
     n_obs = len(p_id)
-    return {
-        path: value if hasattr(value, "__len__") else numpy.full(n_obs, value)
-        for path, value in flat.items()
-    }
+    out: FlatData = {}
+    for path, value in flat.items():
+        if not hasattr(value, "__len__"):
+            out[path] = numpy.full(n_obs, value)
+        elif isinstance(value, pd.Series):
+            out[path] = _canonicalize_input_dtype(value, numpy)
+        else:
+            out[path] = value
+    return out
 
 
 @interface_function()

--- a/src/ttsim/interface_dag_elements/input_data.py
+++ b/src/ttsim/interface_dag_elements/input_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 import dags.tree as dt
+import numpy
 
 from ttsim.interface_dag_elements.data_converters import (
     df_with_mapped_columns_to_flat_data,
@@ -97,7 +98,22 @@ def flat_from_tree(
     xnp: ModuleType,  # noqa: ARG001
 ) -> FlatData:
     """The input data as a flat dictionary of arrays."""
-    return dt.flatten_to_tree_paths(tree)
+    # Broadcast scalar leaves to length-`n_obs` arrays so the tree input
+    # path produces the same shape as the df-based paths. Users who want
+    # scalars partialled into derived consumers must opt in by supplying
+    # their data via `InputData.flat`, which bypasses this conversion.
+    flat = dt.flatten_to_tree_paths(tree)
+    p_id = flat.get(("p_id",))
+    # If `p_id` is missing or itself a scalar, we don't know `n_obs`; pass
+    # the tree through unchanged and let downstream `fail_if` nodes raise
+    # the actionable error.
+    if p_id is None or not hasattr(p_id, "__len__"):
+        return flat
+    n_obs = len(p_id)
+    return {
+        path: value if hasattr(value, "__len__") else numpy.full(n_obs, value)
+        for path, value in flat.items()
+    }
 
 
 @interface_function()

--- a/src/ttsim/interface_dag_elements/orig_policy_objects.py
+++ b/src/ttsim/interface_dag_elements/orig_policy_objects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import inspect
 import sys
@@ -21,7 +22,6 @@ from ttsim.typing import FlatColumnObjectsParamFunctions
 
 if TYPE_CHECKING:
     from ttsim.typing import (
-        FlatColumnObjectsParamFunctions,
         FlatOrigParamSpecs,
         OrigParamSpec,
     )
@@ -111,9 +111,18 @@ def _tree_path_to_orig_column_objects_params_functions(
 
 
 def load_module(path: Path, root: Path) -> ModuleType:
+    canonical_name = _find_canonical_module_name(path)
+    if canonical_name is not None:
+        # Use the proper Python import path so objects defined in the module
+        # have an importable `__module__` — required for `cloudpickle.dumps`
+        # to round-trip the policy environment via pickle-by-reference.
+        return importlib.import_module(canonical_name)
+
+    # Policy environment is a bare directory tree (no `__init__.py` chain
+    # reaching `sys.path`). Objects defined in modules loaded this way carry
+    # a non-importable `__module__` and cannot be cloudpickled by reference.
     name = path.relative_to(root).with_suffix("").as_posix().replace("/", ".")
     spec = importlib.util.spec_from_file_location(name=name, location=path)
-    # Assert that spec is not None and spec.loader is not None, required for mypy
     _msg = f"Could not load module spec for {path},  {root}"
     if spec is None:
         raise ImportError(_msg)
@@ -124,6 +133,28 @@ def load_module(path: Path, root: Path) -> ModuleType:
     spec.loader.exec_module(module)
 
     return module
+
+
+def _find_canonical_module_name(path: Path) -> str | None:
+    """Return the canonical dotted import name for ``path``, if importable.
+
+    Walks up the ``__init__.py`` chain from ``path``'s parent. If the topmost
+    ``__init__.py``-having directory's parent is on ``sys.path``, the dotted
+    name formed by joining the directory names (top to bottom) plus the file
+    stem is the canonical import path. Returns ``None`` if ``path`` is not
+    part of a proper Python package.
+    """
+    parts = [path.stem]
+    current = path.parent
+    while (current / "__init__.py").is_file():
+        parts.append(current.name)
+        current = current.parent
+    if len(parts) == 1:
+        return None
+    sys_path_resolved = {Path(p).resolve() for p in sys.path if Path(p).exists()}
+    if current.resolve() in sys_path_resolved:
+        return ".".join(reversed(parts))
+    return None
 
 
 def _tree_path_to_orig_yaml_object(path: Path, root: Path) -> FlatOrigParamSpecs:

--- a/src/ttsim/interface_dag_elements/orig_policy_objects.py
+++ b/src/ttsim/interface_dag_elements/orig_policy_objects.py
@@ -101,7 +101,7 @@ def _tree_path_to_orig_column_objects_params_functions(
         A flat tree of ColumnObjectParamFunctions.
 
     """
-    module = load_module(path=path, root=root)
+    module = load_module(path=path, root=root, prefer_canonical_name=True)
     tree_path = path.relative_to(root).parts
     return {
         (*tree_path, name): obj
@@ -110,18 +110,33 @@ def _tree_path_to_orig_column_objects_params_functions(
     }
 
 
-def load_module(path: Path, root: Path) -> ModuleType:
-    canonical_name = _find_canonical_module_name(path)
-    if canonical_name is not None:
-        # Use the proper Python import path so objects defined in the module
-        # have an importable `__module__` — required for `cloudpickle.dumps`
-        # to round-trip the policy environment via pickle-by-reference.
-        return importlib.import_module(canonical_name)
+def load_module(
+    path: Path, root: Path, *, prefer_canonical_name: bool = False
+) -> ModuleType:
+    """Load a Python file as a module via `spec_from_file_location`.
 
-    # Policy environment is a bare directory tree (no `__init__.py` chain
-    # reaching `sys.path`). Objects defined in modules loaded this way carry
-    # a non-importable `__module__` and cannot be cloudpickled by reference.
-    name = path.relative_to(root).with_suffix("").as_posix().replace("/", ".")
+    When ``prefer_canonical_name`` is true and the file lives under an
+    ``__init__.py`` chain reaching ``sys.path``, the module is registered under
+    the canonical dotted import name (e.g.
+    ``mettsim.middle_earth.payroll_tax.amount``). Objects defined in the module
+    then carry an importable ``__module__`` — required for
+    ``cloudpickle.dumps`` to round-trip via pickle-by-reference. Used for user
+    policy modules.
+
+    When ``prefer_canonical_name`` is false (default) or no canonical name
+    exists, the module is registered under the root-relative short name. Used
+    for ttsim's own interface DAG elements: the short name keeps the loader
+    decoupled from ttsim's import-time class identities, so re-loaded callable
+    instances stay ``isinstance``-compatible with the normally-imported types.
+    """
+    canonical_name = (
+        _find_canonical_module_name(path) if prefer_canonical_name else None
+    )
+    name = (
+        canonical_name
+        if canonical_name is not None
+        else path.relative_to(root).with_suffix("").as_posix().replace("/", ".")
+    )
     spec = importlib.util.spec_from_file_location(name=name, location=path)
     _msg = f"Could not load module spec for {path},  {root}"
     if spec is None:

--- a/src/ttsim/interface_dag_elements/processed_data.py
+++ b/src/ttsim/interface_dag_elements/processed_data.py
@@ -1,16 +1,33 @@
 from __future__ import annotations
 
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 import dags.tree as dt
+import numpy as np
+import pandas as pd
+from jaxtyping import Shaped
 
 from ttsim.interface_dag_elements.interface_node_objects import interface_function
 from ttsim.tt.column_objects_param_function import reorder_ids
+from ttsim.typing import Array, BoolColumn, FloatColumn, IntColumn
 
 if TYPE_CHECKING:
-    from types import ModuleType
+    from ttsim.typing import FlatData, QNameData
 
-    from ttsim.typing import FlatData, IntColumn, QNameData
+
+def _coerce_uint_to_int64(
+    arr: Shaped[Array | np.ndarray, " n_obs"] | pd.Series,
+    xnp: ModuleType,
+) -> IntColumn | FloatColumn | BoolColumn:
+    """Coerce unsigned-integer arrays to ``int64``; pass others through unchanged.
+
+    Without this, signed arithmetic on uint columns (e.g. ``gross - deductions``)
+    silently underflows into a huge positive value.
+    """
+    if pd.api.types.is_unsigned_integer_dtype(arr):
+        return xnp.asarray(arr, dtype=xnp.int64)
+    return xnp.asarray(arr)
 
 
 @interface_function(in_top_level_namespace=True)
@@ -25,7 +42,7 @@ def processed_data(
     The transformations will be undone when going from raw results to results.
     """
 
-    orig_p_ids = xnp.asarray(input_data__flat[("p_id",)])
+    orig_p_ids = _coerce_uint_to_int64(input_data__flat[("p_id",)], xnp)
     sorted_orig_p_ids = orig_p_ids[input_data__sort_indices]
     internal_p_ids = xnp.arange(len(orig_p_ids))
 
@@ -39,7 +56,7 @@ def processed_data(
             processed_input_data[qname] = data
             continue
 
-        sorted_data = xnp.asarray(data[input_data__sort_indices])
+        sorted_data = _coerce_uint_to_int64(data[input_data__sort_indices], xnp)
 
         if path[-1].endswith("_id"):
             processed_input_data[qname] = reorder_ids(ids=sorted_data, xnp=xnp)

--- a/src/ttsim/interface_dag_elements/processed_data.py
+++ b/src/ttsim/interface_dag_elements/processed_data.py
@@ -10,23 +10,54 @@ from jaxtyping import Shaped
 
 from ttsim.interface_dag_elements.interface_node_objects import interface_function
 from ttsim.tt.column_objects_param_function import reorder_ids
-from ttsim.typing import Array, BoolColumn, FloatColumn, IntColumn
+from ttsim.typing import Array, IntColumn
 
 if TYPE_CHECKING:
     from ttsim.typing import FlatData, QNameData
 
 
-def _coerce_uint_to_int64(
+def _canonicalize_input_dtype(
     arr: Shaped[Array | np.ndarray, " n_obs"] | pd.Series,
     xnp: ModuleType,
-) -> IntColumn | FloatColumn | BoolColumn:
-    """Coerce unsigned-integer arrays to ``int64``; pass others through unchanged.
+) -> Shaped[Array | np.ndarray, " n_obs"]:
+    """Canonicalize a column to a backend-native dtype the TT DAG can operate on.
 
-    Without this, signed arithmetic on uint columns (e.g. ``gross - deductions``)
-    silently underflows into a huge positive value.
+    Handles three families of pandas extension dtypes uniformly with plain
+    numpy / JAX arrays:
+
+    - **Float** (numpy float, pandas-nullable ``Float64``, ``float[pyarrow]``)
+      → ``float64`` with ``pd.NA`` mapped to ``NaN``.
+    - **Unsigned integer** (numpy uint, ``UInt*``, ``uint*[pyarrow]``) →
+      ``int64`` so signed arithmetic on them does not underflow into a huge
+      positive value.
+    - **Signed integer / Bool** (nullable / pyarrow variants) → numpy
+      ``int64`` / ``bool_`` when the column has no missing values; left as
+      an object-dtype array with ``pd.NA`` in place otherwise, for the
+      ``input_data_has_int_or_bool_missing_values`` fail-if to surface.
     """
+    if isinstance(arr, pd.Series):
+        return _canonicalize_series(arr, xnp)
     if pd.api.types.is_unsigned_integer_dtype(arr):
         return xnp.asarray(arr, dtype=xnp.int64)
+    return xnp.asarray(arr)
+
+
+def _canonicalize_series(
+    arr: pd.Series,
+    xnp: ModuleType,
+) -> Shaped[Array | np.ndarray, " n_obs"]:
+    """Series-only branch of `_canonicalize_input_dtype`."""
+    dtype = arr.dtype
+    if pd.api.types.is_float_dtype(dtype):
+        return xnp.asarray(arr.astype("float64"))
+    if pd.api.types.is_bool_dtype(dtype):
+        if arr.isna().any():
+            return arr.to_numpy(dtype=object)
+        return xnp.asarray(arr.astype("bool"))
+    if pd.api.types.is_integer_dtype(dtype):
+        if arr.isna().any():
+            return arr.to_numpy(dtype=object)
+        return xnp.asarray(arr.astype("int64"))
     return xnp.asarray(arr)
 
 
@@ -42,7 +73,7 @@ def processed_data(
     The transformations will be undone when going from raw results to results.
     """
 
-    orig_p_ids = _coerce_uint_to_int64(input_data__flat[("p_id",)], xnp)
+    orig_p_ids = _canonicalize_input_dtype(input_data__flat[("p_id",)], xnp)
     sorted_orig_p_ids = orig_p_ids[input_data__sort_indices]
     internal_p_ids = xnp.arange(len(orig_p_ids))
 
@@ -56,7 +87,7 @@ def processed_data(
             processed_input_data[qname] = data
             continue
 
-        sorted_data = _coerce_uint_to_int64(data[input_data__sort_indices], xnp)
+        sorted_data = _canonicalize_input_dtype(data[input_data__sort_indices], xnp)
 
         if path[-1].endswith("_id"):
             processed_input_data[qname] = reorder_ids(ids=sorted_data, xnp=xnp)

--- a/src/ttsim/interface_dag_elements/raw_results.py
+++ b/src/ttsim/interface_dag_elements/raw_results.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from types import ModuleType
 
 import dags.tree as dt
 
@@ -12,6 +13,7 @@ from ttsim.interface_dag_elements.interface_node_objects import interface_functi
 # stringified annotations via module globals.
 from ttsim.typing import (
     FlatData,
+    IntColumn,
     OrderedQNames,
     QNameData,
     QNameResults,
@@ -25,14 +27,51 @@ def columns(
     labels__root_nodes: UnorderedQNames,
     processed_data: QNameData,
     tt_function: Callable[[QNameData], QNameData],
+    input_data__flat: FlatData,
+    input_data__sort_indices: IntColumn,
+    xnp: ModuleType,
 ) -> QNameData:
     """The raw results of the TT function that have been requested as targets.
 
-    Arrays are sorted according to the internal sort order.
-
+    Arrays are sorted according to the internal sort order. Endogenously-
+    computed `p_id_*` columns hold internal indices; those are reverse-
+    translated to user-space `p_id` values here so consumers downstream see
+    the original identifiers (with `-1` preserved as the no-link sentinel).
     """
-    return tt_function(
+    raw = tt_function(
         {k: v for k, v in processed_data.items() if k in labels__root_nodes},
+    )
+    sorted_orig_p_ids = xnp.asarray(input_data__flat[("p_id",)])[
+        input_data__sort_indices
+    ]
+    return {
+        qname: _translate_internal_to_orig_p_ids(value, sorted_orig_p_ids, xnp)
+        if _is_endogenous_p_id_pointer(qname)
+        else value
+        for qname, value in raw.items()
+    }
+
+
+def _is_endogenous_p_id_pointer(qname: str) -> bool:
+    leaf = dt.tree_path_from_qname(qname)[-1]
+    return leaf.startswith("p_id_")
+
+
+def _translate_internal_to_orig_p_ids(
+    col: IntColumn,
+    sorted_orig_p_ids: IntColumn,
+    xnp: ModuleType,
+) -> IntColumn:
+    """Map internal indices back to user-space `p_id`s, preserving the -1 sentinel.
+
+    `xnp.maximum(col, 0)` keeps the gathered index in-bounds on JAX (which
+    cannot dead-branch on the `xnp.where` predicate); the -1 result is then
+    re-injected by the outer `xnp.where`.
+    """
+    return xnp.where(
+        col == -1,
+        -1,
+        sorted_orig_p_ids[xnp.maximum(col, 0)],
     )
 
 

--- a/src/ttsim/interface_dag_elements/results.py
+++ b/src/ttsim/interface_dag_elements/results.py
@@ -9,6 +9,7 @@ import pandas as pd
 from ttsim.interface_dag_elements.data_converters import (
     nested_data_to_df_with_mapped_columns,
     nested_data_to_df_with_nested_columns,
+    nested_data_to_df_with_qname_columns,
 )
 from ttsim.interface_dag_elements.interface_node_objects import interface_function
 
@@ -70,6 +71,24 @@ def df_with_nested_columns(
 ) -> pd.DataFrame:
     """The results DataFrame with nested column names corresponding to tree paths."""
     return nested_data_to_df_with_nested_columns(
+        nested_data_to_convert=tree,
+        index=pd.Index(input_data__flat[("p_id",)], name="p_id"),
+    )
+
+
+@interface_function()
+def df_with_qname_columns(
+    tree: NestedResults,
+    input_data__flat: FlatData,
+) -> pd.DataFrame:
+    """Results DataFrame with qname-string columns (one flat string per column).
+
+    The column index stays flat regardless of nesting depth, so adding or
+    removing targets does not change the column-index shape — unlike
+    ``df_with_nested_columns``, where the MultiIndex depth tracks the deepest
+    target.
+    """
+    return nested_data_to_df_with_qname_columns(
         nested_data_to_convert=tree,
         index=pd.Index(input_data__flat[("p_id",)], name="p_id"),
     )

--- a/src/ttsim/interface_dag_elements/specialized_environment.py
+++ b/src/ttsim/interface_dag_elements/specialized_environment.py
@@ -183,6 +183,16 @@ def with_processed_params_and_scalars(
             # Leave nodes not in the data what they are.
             all_nodes[n] = f
 
+    # Pick up scalars in `processed_data` whose qname is not a node in
+    # `without_tree_logic_and_with_derived_functions` — e.g. the yearly source
+    # `x_y` for a `policy_input` `x_m`, where the time-conversion machinery
+    # produces conversions *away* from `x_y` (`x_m`, `x_w`, `x_d`) but never
+    # creates `x_y` itself as a self-node. Without this, the scalar drops out of
+    # the env and the derived consumer's argument remains an unbound root node.
+    for qname, value in processed_data.items():
+        if qname not in all_nodes and isinstance(value, int | float | bool):
+            all_nodes[qname] = value
+
     must_set_evaluation_date = (
         # Never need to do anything if the evaluation date is set in the data.
         "evaluation_year" not in processed_data

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -49,6 +49,9 @@ class FailIf(MainTargetABC):
     )
     input_data_is_invalid: str = "fail_if__input_data_is_invalid"
     input_data_tree_is_invalid: str = "fail_if__input_data_tree_is_invalid"
+    input_data_uint64_values_overflow_int64: str = (
+        "fail_if__input_data_uint64_values_overflow_int64"
+    )
     input_df_has_bool_or_numeric_column_names: str = (
         "fail_if__input_df_has_bool_or_numeric_column_names"
     )

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -71,7 +71,6 @@ class FailIf(MainTargetABC):
     paths_are_missing_in_targets_tree_mapper: str = (
         "fail_if__paths_are_missing_in_targets_tree_mapper"
     )
-    endogenous_p_id_among_targets: str = "fail_if__endogenous_p_id_among_targets"
     tt_root_nodes_are_missing: str = "fail_if__tt_root_nodes_are_missing"
     targets_are_not_in_specialized_environment_or_data: str = (
         "fail_if__targets_are_not_in_specialized_environment_or_data"

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -89,6 +89,7 @@ class FailIf(MainTargetABC):
 class Results(MainTargetABC):
     df_with_mapper: str = "results__df_with_mapper"
     df_with_nested_columns: str = "results__df_with_nested_columns"
+    df_with_qname_columns: str = "results__df_with_qname_columns"
     tree: str = "results__tree"
 
 

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -47,6 +47,9 @@ class FailIf(MainTargetABC):
     group_variables_are_not_constant_within_groups: str = (
         "fail_if__group_variables_are_not_constant_within_groups"
     )
+    input_data_has_int_or_bool_missing_values: str = (
+        "fail_if__input_data_has_int_or_bool_missing_values"
+    )
     input_data_is_invalid: str = "fail_if__input_data_is_invalid"
     input_data_tree_is_invalid: str = "fail_if__input_data_tree_is_invalid"
     input_data_uint64_values_overflow_int64: str = (

--- a/src/ttsim/typing.py
+++ b/src/ttsim/typing.py
@@ -1,16 +1,51 @@
 """Type aliases used across ttsim.
 
+Bottom line: JAX must remain an *optional* runtime dependency of ttsim.
+That constraint dictates how the column-type aliases below are defined
+and how every module that references them must import them.
+
+The load-bearing mechanism is in `jaxtyping`. `Bool`, `Float`, `Int`, and
+`Shaped` can be imported at runtime without pulling JAX in. `jaxtyping.Array`
+cannot — its top-level `__getattr__` hook resolves `Array` by importing
+`jax`, so any module that touches `Array` at runtime implicitly imports
+JAX. Column aliases like `IntColumn = Int[Array | np.ndarray, " n_obs"]`
+contain `Array` and would trigger that import if evaluated at runtime.
+(The `try / except ImportError` block below softens this: in JAX-free
+envs `Array` falls back to `np.ndarray`, so the aliases stay defined.
+But the alias *evaluations* still happen at module import time only
+because the wider codebase opts into PEP 563 string annotations — see
+the rules below.)
+
 The aliases split into two groups:
 
-1. Runtime-resolvable aliases at module scope. These can be referenced from
-   `@beartype`-decorated signatures (column-type, scalar-type, simple-name
-   aliases, and the "user-boundary" `User*` aliases that accept the wider
-   set of inputs users may pass).
-2. Aliases that reference forward types (`ColumnObject`, `ParamFunction`,
-   `ParamObject`, …) and would create import cycles at runtime. These stay
-   inside the `TYPE_CHECKING` block and must be referenced from runtime
-   annotations only via the `__future__.annotations` string form (which
-   ttsim's defining modules opt into).
+1. **Runtime-resolvable aliases at module scope.** Column-type, scalar-type,
+   simple-name aliases, and the "user-boundary" `User*` aliases. These are
+   evaluated when this module is imported, so they must not pull JAX in.
+   Safe because `Array | np.ndarray` reaches the `np.ndarray` branch in
+   JAX-free envs.
+2. **Forward-reference aliases inside `TYPE_CHECKING`.** Anything mentioning
+   `ColumnObject`, `ParamFunction`, `ParamObject`, etc. — defined here
+   would create import cycles. Referenced from runtime annotations only
+   via PEP 563 string evaluation.
+
+Do's and don'ts for files that reference the aliases below:
+
+- DO keep `from __future__ import annotations` at the top of any file
+  that uses column-type or `User*` aliases. PEP 563 makes annotations
+  string-only at runtime, so beartype resolves them lazily without
+  forcing a JAX import.
+- DO NOT hoist `jaxtyping.Array` out of `TYPE_CHECKING` in any other
+  module. The fallback in this file is the only place that's allowed to
+  touch `Array` at module scope.
+- DO NOT evaluate column-alias expressions at runtime (e.g., do not
+  `isinstance(x, IntColumn)`). The string form via PEP 563 is fine for
+  signatures; beartype handles it.
+- DO leave the column registry (`ttsim.tt.column_objects_param_function`)
+  returning string-form annotations. Eagerly resolving them would
+  re-introduce the JAX import.
+
+See `.ai-instructions/modules/jax.md` for the cross-project version of
+this rule.
 """
 
 from __future__ import annotations

--- a/src/ttsim/typing.py
+++ b/src/ttsim/typing.py
@@ -194,10 +194,13 @@ else:
     UserNestedData = Mapping[str, object]
 # `UserNestedData`: user-boundary tree mapping TTSIM paths to columns, Series,
 # or sequences.
-# `UserFlatData`: user-boundary flat mapping of tree paths to the same.
+# `UserFlatData`: user-boundary flat mapping of tree paths to columns or
+# scalars (the latter for users opting into the partial-application path).
 # `UserQNameData`: user-boundary mapping of qualified names to the same.
-UserFlatData: TypeAlias = Mapping[tuple[str, ...], UserColumn]
-UserQNameData: TypeAlias = Mapping[str, UserColumn]
+UserFlatData: TypeAlias = Mapping[
+    tuple[str, ...], UserColumn | UserScalarFloat | UserScalarBool
+]
+UserQNameData: TypeAlias = Mapping[str, UserColumn | UserScalarFloat | UserScalarBool]
 
 # `FlatTTTargets`: a flattened target tree, mapping each qualified name to its
 # leaf value (`None` to compute the target, a string to rename it). Produced by

--- a/src/ttsim/typing.py
+++ b/src/ttsim/typing.py
@@ -1,6 +1,6 @@
 """Type aliases used across ttsim.
 
-Bottom line: JAX must remain an *optional* runtime dependency of ttsim.
+Bottom line: JAX shall remain an *optional* runtime dependency of ttsim.
 That constraint dictates how the column-type aliases below are defined
 and how every module that references them must import them.
 

--- a/tests/interface_dag_elements/test_data_converters.py
+++ b/tests/interface_dag_elements/test_data_converters.py
@@ -16,6 +16,7 @@ from ttsim.interface_dag_elements.data_converters import (
     df_with_mapped_columns_to_flat_data,
     df_with_nested_columns_to_flat_data,
     nested_data_to_df_with_mapped_columns,
+    nested_data_to_df_with_qname_columns,
 )
 from ttsim.tt import (
     ScalarParam,
@@ -243,6 +244,23 @@ def test_nested_data_to_dataframe(
         check_dtype=False,
         check_index_type=False,
     )
+
+
+def test_nested_data_to_df_with_qname_columns_flattens_paths_with_double_underscore():
+    nested = {
+        "a": numpy.array([10, 20, 30]),
+        "b": {
+            "c": numpy.array([1, 2, 3]),
+            "d": {"e": numpy.array([0.1, 0.2, 0.3])},
+        },
+    }
+    index = pd.Index([100, 200, 300], name="p_id")
+    result = nested_data_to_df_with_qname_columns(nested, index=index)
+    assert list(result.columns) == ["a", "b__c", "b__d__e"]
+    assert_array_equal(result["a"].to_numpy(), [10, 20, 30])
+    assert_array_equal(result["b__c"].to_numpy(), [1, 2, 3])
+    assert_array_equal(result["b__d__e"].to_numpy(), [0.1, 0.2, 0.3])
+    pd.testing.assert_index_equal(result.index, index)
 
 
 @pytest.mark.parametrize(

--- a/tests/interface_dag_elements/test_endogenous_p_id_targets.py
+++ b/tests/interface_dag_elements/test_endogenous_p_id_targets.py
@@ -1,0 +1,218 @@
+"""Tests for endogenously-computed `p_id_*` columns as targets.
+
+When a policy function computes a `p_id_*` column (e.g. `p_id_recipient`),
+its output values are *internal* indices into the sorted-by-p_id array. The
+interface DAG must reverse-translate those internal indices back to
+user-space `p_id` values before returning results.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from ttsim import InputData, MainTarget, TTTargets, main
+from ttsim.tt import FKType, ScalarParam, policy_function, policy_input
+
+if TYPE_CHECKING:
+    from types import ModuleType
+    from typing import Literal
+
+
+_DATE = datetime.date(2025, 1, 1)
+
+
+def _policy_year_month_day() -> dict[str, ScalarParam]:
+    return {
+        "policy_year": ScalarParam(value=_DATE.year, start_date=_DATE, end_date=_DATE),
+        "policy_month": ScalarParam(
+            value=_DATE.month, start_date=_DATE, end_date=_DATE
+        ),
+        "policy_day": ScalarParam(value=_DATE.day, start_date=_DATE, end_date=_DATE),
+    }
+
+
+def _identity(p_id: int) -> int:
+    return p_id
+
+
+def _recipient_or_minus_one(p_id: int, is_recipient: bool) -> int:
+    return p_id if is_recipient else -1
+
+
+def test_endogenous_p_id_target_returns_user_space_p_ids(
+    xnp: ModuleType, backend: Literal["numpy", "jax"]
+):
+    """`p_id_*` computed by the policy is reverse-translated to user-space p_ids.
+
+    `p_id_recipient = p_id` should yield each row's own user-space `p_id` —
+    not the internal sorted index — even when the input `p_id` order is
+    non-monotonic.
+    """
+    p_id_recipient = policy_function(
+        start_date=_DATE,
+        end_date=_DATE,
+        leaf_name="p_id_recipient",
+    )(_identity)
+
+    result = main(
+        main_target=MainTarget.results.df_with_nested_columns,
+        policy_environment={
+            "p_id_recipient": p_id_recipient,
+            **_policy_year_month_day(),
+        },
+        tt_targets=TTTargets.tree({"p_id_recipient": None}),
+        input_data=InputData.tree(tree={"p_id": xnp.array([20, 10, 30])}),
+        backend=backend,
+    )
+
+    expected = pd.DataFrame(
+        {("p_id_recipient",): [20, 10, 30]},
+        index=pd.Index([20, 10, 30], name="p_id"),
+    )
+    pd.testing.assert_frame_equal(
+        expected, result, check_dtype=False, check_index_type=False
+    )
+
+
+def test_endogenous_p_id_target_preserves_minus_one_sentinel(
+    xnp: ModuleType, backend: Literal["numpy", "jax"]
+):
+    """A `-1` (no-link) sentinel from the policy survives the reverse-translation
+    rather than being mapped to whichever user-space `p_id` happens to sit at
+    sorted index 0.
+    """
+    p_id_recipient = policy_function(
+        start_date=_DATE,
+        end_date=_DATE,
+        leaf_name="p_id_recipient",
+        vectorization_strategy="vectorize",
+    )(_recipient_or_minus_one)
+
+    @policy_input()
+    def is_recipient() -> bool:
+        pass
+
+    result = main(
+        main_target=MainTarget.results.df_with_nested_columns,
+        policy_environment={
+            "p_id_recipient": p_id_recipient,
+            "is_recipient": is_recipient,
+            **_policy_year_month_day(),
+        },
+        tt_targets=TTTargets.tree({"p_id_recipient": None}),
+        input_data=InputData.tree(
+            tree={
+                "p_id": xnp.array([20, 10, 30]),
+                "is_recipient": xnp.array([True, False, True]),
+            }
+        ),
+        backend=backend,
+    )
+
+    expected = pd.DataFrame(
+        {("p_id_recipient",): [20, -1, 30]},
+        index=pd.Index([20, 10, 30], name="p_id"),
+    )
+    pd.testing.assert_frame_equal(
+        expected, result, check_dtype=False, check_index_type=False
+    )
+
+
+def test_exogenous_p_id_pointer_as_input_target_is_unchanged(
+    xnp: ModuleType, backend: Literal["numpy", "jax"]
+):
+    """An exogenous `p_id_parent_1` column requested as a target is delivered
+    verbatim — values stay in user-space `p_id`, including the `-1` sentinel,
+    because it flows through `raw_results.from_input_data` rather than the
+    computed-column path.
+    """
+
+    @policy_input(foreign_key_type=FKType.MAY_POINT_TO_SELF)
+    def p_id_parent_1() -> int:
+        pass
+
+    result = main(
+        main_target=MainTarget.results.df_with_nested_columns,
+        policy_environment={
+            "p_id_parent_1": p_id_parent_1,
+            **_policy_year_month_day(),
+        },
+        tt_targets=TTTargets.tree({"p_id_parent_1": None}),
+        input_data=InputData.tree(
+            tree={
+                "p_id": xnp.array([20, 10, 30]),
+                "p_id_parent_1": xnp.array([30, -1, -1]),
+            }
+        ),
+        backend=backend,
+    )
+
+    expected = pd.DataFrame(
+        {("p_id_parent_1",): [30, -1, -1]},
+        index=pd.Index([20, 10, 30], name="p_id"),
+    )
+    pd.testing.assert_frame_equal(
+        expected, result, check_dtype=False, check_index_type=False
+    )
+
+
+def test_endogenous_p_id_target_mixed_with_regular_column(
+    xnp: ModuleType, backend: Literal["numpy", "jax"]
+):
+    """Endogenous `p_id_*` and a regular numeric column requested in one call:
+    the former is reverse-translated, the latter passes through untouched.
+    """
+    p_id_recipient = policy_function(
+        start_date=_DATE,
+        end_date=_DATE,
+        leaf_name="p_id_recipient",
+    )(_identity)
+
+    @policy_function(
+        start_date=_DATE,
+        end_date=_DATE,
+        leaf_name="doubled",
+        vectorization_strategy="vectorize",
+    )
+    def doubled(income_m: float) -> float:
+        return income_m * 2.0
+
+    @policy_input()
+    def income_m() -> float:
+        pass
+
+    result = main(
+        main_target=MainTarget.results.df_with_nested_columns,
+        policy_environment={
+            "p_id_recipient": p_id_recipient,
+            "doubled": doubled,
+            "income_m": income_m,
+            **_policy_year_month_day(),
+        },
+        tt_targets=TTTargets.tree({"p_id_recipient": None, "doubled": None}),
+        input_data=InputData.tree(
+            tree={
+                "p_id": xnp.array([20, 10, 30]),
+                "income_m": xnp.array([100.0, 200.0, 300.0]),
+            }
+        ),
+        backend=backend,
+    )
+
+    expected = pd.DataFrame(
+        {
+            ("p_id_recipient",): [20, 10, 30],
+            ("doubled",): [200.0, 400.0, 600.0],
+        },
+        index=pd.Index([20, 10, 30], name="p_id"),
+    )
+    pd.testing.assert_frame_equal(
+        expected,
+        result,
+        check_dtype=False,
+        check_index_type=False,
+        check_like=True,
+    )

--- a/tests/interface_dag_elements/test_failures.py
+++ b/tests/interface_dag_elements/test_failures.py
@@ -25,6 +25,7 @@ from ttsim.interface_dag_elements.fail_if import (
     group_ids_are_outside_top_level_namespace,
     group_variables_are_not_constant_within_groups,
     input_data_is_invalid,
+    input_data_uint64_values_overflow_int64,
     input_df_has_bool_or_numeric_column_names,
     input_df_mapper_columns_missing_in_df,
     input_df_mapper_has_incorrect_format,
@@ -930,6 +931,34 @@ def test_fail_if_p_id_does_not_exist(xnp):
         match=r"The input data must contain the `p_id` column.",
     ):
         input_data_is_invalid(data, xnp)
+
+
+def test_fail_if_uint64_input_overflows_int64_raises():
+    data = {
+        ("p_id",): numpy.array([1, 2], dtype=numpy.int64),
+        ("wealth",): numpy.array([0, 2**63], dtype=numpy.uint64),
+    }
+    with pytest.raises(
+        ValueError,
+        match=r"(?s)uint64.*wealth",
+    ):
+        input_data_uint64_values_overflow_int64(data)
+
+
+def test_fail_if_uint64_input_overflows_int64_passes_within_range():
+    data = {
+        ("p_id",): numpy.array([1, 2], dtype=numpy.int64),
+        ("wealth",): numpy.array([0, 2**63 - 1], dtype=numpy.uint64),
+    }
+    input_data_uint64_values_overflow_int64(data)
+
+
+def test_fail_if_uint64_input_overflows_int64_ignores_non_uint64_columns():
+    data = {
+        ("p_id",): numpy.array([1, 2], dtype=numpy.int64),
+        ("wage",): numpy.array([0, 100], dtype=numpy.uint32),
+    }
+    input_data_uint64_values_overflow_int64(data)
 
 
 def test_fail_if_p_id_is_missing_via_main(backend):

--- a/tests/interface_dag_elements/test_failures.py
+++ b/tests/interface_dag_elements/test_failures.py
@@ -20,7 +20,6 @@ from ttsim.interface_dag_elements.fail_if import (
     _ParamWithActivePeriod,
     active_periods_overlap,
     assert_valid_ttsim_pytree,
-    endogenous_p_id_among_targets,
     foreign_keys_are_invalid_in_data,
     group_ids_are_outside_top_level_namespace,
     group_variables_are_not_constant_within_groups,
@@ -42,7 +41,6 @@ from ttsim.tt import (
     DictParam,
     PiecewisePolynomialParam,
     PiecewisePolynomialParamValue,
-    ScalarParam,
     group_creation_function,
     param_function,
     policy_function,
@@ -1937,64 +1935,6 @@ def test_param_function_depends_on_column_objects_via_main(
                 "invalid_param_function": invalid_param_function,
                 "some_policy_function": some_policy_function,
             },
-        )
-
-
-def test_endogenous_p_id_among_targets_direct():
-    """Test that p_id_* columns are not allowed as targets."""
-    targets_with_p_id = ["p_id_child", "valid_target", "p_id_parent"]
-    pattern = re.compile(
-        r"p_id_\* columns were requested as targets, but these contain internal "
-        r"""ID mappings.+p_id_child',\)",\n    "\('p_id_parent.""",
-        re.DOTALL,
-    )
-    with pytest.raises(ValueError, match=pattern):
-        endogenous_p_id_among_targets(labels__column_targets=targets_with_p_id)
-
-
-def test_endogenous_p_id_among_targets_passes_with_valid_targets():
-    """Test that validation passes when no p_id_* columns are in targets."""
-    valid_targets = ["income", "tax", "benefit"]
-
-    # Should not raise any exception
-    endogenous_p_id_among_targets(labels__column_targets=valid_targets)
-
-
-def test_endogenous_p_id_among_targets_via_main(xnp):
-    """Test that p_id_* columns are not allowed as targets via main."""
-    date = datetime.date(2023, 1, 1)
-    with pytest.raises(
-        ValueError,
-        match=(
-            r"p_id_\* columns were requested as targets, but these contain internal ID"
-        ),
-    ):
-        main(
-            main_target=MainTarget.results.df_with_nested_columns,
-            policy_environment={
-                "p_id_person": policy_function(
-                    start_date=date,
-                    end_date=date,
-                    leaf_name="p_id_person",
-                )(identity),
-                "policy_year": ScalarParam(
-                    value=date.year,
-                    start_date=date,
-                    end_date=date,
-                ),
-                "policy_month": ScalarParam(
-                    value=date.month,
-                    start_date=date,
-                    end_date=date,
-                ),
-                "policy_day": ScalarParam(
-                    value=date.day,
-                    start_date=date,
-                    end_date=date,
-                ),
-            },
-            tt_targets=TTTargets.tree({"p_id": None, "p_id_person": None}),
-            input_data=InputData.tree(tree={"p_id": xnp.array([0, 1, 2])}),
         )
 
 

--- a/tests/interface_dag_elements/test_failures.py
+++ b/tests/interface_dag_elements/test_failures.py
@@ -1998,9 +1998,14 @@ def test_endogenous_p_id_among_targets_via_main(xnp):
         )
 
 
-def test_pass_scalars_for_natively_vectorized_functions(
+def test_scalar_inputs_in_tree_are_broadcast_to_p_id_length(
     xnp: ModuleType, backend: Literal["numpy", "jax"]
 ):
+    """Scalar leaves in an `InputData.tree` are broadcast to length-``n_obs``,
+    so they feed natively-vectorized consumers (aggregations, group creation)
+    without error. Users who want partial-application instead must opt in via
+    ``InputData.flat``.
+    """
     input_data_tree = {
         "age": 30,
         "kin_id": 0,
@@ -2026,34 +2031,20 @@ def test_pass_scalars_for_natively_vectorized_functions(
         },
         "wealth": 10000,
     }
-    with pytest.raises(
-        ValueError,
-        match="The following root nodes must be passed as arrays or series, but were "
-        "passed as scalars in the input data:\n\n"
-        "    - \\('age',\\)\n"
-        "    - \\('kin_id',\\)\n"
-        "    - \\('p_id_parent_1',\\)\n"
-        "    - \\('p_id_parent_2',\\)\n"
-        "    - \\('p_id_spouse',\\)\n"
-        "    - \\('parent_is_noble',\\)\n"
-        "    - \\('payroll_tax', 'child_tax_credit', 'p_id_recipient'\\)\n"
-        "    - \\('wealth',\\)\n\n"
-        "To fix this, pass them as arrays \\(numpy, jax\\.numpy\\) or pd\\.Series matching "
-        "the length of `p_id`\\.",
-    ):
-        main(
-            main_target=MainTarget.results.df_with_nested_columns,
-            policy_date_str="2025-01-01",
-            input_data=InputData.tree(input_data_tree),
-            tt_targets=TTTargets.tree(
-                {
-                    "wealth_tax": {"amount_y": None},
-                    "property_tax": {"amount_y": None},
-                    "payroll_tax": {"amount_y": None},
-                    "orc_hunting_bounty": {"amount": None},
-                    "housing_benefits": {"amount_y_fam": None},
-                }
-            ),
-            orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
-            backend=backend,
-        )
+    result = main(
+        main_target=MainTarget.results.df_with_nested_columns,
+        policy_date_str="2025-01-01",
+        input_data=InputData.tree(input_data_tree),
+        tt_targets=TTTargets.tree(
+            {
+                "wealth_tax": {"amount_y": None},
+                "property_tax": {"amount_y": None},
+                "payroll_tax": {"amount_y": None},
+                "orc_hunting_bounty": {"amount": None},
+                "housing_benefits": {"amount_y_fam": None},
+            }
+        ),
+        orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        backend=backend,
+    )
+    assert len(result) == 3

--- a/tests/interface_dag_elements/test_input_data.py
+++ b/tests/interface_dag_elements/test_input_data.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ttsim import InputData, TTTargets, main
+
+
+def test_scalar_leaf_in_tree_is_broadcast_to_p_id_length():
+    flat = main(
+        main_target="input_data__flat",
+        input_data=InputData.tree(
+            {
+                "p_id": np.array([0, 1, 2]),
+                "x": 5.0,
+            }
+        ),
+        tt_targets=TTTargets.tree({"x": None}),
+        backend="numpy",
+    )
+    x = flat[("x",)]
+    assert len(x) == 3
+    assert np.all(x == 5.0)
+
+
+@pytest.mark.parametrize(
+    "input_data_factory",
+    [
+        lambda: InputData.tree({"p_id": np.array([0, 1, 2]), "x": 5.0}),
+        lambda: InputData.df_and_mapper(
+            df=pd.DataFrame({"pid_col": [0, 1, 2]}),
+            mapper={"p_id": "pid_col", "x": 5.0},
+        ),
+        lambda: InputData.df_with_nested_columns(
+            pd.DataFrame({("p_id",): [0, 1, 2], ("x",): [5.0, 5.0, 5.0]})
+        ),
+    ],
+    ids=["tree", "df_and_mapper", "df_with_nested_columns"],
+)
+def test_scalar_input_produces_same_flat_array_across_input_paths(
+    input_data_factory,
+):
+    flat = main(
+        main_target="input_data__flat",
+        input_data=input_data_factory(),
+        tt_targets=TTTargets.tree({"x": None}),
+        backend="numpy",
+    )
+    x = np.asarray(flat[("x",)])
+    np.testing.assert_array_equal(x, [5.0, 5.0, 5.0])
+
+
+def test_scalar_in_input_data_flat_is_preserved_as_scalar():
+    """`InputData.flat` is the advanced opt-out: it bypasses broadcasting
+    so users can rely on scalar partialling for derived consumers."""
+    processed = main(
+        main_target="processed_data",
+        input_data=InputData.flat(
+            {
+                ("p_id",): np.array([0, 1, 2]),
+                ("x",): 5.0,
+            }
+        ),
+        tt_targets=TTTargets.tree({"x": None}),
+        backend="numpy",
+    )
+    assert processed["x"] == 5.0

--- a/tests/interface_dag_elements/test_nullable_dtypes.py
+++ b/tests/interface_dag_elements/test_nullable_dtypes.py
@@ -1,0 +1,220 @@
+"""Canonicalization of pandas-nullable and pyarrow input dtypes.
+
+ttsim accepts inputs in many dtypes (numpy, pandas-nullable, pyarrow-backed)
+and canonicalizes them to plain numpy arrays the TT DAG can operate on:
+
+- Float-nullable / float-pyarrow → ``float64`` with ``pd.NA`` mapped to ``NaN``.
+- Int/UInt-nullable / int-pyarrow / uint-pyarrow without NA → ``int64``.
+- Bool-nullable / bool-pyarrow without NA → numpy ``bool_``.
+- Int/UInt/Bool columns with NA → fail with a precise per-column error so
+  the user can decide whether to fill the missing values or convert the
+  column to a float type that supports NaN.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ttsim import InputData, MainTarget, TTTargets, main
+from ttsim.interface_dag_elements.processed_data import (
+    _canonicalize_input_dtype,
+)
+
+if TYPE_CHECKING:
+    from types import ModuleType
+    from typing import Literal
+
+
+_DATE = datetime.date(2025, 1, 1)
+
+
+def _pyarrow_or_skip(dtype: str) -> str:
+    pytest.importorskip("pyarrow")
+    return dtype
+
+
+def test_float_nullable_input_with_na_round_trips_as_nan(
+    backend: Literal["numpy", "jax"],
+):
+    """A `Float64`-nullable input column with a `pd.NA` survives as `NaN`
+    when requested back as an input-data target.
+    """
+    df = pd.DataFrame(
+        {
+            ("p_id",): [1, 2, 3],
+            ("wage_m",): pd.array([100.0, pd.NA, 300.0], dtype="Float64"),
+        },
+    )
+    result = main(
+        main_target=MainTarget.results.df_with_nested_columns,
+        input_data=InputData.df_with_nested_columns(df),
+        tt_targets=TTTargets.tree({"wage_m": None}),
+        policy_environment={},
+        evaluation_date=datetime.date(2025, 1, 1),
+        backend=backend,
+    )
+
+    expected = pd.DataFrame(
+        {("wage_m",): [100.0, np.nan, 300.0]},
+        index=pd.Index([1, 2, 3], name="p_id"),
+    )
+    pd.testing.assert_frame_equal(
+        expected, result, check_dtype=False, check_index_type=False
+    )
+
+
+@pytest.mark.parametrize(
+    ("series_factory", "expected_dtype_kind"),
+    [
+        (lambda: pd.Series([1, 2, 3], dtype="Int8"), "i"),
+        (lambda: pd.Series([1, 2, 3], dtype="Int16"), "i"),
+        (lambda: pd.Series([1, 2, 3], dtype="Int32"), "i"),
+        (lambda: pd.Series([1, 2, 3], dtype="Int64"), "i"),
+        (lambda: pd.Series([1, 2, 3], dtype="UInt8"), "i"),
+        (lambda: pd.Series([1, 2, 3], dtype="UInt32"), "i"),
+        (lambda: pd.Series([1, 2, 3], dtype="UInt64"), "i"),
+        (lambda: pd.Series([1.0, 2.0, 3.0], dtype="Float32"), "f"),
+        (lambda: pd.Series([1.0, 2.0, 3.0], dtype="Float64"), "f"),
+        (lambda: pd.Series([True, False, True], dtype="boolean"), "b"),
+        (
+            lambda: pd.Series([1, 2, 3], dtype=_pyarrow_or_skip("int32[pyarrow]")),
+            "i",
+        ),
+        (
+            lambda: pd.Series([1, 2, 3], dtype=_pyarrow_or_skip("uint16[pyarrow]")),
+            "i",
+        ),
+        (
+            lambda: pd.Series(
+                [1.0, 2.0, 3.0], dtype=_pyarrow_or_skip("float64[pyarrow]")
+            ),
+            "f",
+        ),
+        (
+            lambda: pd.Series(
+                [True, False, True], dtype=_pyarrow_or_skip("bool[pyarrow]")
+            ),
+            "b",
+        ),
+    ],
+)
+def test_canonicalize_input_dtype_normalises_extension_dtypes(
+    series_factory, expected_dtype_kind, xnp: ModuleType
+):
+    """Each nullable / pyarrow column without NAs ends up as a numpy array
+    with a backend-native dtype kind (``i`` for integers, ``f`` for floats,
+    ``b`` for booleans). JAX may choose narrower widths than int64 when its
+    x64 mode is off — the test asserts kind, not exact width.
+    """
+    result = _canonicalize_input_dtype(series_factory(), xnp)
+    assert result.dtype.kind == expected_dtype_kind
+
+
+def test_canonicalize_input_dtype_floats_map_na_to_nan(xnp: ModuleType):
+    series = pd.Series([1.0, pd.NA, 3.0], dtype="Float64")
+    result = _canonicalize_input_dtype(series, xnp)
+    assert result.dtype.kind == "f"
+    assert bool(xnp.isnan(result[1]))
+
+
+def test_int_input_with_na_fails_with_actionable_message(
+    backend: Literal["numpy", "jax"],
+):
+    """Integer columns with `pd.NA` cannot be represented in numpy `int64`
+    — surface the offending qname and row position so the user knows what
+    to fix.
+    """
+    df = pd.DataFrame(
+        {
+            ("p_id",): [1, 2, 3],
+            ("age",): pd.array([25, pd.NA, 45], dtype="Int64"),
+        },
+    )
+    with pytest.raises(ValueError, match=r"(?s)age.*first\s+NA\s+at\s+row\s+1"):
+        main(
+            main_target=MainTarget.results.df_with_nested_columns,
+            input_data=InputData.df_with_nested_columns(df),
+            tt_targets=TTTargets.tree({"age": None}),
+            policy_environment={},
+            evaluation_date=_DATE,
+            backend=backend,
+        )
+
+
+def test_bool_input_with_na_fails_with_actionable_message(
+    backend: Literal["numpy", "jax"],
+):
+    """Boolean columns with `pd.NA` are also rejected — numpy has no
+    nullable bool sentinel."""
+    df = pd.DataFrame(
+        {
+            ("p_id",): [1, 2, 3],
+            ("is_eligible",): pd.array([True, pd.NA, False], dtype="boolean"),
+        },
+    )
+    with pytest.raises(ValueError, match=r"(?s)is_eligible.*first\s+NA\s+at\s+row\s+1"):
+        main(
+            main_target=MainTarget.results.df_with_nested_columns,
+            input_data=InputData.df_with_nested_columns(df),
+            tt_targets=TTTargets.tree({"is_eligible": None}),
+            policy_environment={},
+            evaluation_date=_DATE,
+            backend=backend,
+        )
+
+
+def test_multiple_int_or_bool_columns_with_na_all_reported(
+    backend: Literal["numpy", "jax"],
+):
+    """When several int / bool columns carry NAs, all of them are surfaced
+    in the single error message — no need to fix-then-rerun in a loop.
+    """
+    df = pd.DataFrame(
+        {
+            ("p_id",): [1, 2, 3],
+            ("age",): pd.array([25, pd.NA, 45], dtype="Int64"),
+            ("is_eligible",): pd.array([pd.NA, True, False], dtype="boolean"),
+        },
+    )
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"(?s)age.*first\s+NA\s+at\s+row\s+1"
+            r".*is_eligible.*first\s+NA\s+at\s+row\s+0"
+        ),
+    ):
+        main(
+            main_target=MainTarget.results.df_with_nested_columns,
+            input_data=InputData.df_with_nested_columns(df),
+            tt_targets=TTTargets.tree({"age": None, "is_eligible": None}),
+            policy_environment={},
+            evaluation_date=_DATE,
+            backend=backend,
+        )
+
+
+def test_pyarrow_int_input_round_trips_as_int(backend: Literal["numpy", "jax"]):
+    """A pyarrow-backed integer column without NAs round-trips through
+    ttsim and lands back as an integer-typed result column.
+    """
+    pytest.importorskip("pyarrow")
+    df = pd.DataFrame(
+        {
+            ("p_id",): [1, 2, 3],
+            ("age",): pd.array([25, 35, 45], dtype="int32[pyarrow]"),
+        },
+    )
+    result = main(
+        main_target=MainTarget.results.df_with_nested_columns,
+        input_data=InputData.df_with_nested_columns(df),
+        tt_targets=TTTargets.tree({"age": None}),
+        policy_environment={},
+        evaluation_date=_DATE,
+        backend=backend,
+    )
+    assert result[("age",)].tolist() == [25, 35, 45]

--- a/tests/interface_dag_elements/test_orig_policy_objects.py
+++ b/tests/interface_dag_elements/test_orig_policy_objects.py
@@ -24,17 +24,30 @@ def test_load_path():
     )
 
 
-def test_load_module_uses_canonical_name_when_part_of_python_package():
-    """When the policy module lives under an `__init__.py` chain reaching
-    `sys.path`, `load_module` returns the canonical-imported module so that
-    objects defined in it carry an importable `__module__` (required for
-    `cloudpickle.dumps` to round-trip).
+def test_load_module_uses_canonical_name_when_opted_in():
+    """With `prefer_canonical_name=True`, `load_module` registers the module
+    under its canonical Python import path so objects defined in it carry an
+    importable `__module__` — required for `cloudpickle.dumps` to round-trip.
+    """
+    module = load_module(
+        path=middle_earth.ROOT_PATH / "payroll_tax" / "amount.py",
+        root=middle_earth.ROOT_PATH,
+        prefer_canonical_name=True,
+    )
+    assert module.__name__ == "mettsim.middle_earth.payroll_tax.amount"
+
+
+def test_load_module_uses_short_name_by_default():
+    """Default behaviour keeps the root-relative short name. Used for ttsim's
+    own interface DAG element modules, whose loaders rely on stable
+    class-identity at import time (re-execution under the canonical name
+    would create duplicate class objects).
     """
     module = load_module(
         path=middle_earth.ROOT_PATH / "payroll_tax" / "amount.py",
         root=middle_earth.ROOT_PATH,
     )
-    assert module.__name__ == "mettsim.middle_earth.payroll_tax.amount"
+    assert module.__name__ == "payroll_tax.amount"
 
 
 def test_find_canonical_module_name_walks_init_chain():

--- a/tests/interface_dag_elements/test_orig_policy_objects.py
+++ b/tests/interface_dag_elements/test_orig_policy_objects.py
@@ -4,6 +4,7 @@ import pytest
 from mettsim import middle_earth
 
 from ttsim.interface_dag_elements.orig_policy_objects import (
+    _find_canonical_module_name,
     _find_files_recursively,
     load_module,
 )
@@ -21,6 +22,31 @@ def test_load_path():
         path=middle_earth.ROOT_PATH / "payroll_tax" / "amount.py",
         root=middle_earth.ROOT_PATH,
     )
+
+
+def test_load_module_uses_canonical_name_when_part_of_python_package():
+    """When the policy module lives under an `__init__.py` chain reaching
+    `sys.path`, `load_module` returns the canonical-imported module so that
+    objects defined in it carry an importable `__module__` (required for
+    `cloudpickle.dumps` to round-trip).
+    """
+    module = load_module(
+        path=middle_earth.ROOT_PATH / "payroll_tax" / "amount.py",
+        root=middle_earth.ROOT_PATH,
+    )
+    assert module.__name__ == "mettsim.middle_earth.payroll_tax.amount"
+
+
+def test_find_canonical_module_name_walks_init_chain():
+    canonical = _find_canonical_module_name(
+        middle_earth.ROOT_PATH / "payroll_tax" / "amount.py"
+    )
+    assert canonical == "mettsim.middle_earth.payroll_tax.amount"
+
+
+def test_find_canonical_module_name_returns_none_for_bare_directory(tmp_path):
+    (tmp_path / "foo.py").write_text("x = 1\n")
+    assert _find_canonical_module_name(tmp_path / "foo.py") is None
 
 
 def test_dont_load_init_py():

--- a/tests/interface_dag_elements/test_processed_data.py
+++ b/tests/interface_dag_elements/test_processed_data.py
@@ -6,7 +6,7 @@ import pytest
 
 from ttsim.interface_dag_elements.input_data import sort_indices
 from ttsim.interface_dag_elements.processed_data import (
-    _coerce_uint_to_int64,
+    _canonicalize_input_dtype,
     processed_data,
 )
 
@@ -143,12 +143,12 @@ def _pyarrow_uint32_series():
         "pd_series_uint32_pyarrow",
     ],
 )
-def test_coerce_uint_to_int64_returns_signed_array(uint_input_factory, xnp):
+def test_canonicalize_input_dtype_returns_signed_array(uint_input_factory, xnp):
     """Coerced output is a signed integer (exact width depends on the backend:
     int64 on numpy, int32 on jax with the default x64-disabled config).
     """
     uint_input = uint_input_factory()
-    result = _coerce_uint_to_int64(uint_input, xnp)
+    result = _canonicalize_input_dtype(uint_input, xnp)
     assert result.dtype.kind == "i"
     assert int(result[0]) == 0
     assert int(result[1]) == 100
@@ -157,9 +157,9 @@ def test_coerce_uint_to_int64_returns_signed_array(uint_input_factory, xnp):
     assert int(result[0] - xnp.asarray(1230, dtype=result.dtype)) == -1230
 
 
-def test_coerce_uint_to_int64_passes_non_uint_through(xnp):
+def test_canonicalize_input_dtype_passes_non_uint_through(xnp):
     arr = numpy.array([-5, 0, 5], dtype=numpy.int32)
-    result = _coerce_uint_to_int64(arr, xnp)
+    result = _canonicalize_input_dtype(arr, xnp)
     assert result.dtype == xnp.int32
     assert int(result[0]) == -5
 

--- a/tests/interface_dag_elements/test_processed_data.py
+++ b/tests/interface_dag_elements/test_processed_data.py
@@ -5,7 +5,10 @@ import pandas as pd
 import pytest
 
 from ttsim.interface_dag_elements.input_data import sort_indices
-from ttsim.interface_dag_elements.processed_data import processed_data
+from ttsim.interface_dag_elements.processed_data import (
+    _coerce_uint_to_int64,
+    processed_data,
+)
 
 
 @pytest.fixture
@@ -112,6 +115,72 @@ def test_processed_data_single_column(xnp):
         ),
         pd.DataFrame(expected),
     )
+
+
+def _pyarrow_uint32_series():
+    pytest.importorskip("pyarrow")
+    return pd.Series([0, 100], dtype="uint32[pyarrow]")
+
+
+@pytest.mark.parametrize(
+    "uint_input_factory",
+    [
+        lambda: numpy.array([0, 100], dtype=numpy.uint8),
+        lambda: numpy.array([0, 100], dtype=numpy.uint16),
+        lambda: numpy.array([0, 100], dtype=numpy.uint32),
+        lambda: numpy.array([0, 100], dtype=numpy.uint64),
+        lambda: pd.Series([0, 100], dtype=numpy.uint32),
+        lambda: pd.Series([0, 100], dtype="UInt32"),
+        _pyarrow_uint32_series,
+    ],
+    ids=[
+        "numpy_uint8",
+        "numpy_uint16",
+        "numpy_uint32",
+        "numpy_uint64",
+        "pd_series_numpy_uint32",
+        "pd_series_UInt32_nullable",
+        "pd_series_uint32_pyarrow",
+    ],
+)
+def test_coerce_uint_to_int64_returns_signed_array(uint_input_factory, xnp):
+    """Coerced output is a signed integer (exact width depends on the backend:
+    int64 on numpy, int32 on jax with the default x64-disabled config).
+    """
+    uint_input = uint_input_factory()
+    result = _coerce_uint_to_int64(uint_input, xnp)
+    assert result.dtype.kind == "i"
+    assert int(result[0]) == 0
+    assert int(result[1]) == 100
+    # Subtracting a larger value stays signed instead of wrapping into a huge
+    # positive uint value.
+    assert int(result[0] - xnp.asarray(1230, dtype=result.dtype)) == -1230
+
+
+def test_coerce_uint_to_int64_passes_non_uint_through(xnp):
+    arr = numpy.array([-5, 0, 5], dtype=numpy.int32)
+    result = _coerce_uint_to_int64(arr, xnp)
+    assert result.dtype == xnp.int32
+    assert int(result[0]) == -5
+
+
+def test_processed_data_coerces_uint_columns_to_signed(xnp):
+    input_data__flat = {
+        ("p_id",): numpy.array([5, 7], dtype=numpy.uint32),
+        ("wage",): numpy.array([0, 100], dtype=numpy.uint32),
+    }
+    result = processed_data(
+        input_data__flat=input_data__flat,
+        input_data__sort_indices=sort_indices(
+            input_data__flat=input_data__flat, xnp=xnp
+        ),
+        xnp=xnp,
+    )
+    assert result["wage"].dtype.kind == "i"
+    # Subtraction stays signed instead of underflowing into uint wraparound.
+    diff = result["wage"] - xnp.asarray([1230, 50], dtype=result["wage"].dtype)
+    assert int(diff[0]) == -1230
+    assert int(diff[1]) == 50
 
 
 def test_processed_data_single_row(xnp):

--- a/tests/interface_dag_elements/test_raw_results.py
+++ b/tests/interface_dag_elements/test_raw_results.py
@@ -24,6 +24,18 @@ def test_columns_is_interface_function():
     assert isinstance(columns, InterfaceFunction)
 
 
+def _identity_p_id_inputs(xnp, n: int) -> dict:
+    """Minimal `input_data__flat` + sort indices for tests that don't care
+    about row order — the original `p_id` array is already sorted, so the
+    sort is the identity permutation.
+    """
+    return {
+        "input_data__flat": {("p_id",): xnp.arange(n)},
+        "input_data__sort_indices": xnp.arange(n),
+        "xnp": xnp,
+    }
+
+
 def test_columns_filters_to_root_nodes(xnp):
     processed_data = {
         "p_id": xnp.array([0, 1, 2]),
@@ -40,6 +52,7 @@ def test_columns_filters_to_root_nodes(xnp):
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
+        **_identity_p_id_inputs(xnp, n=3),
     )
 
     # Only root_nodes should be passed to tt_function
@@ -65,6 +78,7 @@ def test_columns_calls_tt_function_with_filtered_data(xnp):
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
+        **_identity_p_id_inputs(xnp, n=2),
     )
 
     # Verify tt_function was called with only root_nodes data
@@ -86,6 +100,7 @@ def test_columns_returns_tt_function_output(xnp):
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
+        **_identity_p_id_inputs(xnp, n=2),
     )
 
     assert result == expected_output
@@ -102,6 +117,7 @@ def test_columns_with_empty_root_nodes(xnp):
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
+        **_identity_p_id_inputs(xnp, n=2),
     )
 
     assert result == {}
@@ -290,6 +306,9 @@ def test_columns_dependencies():
         "labels__root_nodes",
         "processed_data",
         "tt_function",
+        "input_data__flat",
+        "input_data__sort_indices",
+        "xnp",
     }
 
 

--- a/tests/interface_dag_elements/test_specialized_environment.py
+++ b/tests/interface_dag_elements/test_specialized_environment.py
@@ -882,10 +882,6 @@ def test_scalars_in_input_data_become_part_of_specialized_environment(xnp, backe
     assert root_nodes == set()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://github.com/ttsim-dev/ttsim/issues/79",
-)
 def test_derived_time_converted_scalar_not_in_processed_environment(xnp, backend):
     """Scalar inputs are partialled correctly.
 

--- a/tests/interface_dag_elements/test_specialized_environment.py
+++ b/tests/interface_dag_elements/test_specialized_environment.py
@@ -29,6 +29,7 @@ from ttsim.tt import (
     policy_function,
     policy_input,
 )
+from ttsim.typing import UserFlatData
 
 if TYPE_CHECKING:
     from ttsim.typing import IntColumn, RawParamValue
@@ -861,18 +862,20 @@ def test_can_override_ttsim_objects_with_data(
 
 
 def test_scalars_in_input_data_become_part_of_specialized_environment(xnp, backend):
+    """`InputData.flat` is the advanced opt-out: scalars there are partialled
+    into derived consumers and don't show up as root nodes of the tt_dag."""
     policy_environment = {
         "identity": identity,
         "identity_plus_one": identity_plus_one,
     }
-    input_data = {
-        "p_id": xnp.array([1, 2, 3]),
-        "identity": 1,
+    input_data: UserFlatData = {
+        ("p_id",): xnp.array([1, 2, 3]),
+        ("identity",): 1,
     }
     root_nodes = main(
         main_target=MainTarget.labels.root_nodes,
         policy_environment=policy_environment,
-        input_data=InputData.tree(input_data),
+        input_data=InputData.flat(input_data),
         tt_targets=TTTargets.tree({"identity_plus_one": None}),
         policy_date=datetime.date(2024, 1, 1),
         evaluation_date_str="2024-01-01",
@@ -883,23 +886,22 @@ def test_scalars_in_input_data_become_part_of_specialized_environment(xnp, backe
 
 
 def test_derived_time_converted_scalar_not_in_processed_environment(xnp, backend):
-    """Scalar inputs are partialled correctly.
-
-    Scalars in input_data that are dependencies of derived functions should be
-    included in the processed environment."""
+    """Scalars provided via `InputData.flat` (the advanced opt-out) that are
+    sources for derived time-conversion functions get partialled in and don't
+    show up as root nodes of the tt_dag."""
     policy_environment = {
         "p_id": p_id,
         "income_m": income_m,
         "benefit": benefit,
     }
-    input_data = {
-        "p_id": xnp.array([1, 2, 3]),
-        "income_y": 12000,
+    input_data: UserFlatData = {
+        ("p_id",): xnp.array([1, 2, 3]),
+        ("income_y",): 12000,
     }
     root_nodes = main(
         main_target=MainTarget.labels.root_nodes,
         policy_environment=policy_environment,
-        input_data=InputData.tree(input_data),
+        input_data=InputData.flat(input_data),
         tt_targets=TTTargets.tree({"benefit": None}),
         policy_date_str="2024-01-01",
         evaluation_date_str="2024-01-01",

--- a/tests/interface_dag_elements/test_warnings.py
+++ b/tests/interface_dag_elements/test_warnings.py
@@ -151,6 +151,7 @@ def test_warn_if_evaluation_date_set_in_multiple_places_implicitly_added(backend
             policy_environment=policy_environment,
             evaluation_date=datetime.date(2025, 1, 1),
             processed_data={"p_id": xnp.array([0])},
+            input_data=InputData.tree(tree={"p_id": xnp.array([0])}),
             tt_targets=TTTargets.tree({"p_id": None}),
             backend=backend,
         )
@@ -171,6 +172,7 @@ def test_do_not_need_to_warn_if_evaluation_date_is_set_only_once(backend, xnp):
             policy_environment=policy_environment,
             evaluation_date=datetime.date(2025, 1, 1),
             processed_data={"p_id": xnp.array([0])},
+            input_data=InputData.tree(tree={"p_id": xnp.array([0])}),
             tt_targets=TTTargets.tree({"p_id": None}),
             backend=backend,
         )

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -188,6 +188,73 @@ def test_df_with_qname_columns_has_qname_string_columns(
     assert list(result.index) == [2, 0, 1]
 
 
+def test_cloudpickle_round_trip_preserves_tt_function_output(tmp_path):
+    """A `tt_function` built against a policy environment that lives under a
+    proper Python package (here: mettsim) survives a cloudpickle round-trip
+    with results unchanged. Regression for #73.
+
+    Runs in a fresh subprocess to avoid pytest's stdout-capture wrappers
+    leaking into module-level closures (which would taint cloudpickle later).
+    """
+    pytest.importorskip("cloudpickle")
+    import subprocess  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+    import textwrap  # noqa: PLC0415
+
+    script = tmp_path / "repro.py"
+    script.write_text(
+        textwrap.dedent(
+            """
+            import cloudpickle
+            import numpy as np
+            from mettsim import middle_earth
+
+            from ttsim import InputData, OrigPolicyObjects, TTTargets, main
+
+            data = {
+                ("age",): np.array([30, 30]),
+                ("kin_id",): np.array([0, 0]),
+                ("p_id",): np.array([0, 1]),
+                ("p_id_parent_1",): np.array([-1, -1]),
+                ("p_id_parent_2",): np.array([-1, -1]),
+                ("p_id_spouse",): np.array([1, 0]),
+                ("parent_is_noble",): np.array([False, False]),
+                ("payroll_tax", "child_tax_credit", "p_id_recipient"):
+                    np.array([-1, -1]),
+                ("payroll_tax", "income", "gross_wage_y"):
+                    np.array([10000.0, 0.0]),
+                ("wealth",): np.array([0.0, 0.0]),
+            }
+            kwargs = dict(
+                policy_date_str="2025-01-01",
+                input_data=InputData.flat(data),
+                orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+                tt_targets=TTTargets.tree({"payroll_tax": {"amount_y": None}}),
+                backend="numpy",
+            )
+            tt_func = main(main_target="tt_function", **kwargs)
+            processed = main(main_target="processed_data", **kwargs)
+            restored = cloudpickle.loads(cloudpickle.dumps(tt_func))
+            expected = tt_func(processed)
+            actual = restored(processed)
+            for qname in expected:
+                np.testing.assert_array_equal(expected[qname], actual[qname])
+            print("OK")
+            """
+        )
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
 def test_can_create_input_template(backend: Literal["numpy", "jax"]):
     result_template = main(
         main_target=MainTarget.templates.input_data_dtypes.tree,

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -188,13 +188,11 @@ def test_df_with_qname_columns_has_qname_string_columns(
     assert list(result.index) == [2, 0, 1]
 
 
-def test_cloudpickle_round_trip_preserves_tt_function_output(tmp_path):
-    """A `tt_function` built against a policy environment that lives under a
-    proper Python package (here: mettsim) survives a cloudpickle round-trip
-    with results unchanged. Regression for #73.
+def _run_cloudpickle_subprocess(tmp_path, script_body: str) -> None:
+    """Run a cloudpickle round-trip in a fresh subprocess.
 
-    Runs in a fresh subprocess to avoid pytest's stdout-capture wrappers
-    leaking into module-level closures (which would taint cloudpickle later).
+    A subprocess avoids pytest's stdout-capture wrappers leaking into
+    module-level closures (which would otherwise taint cloudpickle).
     """
     pytest.importorskip("cloudpickle")
     import subprocess  # noqa: PLC0415
@@ -202,47 +200,7 @@ def test_cloudpickle_round_trip_preserves_tt_function_output(tmp_path):
     import textwrap  # noqa: PLC0415
 
     script = tmp_path / "repro.py"
-    script.write_text(
-        textwrap.dedent(
-            """
-            import cloudpickle
-            import numpy as np
-            from mettsim import middle_earth
-
-            from ttsim import InputData, OrigPolicyObjects, TTTargets, main
-
-            data = {
-                ("age",): np.array([30, 30]),
-                ("kin_id",): np.array([0, 0]),
-                ("p_id",): np.array([0, 1]),
-                ("p_id_parent_1",): np.array([-1, -1]),
-                ("p_id_parent_2",): np.array([-1, -1]),
-                ("p_id_spouse",): np.array([1, 0]),
-                ("parent_is_noble",): np.array([False, False]),
-                ("payroll_tax", "child_tax_credit", "p_id_recipient"):
-                    np.array([-1, -1]),
-                ("payroll_tax", "income", "gross_wage_y"):
-                    np.array([10000.0, 0.0]),
-                ("wealth",): np.array([0.0, 0.0]),
-            }
-            kwargs = dict(
-                policy_date_str="2025-01-01",
-                input_data=InputData.flat(data),
-                orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
-                tt_targets=TTTargets.tree({"payroll_tax": {"amount_y": None}}),
-                backend="numpy",
-            )
-            tt_func = main(main_target="tt_function", **kwargs)
-            processed = main(main_target="processed_data", **kwargs)
-            restored = cloudpickle.loads(cloudpickle.dumps(tt_func))
-            expected = tt_func(processed)
-            actual = restored(processed)
-            for qname in expected:
-                np.testing.assert_array_equal(expected[qname], actual[qname])
-            print("OK")
-            """
-        )
-    )
+    script.write_text(textwrap.dedent(script_body))
     result = subprocess.run(  # noqa: S603
         [sys.executable, str(script)],
         capture_output=True,
@@ -253,6 +211,110 @@ def test_cloudpickle_round_trip_preserves_tt_function_output(tmp_path):
         f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
     )
     assert "OK" in result.stdout
+
+
+def test_cloudpickle_round_trip_preserves_tt_function_output(tmp_path):
+    """A `tt_function` built against a policy environment loaded from a
+    ROOT_PATH (here: mettsim) survives a cloudpickle round-trip with results
+    unchanged. Regression for #73.
+    """
+    _run_cloudpickle_subprocess(
+        tmp_path,
+        """
+        import cloudpickle
+        import numpy as np
+        from mettsim import middle_earth
+
+        from ttsim import InputData, OrigPolicyObjects, TTTargets, main
+
+        data = {
+            ("age",): np.array([30, 30]),
+            ("kin_id",): np.array([0, 0]),
+            ("p_id",): np.array([0, 1]),
+            ("p_id_parent_1",): np.array([-1, -1]),
+            ("p_id_parent_2",): np.array([-1, -1]),
+            ("p_id_spouse",): np.array([1, 0]),
+            ("parent_is_noble",): np.array([False, False]),
+            ("payroll_tax", "child_tax_credit", "p_id_recipient"):
+                np.array([-1, -1]),
+            ("payroll_tax", "income", "gross_wage_y"):
+                np.array([10000.0, 0.0]),
+            ("wealth",): np.array([0.0, 0.0]),
+        }
+        kwargs = dict(
+            policy_date_str="2025-01-01",
+            input_data=InputData.flat(data),
+            orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            tt_targets=TTTargets.tree({"payroll_tax": {"amount_y": None}}),
+            backend="numpy",
+        )
+        tt_func = main(main_target="tt_function", **kwargs)
+        processed = main(main_target="processed_data", **kwargs)
+        restored = cloudpickle.loads(cloudpickle.dumps(tt_func))
+        expected = tt_func(processed)
+        actual = restored(processed)
+        for qname in expected:
+            np.testing.assert_array_equal(expected[qname], actual[qname])
+        print("OK")
+        """,
+    )
+
+
+def test_cloudpickle_round_trip_with_inline_policy_environment(tmp_path):
+    """A `tt_function` built from a user-defined inline `policy_environment`
+    (no `OrigPolicyObjects.root`, no on-disk policy package) also survives a
+    cloudpickle round-trip. Guard rail: the fix for #73 must not regress this
+    path.
+    """
+    _run_cloudpickle_subprocess(
+        tmp_path,
+        """
+        import datetime
+        import cloudpickle
+        import numpy as np
+
+        from ttsim import InputData, TTTargets, main
+        from ttsim.tt import policy_function, policy_input
+
+
+        @policy_input()
+        def p_id() -> int: ...
+
+
+        @policy_input()
+        def income_m() -> float: ...
+
+
+        @policy_function(vectorization_strategy="vectorize")
+        def benefit_m(income_m: float) -> float:
+            return income_m * 0.5
+
+
+        env = {"p_id": p_id, "income_m": income_m, "benefit_m": benefit_m}
+        kwargs = dict(
+            policy_environment=env,
+            input_data=InputData.tree({
+                "p_id": np.array([0, 1, 2]),
+                "income_m": np.array([1000.0, 2000.0, 3000.0]),
+            }),
+            tt_targets=TTTargets.tree({"benefit_m": None}),
+            evaluation_date=datetime.date(2025, 1, 1),
+            rounding=False,
+            backend="numpy",
+        )
+        tt_func = main(main_target="tt_function", **kwargs)
+        processed = main(main_target="processed_data", **kwargs)
+        root_nodes = main(main_target="labels__root_nodes", **kwargs)
+        filtered = {k: v for k, v in processed.items() if k in root_nodes}
+
+        restored = cloudpickle.loads(cloudpickle.dumps(tt_func))
+        expected = tt_func(filtered)
+        actual = restored(filtered)
+        for qname in expected:
+            np.testing.assert_array_equal(expected[qname], actual[qname])
+        print("OK")
+        """,
+    )
 
 
 def test_can_create_input_template(backend: Literal["numpy", "jax"]):

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -126,6 +126,37 @@ def test_end_to_end(input_data_arg, backend: Literal["numpy", "jax"]):
     )
 
 
+@pytest.mark.parametrize(
+    "wage_dtype",
+    ["uint32", "UInt32", "uint32[pyarrow]"],
+)
+def test_uint_wage_input_does_not_underflow(
+    wage_dtype: str, backend: Literal["numpy", "jax"]
+):
+    """A `uint`-typed wage column flows through `max(gross - deductions, 0)` as
+    signed arithmetic, so the result is 0 rather than the uint wraparound.
+    """
+    if wage_dtype.endswith("[pyarrow]"):
+        pytest.importorskip("pyarrow")
+    nested_columns_df = DF_WITH_NESTED_COLUMNS.copy()
+    nested_columns_df[("payroll_tax", "income", "gross_wage_y")] = pd.Series(
+        [0, 0, 0], dtype=wage_dtype
+    )
+    result = main(
+        main_target=MainTarget.results.tree,
+        input_data=InputData.df_with_nested_columns(nested_columns_df),
+        tt_targets=TTTargets.tree({"payroll_tax": {"amount_y": None}}),
+        policy_date_str="2025-01-01",
+        rounding=False,
+        orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        backend=backend,
+    )
+    amount_y = result["payroll_tax"]["amount_y"]
+    assert float(amount_y[0]) == 0.0
+    assert float(amount_y[1]) == 0.0
+    assert float(amount_y[2]) == 0.0
+
+
 def test_can_create_input_template(backend: Literal["numpy", "jax"]):
     result_template = main(
         main_target=MainTarget.templates.input_data_dtypes.tree,

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from types import ModuleType
     from typing import Literal
 
+    from ttsim.typing import UserFlatData
+
 
 DF_WITH_NESTED_COLUMNS = pd.DataFrame(
     {
@@ -470,24 +472,23 @@ def test_input_data_reordering_with_distinct_values(
 
 
 def test_derived_time_converted_scalar_can_partialled(xnp, backend):
-    """Scalar inputs are partialled correctly.
-
-    Scalar inputs are partialled also if they replace a function that is derived from
-    a policy input.
+    """A scalar passed via `InputData.flat` (the advanced opt-out) that
+    drives a derived time-conversion function is partialled in and doesn't
+    show up as a root node of the tt_dag.
     """
     policy_environment = {
         "p_id": p_id,
         "income_m": income_m,
         "benefit": benefit,
     }
-    input_data = {
-        "p_id": xnp.array([1, 2, 3]),
-        "income_y": 12000,
+    input_data: UserFlatData = {
+        ("p_id",): xnp.array([1, 2, 3]),
+        ("income_y",): 12000,
     }
     root_nodes = main(
         main_target=MainTarget.labels.root_nodes,
         policy_environment=policy_environment,
-        input_data=InputData.tree(input_data),
+        input_data=InputData.flat(input_data),
         tt_targets=TTTargets.tree({"benefit": None}),
         policy_date_str="2024-01-01",
         evaluation_date_str="2024-01-01",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -157,6 +157,37 @@ def test_uint_wage_input_does_not_underflow(
     assert float(amount_y[2]) == 0.0
 
 
+def test_df_with_qname_columns_has_qname_string_columns(
+    backend: Literal["numpy", "jax"],
+):
+    """Flat qname-named columns survive adding/removing targets without changing
+    the column index depth — unlike `df_with_nested_columns` which uses a
+    MultiIndex whose depth tracks the deepest target.
+    """
+    result = main(
+        main_target=MainTarget.results.df_with_qname_columns,
+        input_data=InputData.df_with_nested_columns(DF_WITH_NESTED_COLUMNS),
+        tt_targets=TTTargets.tree(
+            {
+                "payroll_tax": {
+                    "amount_y": None,
+                    "child_tax_credit": {"amount_m": None},
+                },
+            }
+        ),
+        policy_date_str="2025-01-01",
+        rounding=False,
+        orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        backend=backend,
+    )
+    assert list(result.columns) == [
+        "payroll_tax__amount_y",
+        "payroll_tax__child_tax_credit__amount_m",
+    ]
+    assert result.index.name == "p_id"
+    assert list(result.index) == [2, 0, 1]
+
+
 def test_can_create_input_template(backend: Literal["numpy", "jax"]):
     result_template = main(
         main_target=MainTarget.templates.input_data_dtypes.tree,

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -340,10 +340,6 @@ def test_input_data_reordering_with_distinct_values(
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://github.com/ttsim-dev/ttsim/issues/79",
-)
 def test_derived_time_converted_scalar_can_partialled(xnp, backend):
     """Scalar inputs are partialled correctly.
 


### PR DESCRIPTION
## Summary
- `_coerce_uint_to_int64` → `_canonicalize_input_dtype`, now also handles pandas-nullable and pyarrow-backed column dtypes.
- Float-nullable / float-pyarrow → numpy `float64`, with `pd.NA → NaN` (silent).
- Int / UInt / Bool nullable variants → `int64` / `bool` when NA-free.
- NA in int / bool columns → new `fail_if.input_data_has_int_or_bool_missing_values` reports every offending qname + first-NA row position in one error.
- Wired into both df-based and tree-based input paths; canonicalization runs in `data_converters` and `flat_from_tree` so all entry points benefit.

Closes #94. Stacked on #108 (`feat/43-endogenous-p-id-targets`).

## Test plan
- [x] `pixi run -e py314 tests -n 7` — 1038 passed
- [x] `pixi run -e py314-jax tests-jax -n 7` — 1021 passed
- [x] `pixi run ty` — no new errors in touched files
- [x] `prek run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)