### PR TITLE
Fix mettsim policy-case collection: all cases were silently skipped

### DIFF
--- a/src_mettsim/tests_middle_earth/test_mettsim.py
+++ b/src_mettsim/tests_middle_earth/test_mettsim.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 POLICY_TEST_IDS_AND_CASES = load_policy_cases(
     policy_cases_root=(
-        middle_earth.ROOT_PATH.parent / "tests_middle_earth" / "policy_cases"
+        middle_earth.ROOT_PATH.parent.parent / "tests_middle_earth" / "policy_cases"
     ),
     policy_name="",
     xnp=numpy,

--- a/src_mettsim/tests_middle_earth/test_mettsim.py
+++ b/src_mettsim/tests_middle_earth/test_mettsim.py
@@ -73,6 +73,11 @@ def test_policy_cases(test: PolicyTest, backend: Literal["numpy", "jax"]):
     execute_test(test=test, root=middle_earth.ROOT_PATH, backend=backend)
 
 
+def test_enough_policy_cases_are_collected():
+    """Guard against silently skipping all policy cases via a broken glob root."""
+    assert len(POLICY_TEST_IDS_AND_CASES) >= 20
+
+
 def test_python314_annotation_extraction_bug(backend: Literal["numpy", "jax"]):
     """Check Python 3.14 annotation extraction bug (fixed in dags>=0.4.2)."""
 


### PR DESCRIPTION
`load_policy_cases` in `test_mettsim.py` resolved the policy-cases root as `ROOT_PATH.parent / "tests_middle_earth" / "policy_cases"`, i.e. `src_mettsim/mettsim/tests_middle_earth/...`, which does not exist. The glob found nothing, `POLICY_TEST_IDS_AND_CASES` was empty, and `test_policy_cases` collected as a single `[NOTSET]` skip — so **all 24 mettsim policy cases have been silently skipped on `main`**.

Fix: `ROOT_PATH.parent.parent`, matching the construction `test_python314_annotation_extraction_bug` already uses.

Independent of the GEP-10 stack (found while working on #126; #126 will pick it up via rebase once this merges).

## Test plan

- [x] `pixi run -e py314 pytest src_mettsim/tests_middle_earth -q` — 32 passed (24 policy cases now collected and green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)