### PR TITLE
Split raw_results.columns into columns_with_internal_p_ids / columns_with_original_p_ids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
+- {gh}`130` Move the reverse-translation of endogenous `p_id_*` columns out of
+  `raw_results.columns` into the new node `raw_results.columns_with_remapped_ids`.
+  `raw_results.columns` is computable from `processed_data` alone again (without any
+  `input_data`); `results.tree` and everything downstream keep returning user-space
+  `p_id` values via the new node. ({ghuser}`MImmesberger`)
 - Fill in the `count_by_p_id`, `mean_by_p_id`, `max_by_p_id`, `min_by_p_id`,
   `any_by_p_id`, and `all_by_p_id` aggregations on both the NumPy and JAX backends.
   Negative source `p_id` entries are masked out so they cannot influence the result;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,15 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
-- {gh}`130` Move the reverse-translation of endogenous `p_id_*` columns out of
-  `raw_results.columns` into the new node `raw_results.columns_with_remapped_ids`.
-  `raw_results.columns` is computable from `processed_data` alone again (without any
-  `input_data`); `results.tree` and everything downstream keep returning user-space
-  `p_id` values via the new node. ({ghuser}`MImmesberger`)
+- {gh}`130` Split `raw_results.columns` into the symmetric pair
+  `raw_results.columns_with_internal_p_ids` and
+  `raw_results.columns_with_original_p_ids`. The former holds internal indices in
+  endogenous `p_id_*` columns and is computable from `processed_data` alone (without any
+  `input_data`); the latter carries the reverse-translation to user-space `p_id` values
+  introduced in {gh}`108`. `results.tree` and everything downstream keep returning
+  user-space `p_id` values. Breaking: the target `raw_results.columns` no longer exists;
+  use `raw_results.columns_with_internal_p_ids` for the old (pre-{gh}`108`) semantics.
+  ({ghuser}`MImmesberger`)
 - Fill in the `count_by_p_id`, `mean_by_p_id`, `max_by_p_id`, `min_by_p_id`,
   `any_by_p_id`, and `all_by_p_id` aggregations on both the NumPy and JAX backends.
   Negative source `p_id` entries are masked out so they cannot influence the result;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,14 +6,9 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/ttsim)
 
 ## Unreleased
 
-- {gh}`130` Split `raw_results.columns` into the symmetric pair
-  `raw_results.columns_with_internal_p_ids` and
-  `raw_results.columns_with_original_p_ids`. The former holds internal indices in
-  endogenous `p_id_*` columns and is computable from `processed_data` alone (without any
-  `input_data`); the latter carries the reverse-translation to user-space `p_id` values
-  introduced in {gh}`108`. `results.tree` and everything downstream keep returning
-  user-space `p_id` values. Breaking: the target `raw_results.columns` no longer exists;
-  use `raw_results.columns_with_internal_p_ids` for the old (pre-{gh}`108`) semantics.
+- {gh}`130` Split `raw_results.columns` into `raw_results.columns_with_internal_p_ids`
+  (computable from `processed_data` alone) and `raw_results.columns_with_original_p_ids`
+  (the reverse-translation of endogenous `p_id_*` columns from {gh}`108`).
   ({ghuser}`MImmesberger`)
 - Fill in the `count_by_p_id`, `mean_by_p_id`, `max_by_p_id`, `min_by_p_id`,
   `any_by_p_id`, and `all_by_p_id` aggregations on both the NumPy and JAX backends.

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,3 +13,7 @@ coverage:
     project:
       default:
         target: 85%
+ignore:
+  # Runs on the JAX backend only; the coverage job uses the NumPy backend,
+  # under which all of its cases are skipped.
+  - src_mettsim/tests_middle_earth/test_jittability.py

--- a/src/ttsim/interface_dag_elements/raw_results.py
+++ b/src/ttsim/interface_dag_elements/raw_results.py
@@ -22,20 +22,36 @@ def columns(
     labels__root_nodes: UnorderedQNames,
     processed_data: QNameData,
     tt_function: Callable[[QNameData], QNameData],
+) -> QNameData:
+    """The raw results of the TT function that have been requested as targets.
+
+    Arrays are sorted according to the internal sort order. Endogenously-
+    computed `p_id_*` columns hold internal indices; see
+    `columns_with_remapped_ids` for the version with user-space `p_id` values.
+
+    Computable from `processed_data` alone, without any `input_data`.
+    """
+    return tt_function(
+        {k: v for k, v in processed_data.items() if k in labels__root_nodes},
+    )
+
+
+@interface_function()
+def columns_with_remapped_ids(
+    columns: QNameData,
     input_data__flat: FlatData,
     input_data__sort_indices: IntColumn,
     xnp: ModuleType,
 ) -> QNameData:
-    """The raw results of the TT function that have been requested as targets.
+    """Raw results with endogenous `p_id_*` columns remapped to user-space `p_id`s.
 
     Arrays are sorted according to the internal sort order. Endogenously-
     computed `p_id_*` columns hold internal indices; those are reverse-
     translated to user-space `p_id` values here so consumers downstream see
     the original identifiers (with `-1` preserved as the no-link sentinel).
+
+    Requires `input_data` because the original `p_id` values only exist there.
     """
-    raw = tt_function(
-        {k: v for k, v in processed_data.items() if k in labels__root_nodes},
-    )
     sorted_orig_p_ids = xnp.asarray(input_data__flat[("p_id",)])[
         input_data__sort_indices
     ]
@@ -47,7 +63,7 @@ def columns(
         )
         if _is_endogenous_p_id_pointer(qname)
         else value
-        for qname, value in raw.items()
+        for qname, value in columns.items()
     }
 
 

--- a/src/ttsim/interface_dag_elements/raw_results.py
+++ b/src/ttsim/interface_dag_elements/raw_results.py
@@ -25,11 +25,9 @@ def columns(
 ) -> QNameData:
     """The raw results of the TT function that have been requested as targets.
 
-    Arrays are sorted according to the internal sort order. Endogenously-
-    computed `p_id_*` columns hold internal indices; see
-    `columns_with_remapped_ids` for the version with user-space `p_id` values.
-
-    Computable from `processed_data` alone, without any `input_data`.
+    Arrays are sorted according to the internal sort order. Endogenously- computed
+    `p_id_*` columns hold internal indices; see `columns_with_remapped_ids` for the
+    version with user-space `p_id` values.
     """
     return tt_function(
         {k: v for k, v in processed_data.items() if k in labels__root_nodes},
@@ -49,8 +47,6 @@ def columns_with_remapped_ids(
     computed `p_id_*` columns hold internal indices; those are reverse-
     translated to user-space `p_id` values here so consumers downstream see
     the original identifiers (with `-1` preserved as the no-link sentinel).
-
-    Requires `input_data` because the original `p_id` values only exist there.
     """
     sorted_orig_p_ids = xnp.asarray(input_data__flat[("p_id",)])[
         input_data__sort_indices

--- a/src/ttsim/interface_dag_elements/raw_results.py
+++ b/src/ttsim/interface_dag_elements/raw_results.py
@@ -18,7 +18,7 @@ from ttsim.typing import (
 
 
 @interface_function()
-def columns(
+def columns_with_internal_p_ids(
     labels__root_nodes: UnorderedQNames,
     processed_data: QNameData,
     tt_function: Callable[[QNameData], QNameData],
@@ -27,7 +27,7 @@ def columns(
 
     Arrays are sorted according to the internal sort order. Endogenously-
     computed `p_id_*` columns hold internal indices; see
-    `columns_with_remapped_ids` for the version with user-space `p_id` values.
+    `columns_with_original_p_ids` for the version with user-space `p_id` values.
 
     Computable from `processed_data` alone, without any `input_data`.
     """
@@ -37,8 +37,8 @@ def columns(
 
 
 @interface_function()
-def columns_with_remapped_ids(
-    columns: QNameData,
+def columns_with_original_p_ids(
+    columns_with_internal_p_ids: QNameData,
     input_data__flat: FlatData,
     input_data__sort_indices: IntColumn,
     xnp: ModuleType,
@@ -63,7 +63,7 @@ def columns_with_remapped_ids(
         )
         if _is_endogenous_p_id_pointer(qname)
         else value
-        for qname, value in columns.items()
+        for qname, value in columns_with_internal_p_ids.items()
     }
 
 

--- a/src/ttsim/interface_dag_elements/results.py
+++ b/src/ttsim/interface_dag_elements/results.py
@@ -25,7 +25,7 @@ from ttsim.typing import (
 
 @interface_function()
 def tree(
-    raw_results__columns_with_remapped_ids: QNameData,
+    raw_results__columns_with_original_p_ids: QNameData,
     raw_results__params: QNameResults,
     raw_results__from_input_data: QNameData,
     input_data__sort_indices: IntColumn,
@@ -45,7 +45,7 @@ def tree(
             **raw_results__from_input_data,
             **{
                 k: reorder_arrays(v)
-                for k, v in raw_results__columns_with_remapped_ids.items()
+                for k, v in raw_results__columns_with_original_p_ids.items()
             },
         }
     )

--- a/src/ttsim/interface_dag_elements/results.py
+++ b/src/ttsim/interface_dag_elements/results.py
@@ -25,7 +25,7 @@ from ttsim.typing import (
 
 @interface_function()
 def tree(
-    raw_results__columns: QNameData,
+    raw_results__columns_with_remapped_ids: QNameData,
     raw_results__params: QNameResults,
     raw_results__from_input_data: QNameData,
     input_data__sort_indices: IntColumn,
@@ -43,7 +43,10 @@ def tree(
         {
             **raw_results__params,
             **raw_results__from_input_data,
-            **{k: reorder_arrays(v) for k, v in raw_results__columns.items()},
+            **{
+                k: reorder_arrays(v)
+                for k, v in raw_results__columns_with_remapped_ids.items()
+            },
         }
     )
 

--- a/src/ttsim/main_args.py
+++ b/src/ttsim/main_args.py
@@ -264,8 +264,8 @@ class Labels(MainArg):
 
 @dataclass(frozen=True)
 class RawResults(MainArg):
-    columns: QNameData | None = None
-    columns_with_remapped_ids: QNameData | None = None
+    columns_with_internal_p_ids: QNameData | None = None
+    columns_with_original_p_ids: QNameData | None = None
     params: QNameData | None = None
     from_input_data: QNameData | None = None
     combined: QNameData | None = None
@@ -274,19 +274,26 @@ class RawResults(MainArg):
         _fix_classmethod_namespace_conflicts(self)
 
     @classmethod
-    def columns(cls, columns: QNameData) -> RawResults:
-        """Column results data."""
-        return _set_single_field(cls=cls, field_name="columns", field_value=columns)
+    def columns_with_internal_p_ids(
+        cls, columns_with_internal_p_ids: QNameData
+    ) -> RawResults:
+        """Column results data with endogenous `p_id_*` columns holding internal
+        indices."""
+        return _set_single_field(
+            cls=cls,
+            field_name="columns_with_internal_p_ids",
+            field_value=columns_with_internal_p_ids,
+        )
 
     @classmethod
-    def columns_with_remapped_ids(
-        cls, columns_with_remapped_ids: QNameData
+    def columns_with_original_p_ids(
+        cls, columns_with_original_p_ids: QNameData
     ) -> RawResults:
         """Column results data with endogenous `p_id_*` columns in user space."""
         return _set_single_field(
             cls=cls,
-            field_name="columns_with_remapped_ids",
-            field_value=columns_with_remapped_ids,
+            field_name="columns_with_original_p_ids",
+            field_value=columns_with_original_p_ids,
         )
 
     @classmethod

--- a/src/ttsim/main_args.py
+++ b/src/ttsim/main_args.py
@@ -265,6 +265,7 @@ class Labels(MainArg):
 @dataclass(frozen=True)
 class RawResults(MainArg):
     columns: QNameData | None = None
+    columns_with_remapped_ids: QNameData | None = None
     params: QNameData | None = None
     from_input_data: QNameData | None = None
     combined: QNameData | None = None
@@ -276,6 +277,17 @@ class RawResults(MainArg):
     def columns(cls, columns: QNameData) -> RawResults:
         """Column results data."""
         return _set_single_field(cls=cls, field_name="columns", field_value=columns)
+
+    @classmethod
+    def columns_with_remapped_ids(
+        cls, columns_with_remapped_ids: QNameData
+    ) -> RawResults:
+        """Column results data with endogenous `p_id_*` columns in user space."""
+        return _set_single_field(
+            cls=cls,
+            field_name="columns_with_remapped_ids",
+            field_value=columns_with_remapped_ids,
+        )
 
     @classmethod
     def params(cls, params: QNameData) -> RawResults:

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -96,8 +96,8 @@ class Results(MainTargetABC):
 
 @dataclass(frozen=True)
 class RawResults(MainTargetABC):
-    columns: str = "raw_results__columns"
-    columns_with_remapped_ids: str = "raw_results__columns_with_remapped_ids"
+    columns_with_internal_p_ids: str = "raw_results__columns_with_internal_p_ids"
+    columns_with_original_p_ids: str = "raw_results__columns_with_original_p_ids"
     from_input_data: str = "raw_results__from_input_data"
     params: str = "raw_results__params"
 

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -97,6 +97,7 @@ class Results(MainTargetABC):
 @dataclass(frozen=True)
 class RawResults(MainTargetABC):
     columns: str = "raw_results__columns"
+    columns_with_remapped_ids: str = "raw_results__columns_with_remapped_ids"
     from_input_data: str = "raw_results__from_input_data"
     params: str = "raw_results__params"
 

--- a/src_mettsim/tests_middle_earth/test_jittability.py
+++ b/src_mettsim/tests_middle_earth/test_jittability.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import datetime
+import functools
+import inspect
+from typing import TYPE_CHECKING, Literal
+
+import dags.tree as dt
+import pytest
+from dags import get_free_arguments
+from mettsim import middle_earth
+
+from ttsim import (
+    MainTarget,
+    OrigPolicyObjects,
+    SpecializedEnvironment,
+    TTTargets,
+    main,
+)
+from ttsim.tt import ColumnFunction
+
+if TYPE_CHECKING:
+    from ttsim.typing import SpecEnvWithPartialledParamsAndScalars
+
+
+def get_orig_mettsim_column_functions() -> list[tuple[tuple[str, ...], ColumnFunction]]:
+    orig = main(
+        main_target=MainTarget.orig_policy_objects.column_objects_and_param_functions,
+        orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+    )
+    return [(tp, cf) for tp, cf in orig.items() if isinstance(cf, ColumnFunction)]
+
+
+@functools.lru_cache(maxsize=100)
+def cached_specialized_environment(
+    policy_date: datetime.date,
+    backend: Literal["numpy", "jax"],
+) -> SpecEnvWithPartialledParamsAndScalars:
+    return main(
+        main_target=(
+            "specialized_environment_for_plotting_and_templates",
+            "with_partialled_params_and_scalars",
+        ),
+        policy_date=policy_date,
+        orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        backend=backend,
+        include_fail_nodes=False,
+        include_warn_nodes=False,
+    )
+
+
+@pytest.mark.skipif_numpy
+@pytest.mark.parametrize(
+    ("tree_path", "fun"),
+    get_orig_mettsim_column_functions(),
+    ids=[str(x[0]) for x in get_orig_mettsim_column_functions()],
+)
+def test_jittable(tree_path, fun, backend, xnp):
+    policy_date = min(fun.end_date, datetime.date.today())  # noqa: DTZ011
+    qname = dt.qname_from_tree_path((*tree_path[:-2], fun.leaf_name))
+    env = {
+        qname: cached_specialized_environment(policy_date=policy_date, backend=backend)[
+            qname
+        ]
+    }
+
+    processed_data = {}
+    for arg_name in get_free_arguments(env[qname]):
+        arg = inspect.signature(env[qname]).parameters[arg_name]
+        if "FloatColumn" in arg.annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=float)
+        elif "IntColumn" in arg.annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=int)
+        elif "BoolColumn" in arg.annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=bool)
+        else:
+            raise ValueError(f"Unknown column type: {arg.annotation}")
+
+    if not fun.fail_msg_if_included:
+        main(
+            main_target=("raw_results", "columns_with_internal_p_ids"),
+            policy_date=policy_date,
+            specialized_environment=SpecializedEnvironment.with_partialled_params_and_scalars(
+                env
+            ),
+            processed_data=processed_data,
+            tt_targets=TTTargets.qname([qname]),
+            backend=backend,
+            include_fail_nodes=False,
+            include_warn_nodes=False,
+        )

--- a/tests/interface_dag_elements/test_endogenous_p_id_targets.py
+++ b/tests/interface_dag_elements/test_endogenous_p_id_targets.py
@@ -276,10 +276,10 @@ def test_endogenous_p_id_target_mixed_with_regular_column(
 def test_raw_results_columns_computable_from_processed_data_alone(
     xnp: ModuleType, backend: Literal["numpy", "jax"]
 ):
-    """Targeting `raw_results.columns` with `processed_data` and a pre-built
-    specialized environment must not require `input_data` (regression test
-    for #130). The remapping to user-space `p_id`s lives in
-    `raw_results.columns_with_remapped_ids`, which is pruned here.
+    """Targeting `raw_results.columns_with_internal_p_ids` with `processed_data`
+    and a pre-built specialized environment must not require `input_data`
+    (regression test for #130). The remapping to user-space `p_id`s lives in
+    `raw_results.columns_with_original_p_ids`, which is pruned here.
     """
     p_id_recipient = policy_function(
         start_date=_DATE,
@@ -302,7 +302,7 @@ def test_raw_results_columns_computable_from_processed_data_alone(
     )
 
     result = main(
-        main_target=MainTarget.raw_results.columns,
+        main_target=MainTarget.raw_results.columns_with_internal_p_ids,
         specialized_environment=(
             SpecializedEnvironment.with_partialled_params_and_scalars(
                 {"p_id_recipient": env["p_id_recipient"]}

--- a/tests/interface_dag_elements/test_endogenous_p_id_targets.py
+++ b/tests/interface_dag_elements/test_endogenous_p_id_targets.py
@@ -280,10 +280,10 @@ def test_jittable_with_specialized_environment_and_dummy_processed_data(
 ):
     """Jit-compile a single policy function from dummy `processed_data` and a
     pre-built specialized environment, without any `input_data` (regression
-    test for #130). This mirrors GETTSIM's `test_jittable`: the dummy data is
-    derived from the function's free arguments, and the target is
-    `raw_results.columns_with_internal_p_ids` so that the remapping to
-    user-space `p_id`s (`raw_results.columns_with_original_p_ids`) is pruned.
+    test for #130). The dummy data is derived from the function's free
+    arguments, and the target is `raw_results.columns_with_internal_p_ids` so
+    that the remapping to user-space `p_id`s
+    (`raw_results.columns_with_original_p_ids`) is pruned.
     """
     p_id_recipient = policy_function(
         start_date=_DATE,

--- a/tests/interface_dag_elements/test_endogenous_p_id_targets.py
+++ b/tests/interface_dag_elements/test_endogenous_p_id_targets.py
@@ -13,7 +13,13 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from ttsim import InputData, MainTarget, TTTargets, main
+from ttsim import (
+    InputData,
+    MainTarget,
+    SpecializedEnvironment,
+    TTTargets,
+    main,
+)
 from ttsim.tt import FKType, ScalarParam, policy_function, policy_input
 
 if TYPE_CHECKING:
@@ -265,3 +271,49 @@ def test_endogenous_p_id_target_mixed_with_regular_column(
         check_index_type=False,
         check_like=True,
     )
+
+
+def test_raw_results_columns_computable_from_processed_data_alone(
+    xnp: ModuleType, backend: Literal["numpy", "jax"]
+):
+    """Targeting `raw_results.columns` with `processed_data` and a pre-built
+    specialized environment must not require `input_data` (regression test
+    for #130). The remapping to user-space `p_id`s lives in
+    `raw_results.columns_with_remapped_ids`, which is pruned here.
+    """
+    p_id_recipient = policy_function(
+        start_date=_DATE,
+        end_date=_DATE,
+        leaf_name="p_id_recipient",
+    )(_identity)
+
+    env = main(
+        main_target=(
+            "specialized_environment_for_plotting_and_templates",
+            "with_partialled_params_and_scalars",
+        ),
+        policy_environment={
+            "p_id_recipient": p_id_recipient,
+            **_policy_year_month_day(),
+        },
+        backend=backend,
+        include_fail_nodes=False,
+        include_warn_nodes=False,
+    )
+
+    result = main(
+        main_target=MainTarget.raw_results.columns,
+        specialized_environment=(
+            SpecializedEnvironment.with_partialled_params_and_scalars(
+                {"p_id_recipient": env["p_id_recipient"]}
+            )
+        ),
+        processed_data={"p_id": xnp.array([0, 1, 2])},
+        tt_targets=TTTargets.qname(["p_id_recipient"]),
+        backend=backend,
+        include_fail_nodes=False,
+        include_warn_nodes=False,
+    )
+
+    # Raw results stay in internal representation: no remapping happens.
+    assert list(result["p_id_recipient"]) == [0, 1, 2]

--- a/tests/interface_dag_elements/test_endogenous_p_id_targets.py
+++ b/tests/interface_dag_elements/test_endogenous_p_id_targets.py
@@ -9,9 +9,11 @@ user-space `p_id` values before returning results.
 from __future__ import annotations
 
 import datetime
+import inspect
 from typing import TYPE_CHECKING
 
 import pandas as pd
+from dags import get_free_arguments
 
 from ttsim import (
     InputData,
@@ -273,13 +275,15 @@ def test_endogenous_p_id_target_mixed_with_regular_column(
     )
 
 
-def test_raw_results_columns_computable_from_processed_data_alone(
+def test_jittable_with_specialized_environment_and_dummy_processed_data(
     xnp: ModuleType, backend: Literal["numpy", "jax"]
 ):
-    """Targeting `raw_results.columns_with_internal_p_ids` with `processed_data`
-    and a pre-built specialized environment must not require `input_data`
-    (regression test for #130). The remapping to user-space `p_id`s lives in
-    `raw_results.columns_with_original_p_ids`, which is pruned here.
+    """Jit-compile a single policy function from dummy `processed_data` and a
+    pre-built specialized environment, without any `input_data` (regression
+    test for #130). This mirrors GETTSIM's `test_jittable`: the dummy data is
+    derived from the function's free arguments, and the target is
+    `raw_results.columns_with_internal_p_ids` so that the remapping to
+    user-space `p_id`s (`raw_results.columns_with_original_p_ids`) is pruned.
     """
     p_id_recipient = policy_function(
         start_date=_DATE,
@@ -287,7 +291,7 @@ def test_raw_results_columns_computable_from_processed_data_alone(
         leaf_name="p_id_recipient",
     )(_identity)
 
-    env = main(
+    full_env = main(
         main_target=(
             "specialized_environment_for_plotting_and_templates",
             "with_partialled_params_and_scalars",
@@ -300,15 +304,28 @@ def test_raw_results_columns_computable_from_processed_data_alone(
         include_fail_nodes=False,
         include_warn_nodes=False,
     )
+    env = {"p_id_recipient": full_env["p_id_recipient"]}
+
+    processed_data = {}
+    for arg_name in get_free_arguments(env["p_id_recipient"]):
+        annotation = str(
+            inspect.signature(env["p_id_recipient"]).parameters[arg_name].annotation
+        )
+        if "FloatColumn" in annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=float)
+        elif "IntColumn" in annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=int)
+        elif "BoolColumn" in annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=bool)
+        else:
+            raise ValueError(f"Unknown column type: {annotation}")
 
     result = main(
         main_target=MainTarget.raw_results.columns_with_internal_p_ids,
         specialized_environment=(
-            SpecializedEnvironment.with_partialled_params_and_scalars(
-                {"p_id_recipient": env["p_id_recipient"]}
-            )
+            SpecializedEnvironment.with_partialled_params_and_scalars(env)
         ),
-        processed_data={"p_id": xnp.array([0, 1, 2])},
+        processed_data=processed_data,
         tt_targets=TTTargets.qname(["p_id_recipient"]),
         backend=backend,
         include_fail_nodes=False,
@@ -316,4 +333,4 @@ def test_raw_results_columns_computable_from_processed_data_alone(
     )
 
     # Raw results stay in internal representation: no remapping happens.
-    assert list(result["p_id_recipient"]) == [0, 1, 2]
+    assert list(result["p_id_recipient"]) == [0]

--- a/tests/interface_dag_elements/test_endogenous_p_id_targets.py
+++ b/tests/interface_dag_elements/test_endogenous_p_id_targets.py
@@ -9,19 +9,11 @@ user-space `p_id` values before returning results.
 from __future__ import annotations
 
 import datetime
-import inspect
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from dags import get_free_arguments
 
-from ttsim import (
-    InputData,
-    MainTarget,
-    SpecializedEnvironment,
-    TTTargets,
-    main,
-)
+from ttsim import InputData, MainTarget, TTTargets, main
 from ttsim.tt import FKType, ScalarParam, policy_function, policy_input
 
 if TYPE_CHECKING:
@@ -273,64 +265,3 @@ def test_endogenous_p_id_target_mixed_with_regular_column(
         check_index_type=False,
         check_like=True,
     )
-
-
-def test_jittable_with_specialized_environment_and_dummy_processed_data(
-    xnp: ModuleType, backend: Literal["numpy", "jax"]
-):
-    """Jit-compile a single policy function from dummy `processed_data` and a
-    pre-built specialized environment, without any `input_data` (regression
-    test for #130). The dummy data is derived from the function's free
-    arguments, and the target is `raw_results.columns_with_internal_p_ids` so
-    that the remapping to user-space `p_id`s
-    (`raw_results.columns_with_original_p_ids`) is pruned.
-    """
-    p_id_recipient = policy_function(
-        start_date=_DATE,
-        end_date=_DATE,
-        leaf_name="p_id_recipient",
-    )(_identity)
-
-    full_env = main(
-        main_target=(
-            "specialized_environment_for_plotting_and_templates",
-            "with_partialled_params_and_scalars",
-        ),
-        policy_environment={
-            "p_id_recipient": p_id_recipient,
-            **_policy_year_month_day(),
-        },
-        backend=backend,
-        include_fail_nodes=False,
-        include_warn_nodes=False,
-    )
-    env = {"p_id_recipient": full_env["p_id_recipient"]}
-
-    processed_data = {}
-    for arg_name in get_free_arguments(env["p_id_recipient"]):
-        annotation = str(
-            inspect.signature(env["p_id_recipient"]).parameters[arg_name].annotation
-        )
-        if "FloatColumn" in annotation:
-            processed_data[arg_name] = xnp.zeros(1, dtype=float)
-        elif "IntColumn" in annotation:
-            processed_data[arg_name] = xnp.zeros(1, dtype=int)
-        elif "BoolColumn" in annotation:
-            processed_data[arg_name] = xnp.zeros(1, dtype=bool)
-        else:
-            raise ValueError(f"Unknown column type: {annotation}")
-
-    result = main(
-        main_target=MainTarget.raw_results.columns_with_internal_p_ids,
-        specialized_environment=(
-            SpecializedEnvironment.with_partialled_params_and_scalars(env)
-        ),
-        processed_data=processed_data,
-        tt_targets=TTTargets.qname(["p_id_recipient"]),
-        backend=backend,
-        include_fail_nodes=False,
-        include_warn_nodes=False,
-    )
-
-    # Raw results stay in internal representation: no remapping happens.
-    assert list(result["p_id_recipient"]) == [0]

--- a/tests/interface_dag_elements/test_failures.py
+++ b/tests/interface_dag_elements/test_failures.py
@@ -1641,7 +1641,7 @@ def test_fail_if_name_of_last_branch_element_is_not_the_functions_leaf_name(
     "main_target",
     [
         MainTarget.tt_function,
-        MainTarget.raw_results.columns,
+        MainTarget.raw_results.columns_with_internal_p_ids,
     ],
 )
 def test_raise_tt_root_nodes_are_missing_without_input_data(

--- a/tests/interface_dag_elements/test_raw_results.py
+++ b/tests/interface_dag_elements/test_raw_results.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import ttsim.interface_dag_elements
-from ttsim.interface_dag_elements.interface_node_objects import InterfaceFunction
 from ttsim.interface_dag_elements.orig_policy_objects import load_module
 
 # The package claw rewrites normally-imported `interface_dag_elements` modules,
@@ -21,10 +20,6 @@ params = _raw_results.params
 # =============================================================================
 # columns_with_internal_p_ids() function tests
 # =============================================================================
-def test_columns_with_internal_p_ids_is_interface_function():
-    assert isinstance(columns_with_internal_p_ids, InterfaceFunction)
-
-
 def test_columns_filters_to_root_nodes(xnp):
     processed_data = {
         "p_id": xnp.array([0, 1, 2]),
@@ -111,53 +106,33 @@ def test_columns_with_empty_root_nodes(xnp):
 # =============================================================================
 # columns_with_original_p_ids() function tests
 # =============================================================================
-def test_columns_with_original_p_ids_is_interface_function():
-    assert isinstance(columns_with_original_p_ids, InterfaceFunction)
+def test_columns_with_original_p_ids(xnp):
+    """Unit-level localizer for the remapping; end-to-end behavior is covered in
+    test_endogenous_p_id_targets.py.
 
-
-def test_columns_with_original_p_ids_translates_endogenous_p_id_columns(xnp):
-    # Original p_ids [20, 10, 30] sort to internal order [10, 20, 30],
-    # i.e. sort_indices [1, 0, 2]. Internal index i points to the person at
-    # internal position i, whose original p_id is sorted_orig_p_ids[i].
+    Endogenous `p_id_*` columns are gathered through the sorted original p_ids
+    (internal index i → sorted_orig_p_ids[i]); any negative value — not just
+    the canonical `-1` — collapses to the no-link sentinel; non-`p_id_*`
+    columns pass through untouched. Original p_ids are non-monotonic so a
+    dropped or misapplied `sort_indices` shows up.
+    """
     result = columns_with_original_p_ids(
-        columns_with_internal_p_ids={"p_id_recipient": xnp.array([0, 1, 2])},
-        input_data__flat={("p_id",): xnp.array([20, 10, 30])},
-        input_data__sort_indices=xnp.array([1, 0, 2]),
+        columns_with_internal_p_ids={
+            "p_id_recipient": xnp.array([0, -1, -2, 1]),
+            "income": xnp.array([100, 200, 300, 400]),
+        },
+        input_data__flat={("p_id",): xnp.array([20, 10, 30, 40])},
+        input_data__sort_indices=xnp.array([1, 0, 2, 3]),
         xnp=xnp,
     )
 
-    assert list(result["p_id_recipient"]) == [10, 20, 30]
-
-
-def test_columns_with_original_p_ids_collapses_negatives_to_sentinel(xnp):
-    result = columns_with_original_p_ids(
-        columns_with_internal_p_ids={"p_id_recipient": xnp.array([-1, -2, 1])},
-        input_data__flat={("p_id",): xnp.array([20, 10, 30])},
-        input_data__sort_indices=xnp.array([1, 0, 2]),
-        xnp=xnp,
-    )
-
-    assert list(result["p_id_recipient"]) == [-1, -1, 20]
-
-
-def test_columns_with_original_p_ids_leaves_other_columns_unchanged(xnp):
-    result = columns_with_original_p_ids(
-        columns_with_internal_p_ids={"income": xnp.array([100, 200, 300])},
-        input_data__flat={("p_id",): xnp.array([20, 10, 30])},
-        input_data__sort_indices=xnp.array([1, 0, 2]),
-        xnp=xnp,
-    )
-
-    assert list(result["income"]) == [100, 200, 300]
+    assert list(result["p_id_recipient"]) == [10, -1, -1, 20]
+    assert list(result["income"]) == [100, 200, 300, 400]
 
 
 # =============================================================================
 # from_input_data() function tests
 # =============================================================================
-def test_from_input_data_is_interface_function():
-    assert isinstance(from_input_data, InterfaceFunction)
-
-
 def test_from_input_data_extracts_requested_targets(xnp):
     input_data__flat = {
         ("p_id",): xnp.array([0, 1, 2]),
@@ -242,10 +217,6 @@ def test_from_input_data_returns_arrays_unsorted(xnp):
 # =============================================================================
 # params() function tests
 # =============================================================================
-def test_params_is_interface_function():
-    assert isinstance(params, InterfaceFunction)
-
-
 def test_params_extracts_requested_param_targets():
     specialized_env = {
         "param_a": 100,

--- a/tests/interface_dag_elements/test_raw_results.py
+++ b/tests/interface_dag_elements/test_raw_results.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import ttsim.interface_dag_elements
+from ttsim.interface_dag_elements.interface_node_objects import InterfaceFunction
 from ttsim.interface_dag_elements.orig_policy_objects import load_module
 
 # The package claw rewrites normally-imported `interface_dag_elements` modules,
@@ -20,6 +21,10 @@ params = _raw_results.params
 # =============================================================================
 # columns_with_internal_p_ids() function tests
 # =============================================================================
+def test_columns_with_internal_p_ids_is_interface_function():
+    assert isinstance(columns_with_internal_p_ids, InterfaceFunction)
+
+
 def test_columns_filters_to_root_nodes(xnp):
     processed_data = {
         "p_id": xnp.array([0, 1, 2]),
@@ -106,6 +111,10 @@ def test_columns_with_empty_root_nodes(xnp):
 # =============================================================================
 # columns_with_original_p_ids() function tests
 # =============================================================================
+def test_columns_with_original_p_ids_is_interface_function():
+    assert isinstance(columns_with_original_p_ids, InterfaceFunction)
+
+
 def test_columns_with_original_p_ids(xnp):
     """Unit-level localizer for the remapping; end-to-end behavior is covered in
     test_endogenous_p_id_targets.py.
@@ -133,6 +142,10 @@ def test_columns_with_original_p_ids(xnp):
 # =============================================================================
 # from_input_data() function tests
 # =============================================================================
+def test_from_input_data_is_interface_function():
+    assert isinstance(from_input_data, InterfaceFunction)
+
+
 def test_from_input_data_extracts_requested_targets(xnp):
     input_data__flat = {
         ("p_id",): xnp.array([0, 1, 2]),
@@ -217,6 +230,10 @@ def test_from_input_data_returns_arrays_unsorted(xnp):
 # =============================================================================
 # params() function tests
 # =============================================================================
+def test_params_is_interface_function():
+    assert isinstance(params, InterfaceFunction)
+
+
 def test_params_extracts_requested_param_targets():
     specialized_env = {
         "param_a": 100,

--- a/tests/interface_dag_elements/test_raw_results.py
+++ b/tests/interface_dag_elements/test_raw_results.py
@@ -13,6 +13,7 @@ from ttsim.interface_dag_elements.orig_policy_objects import load_module
 _IFACE_DIR = Path(ttsim.interface_dag_elements.__file__).parent
 _raw_results = load_module(path=_IFACE_DIR / "raw_results.py", root=_IFACE_DIR)
 columns = _raw_results.columns
+columns_with_remapped_ids = _raw_results.columns_with_remapped_ids
 from_input_data = _raw_results.from_input_data
 params = _raw_results.params
 
@@ -22,18 +23,6 @@ params = _raw_results.params
 # =============================================================================
 def test_columns_is_interface_function():
     assert isinstance(columns, InterfaceFunction)
-
-
-def _identity_p_id_inputs(xnp, n: int) -> dict:
-    """Minimal `input_data__flat` + sort indices for tests that don't care
-    about row order — the original `p_id` array is already sorted, so the
-    sort is the identity permutation.
-    """
-    return {
-        "input_data__flat": {("p_id",): xnp.arange(n)},
-        "input_data__sort_indices": xnp.arange(n),
-        "xnp": xnp,
-    }
 
 
 def test_columns_filters_to_root_nodes(xnp):
@@ -52,7 +41,6 @@ def test_columns_filters_to_root_nodes(xnp):
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
-        **_identity_p_id_inputs(xnp, n=3),
     )
 
     # Only root_nodes should be passed to tt_function
@@ -78,7 +66,6 @@ def test_columns_calls_tt_function_with_filtered_data(xnp):
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
-        **_identity_p_id_inputs(xnp, n=2),
     )
 
     # Verify tt_function was called with only root_nodes data
@@ -100,7 +87,6 @@ def test_columns_returns_tt_function_output(xnp):
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
-        **_identity_p_id_inputs(xnp, n=2),
     )
 
     assert result == expected_output
@@ -117,10 +103,52 @@ def test_columns_with_empty_root_nodes(xnp):
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
-        **_identity_p_id_inputs(xnp, n=2),
     )
 
     assert result == {}
+
+
+# =============================================================================
+# columns_with_remapped_ids() function tests
+# =============================================================================
+def test_columns_with_remapped_ids_is_interface_function():
+    assert isinstance(columns_with_remapped_ids, InterfaceFunction)
+
+
+def test_columns_with_remapped_ids_translates_endogenous_p_id_columns(xnp):
+    # Original p_ids [20, 10, 30] sort to internal order [10, 20, 30],
+    # i.e. sort_indices [1, 0, 2]. Internal index i points to the person at
+    # internal position i, whose original p_id is sorted_orig_p_ids[i].
+    result = columns_with_remapped_ids(
+        columns={"p_id_recipient": xnp.array([0, 1, 2])},
+        input_data__flat={("p_id",): xnp.array([20, 10, 30])},
+        input_data__sort_indices=xnp.array([1, 0, 2]),
+        xnp=xnp,
+    )
+
+    assert list(result["p_id_recipient"]) == [10, 20, 30]
+
+
+def test_columns_with_remapped_ids_collapses_negatives_to_sentinel(xnp):
+    result = columns_with_remapped_ids(
+        columns={"p_id_recipient": xnp.array([-1, -2, 1])},
+        input_data__flat={("p_id",): xnp.array([20, 10, 30])},
+        input_data__sort_indices=xnp.array([1, 0, 2]),
+        xnp=xnp,
+    )
+
+    assert list(result["p_id_recipient"]) == [-1, -1, 20]
+
+
+def test_columns_with_remapped_ids_leaves_other_columns_unchanged(xnp):
+    result = columns_with_remapped_ids(
+        columns={"income": xnp.array([100, 200, 300])},
+        input_data__flat={("p_id",): xnp.array([20, 10, 30])},
+        input_data__sort_indices=xnp.array([1, 0, 2]),
+        xnp=xnp,
+    )
+
+    assert list(result["income"]) == [100, 200, 300]
 
 
 # =============================================================================
@@ -306,6 +334,12 @@ def test_columns_dependencies():
         "labels__root_nodes",
         "processed_data",
         "tt_function",
+    }
+
+
+def test_columns_with_remapped_ids_dependencies():
+    assert columns_with_remapped_ids.dependencies == {
+        "columns",
         "input_data__flat",
         "input_data__sort_indices",
         "xnp",

--- a/tests/interface_dag_elements/test_raw_results.py
+++ b/tests/interface_dag_elements/test_raw_results.py
@@ -115,30 +115,6 @@ def test_columns_with_original_p_ids_is_interface_function():
     assert isinstance(columns_with_original_p_ids, InterfaceFunction)
 
 
-def test_columns_with_original_p_ids(xnp):
-    """Unit-level localizer for the remapping; end-to-end behavior is covered in
-    test_endogenous_p_id_targets.py.
-
-    Endogenous `p_id_*` columns are gathered through the sorted original p_ids
-    (internal index i → sorted_orig_p_ids[i]); any negative value — not just
-    the canonical `-1` — collapses to the no-link sentinel; non-`p_id_*`
-    columns pass through untouched. Original p_ids are non-monotonic so a
-    dropped or misapplied `sort_indices` shows up.
-    """
-    result = columns_with_original_p_ids(
-        columns_with_internal_p_ids={
-            "p_id_recipient": xnp.array([0, -1, -2, 1]),
-            "income": xnp.array([100, 200, 300, 400]),
-        },
-        input_data__flat={("p_id",): xnp.array([20, 10, 30, 40])},
-        input_data__sort_indices=xnp.array([1, 0, 2, 3]),
-        xnp=xnp,
-    )
-
-    assert list(result["p_id_recipient"]) == [10, -1, -1, 20]
-    assert list(result["income"]) == [100, 200, 300, 400]
-
-
 # =============================================================================
 # from_input_data() function tests
 # =============================================================================

--- a/tests/interface_dag_elements/test_raw_results.py
+++ b/tests/interface_dag_elements/test_raw_results.py
@@ -12,17 +12,17 @@ from ttsim.interface_dag_elements.orig_policy_objects import load_module
 # these objects — to assert on the pristine instances.
 _IFACE_DIR = Path(ttsim.interface_dag_elements.__file__).parent
 _raw_results = load_module(path=_IFACE_DIR / "raw_results.py", root=_IFACE_DIR)
-columns = _raw_results.columns
-columns_with_remapped_ids = _raw_results.columns_with_remapped_ids
+columns_with_internal_p_ids = _raw_results.columns_with_internal_p_ids
+columns_with_original_p_ids = _raw_results.columns_with_original_p_ids
 from_input_data = _raw_results.from_input_data
 params = _raw_results.params
 
 
 # =============================================================================
-# columns() function tests
+# columns_with_internal_p_ids() function tests
 # =============================================================================
-def test_columns_is_interface_function():
-    assert isinstance(columns, InterfaceFunction)
+def test_columns_with_internal_p_ids_is_interface_function():
+    assert isinstance(columns_with_internal_p_ids, InterfaceFunction)
 
 
 def test_columns_filters_to_root_nodes(xnp):
@@ -37,7 +37,7 @@ def test_columns_filters_to_root_nodes(xnp):
     def tt_function(data):
         return data
 
-    result = columns(
+    result = columns_with_internal_p_ids(
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
@@ -62,7 +62,7 @@ def test_columns_calls_tt_function_with_filtered_data(xnp):
         call_args.append(data)
         return {"output": xnp.array([1, 2])}
 
-    columns(
+    columns_with_internal_p_ids(
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
@@ -83,7 +83,7 @@ def test_columns_returns_tt_function_output(xnp):
     def tt_function(_data):
         return expected_output
 
-    result = columns(
+    result = columns_with_internal_p_ids(
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
@@ -99,7 +99,7 @@ def test_columns_with_empty_root_nodes(xnp):
     def tt_function(data):
         return data
 
-    result = columns(
+    result = columns_with_internal_p_ids(
         labels__root_nodes=root_nodes,
         processed_data=processed_data,
         tt_function=tt_function,
@@ -109,18 +109,18 @@ def test_columns_with_empty_root_nodes(xnp):
 
 
 # =============================================================================
-# columns_with_remapped_ids() function tests
+# columns_with_original_p_ids() function tests
 # =============================================================================
-def test_columns_with_remapped_ids_is_interface_function():
-    assert isinstance(columns_with_remapped_ids, InterfaceFunction)
+def test_columns_with_original_p_ids_is_interface_function():
+    assert isinstance(columns_with_original_p_ids, InterfaceFunction)
 
 
-def test_columns_with_remapped_ids_translates_endogenous_p_id_columns(xnp):
+def test_columns_with_original_p_ids_translates_endogenous_p_id_columns(xnp):
     # Original p_ids [20, 10, 30] sort to internal order [10, 20, 30],
     # i.e. sort_indices [1, 0, 2]. Internal index i points to the person at
     # internal position i, whose original p_id is sorted_orig_p_ids[i].
-    result = columns_with_remapped_ids(
-        columns={"p_id_recipient": xnp.array([0, 1, 2])},
+    result = columns_with_original_p_ids(
+        columns_with_internal_p_ids={"p_id_recipient": xnp.array([0, 1, 2])},
         input_data__flat={("p_id",): xnp.array([20, 10, 30])},
         input_data__sort_indices=xnp.array([1, 0, 2]),
         xnp=xnp,
@@ -129,9 +129,9 @@ def test_columns_with_remapped_ids_translates_endogenous_p_id_columns(xnp):
     assert list(result["p_id_recipient"]) == [10, 20, 30]
 
 
-def test_columns_with_remapped_ids_collapses_negatives_to_sentinel(xnp):
-    result = columns_with_remapped_ids(
-        columns={"p_id_recipient": xnp.array([-1, -2, 1])},
+def test_columns_with_original_p_ids_collapses_negatives_to_sentinel(xnp):
+    result = columns_with_original_p_ids(
+        columns_with_internal_p_ids={"p_id_recipient": xnp.array([-1, -2, 1])},
         input_data__flat={("p_id",): xnp.array([20, 10, 30])},
         input_data__sort_indices=xnp.array([1, 0, 2]),
         xnp=xnp,
@@ -140,9 +140,9 @@ def test_columns_with_remapped_ids_collapses_negatives_to_sentinel(xnp):
     assert list(result["p_id_recipient"]) == [-1, -1, 20]
 
 
-def test_columns_with_remapped_ids_leaves_other_columns_unchanged(xnp):
-    result = columns_with_remapped_ids(
-        columns={"income": xnp.array([100, 200, 300])},
+def test_columns_with_original_p_ids_leaves_other_columns_unchanged(xnp):
+    result = columns_with_original_p_ids(
+        columns_with_internal_p_ids={"income": xnp.array([100, 200, 300])},
         input_data__flat={("p_id",): xnp.array([20, 10, 30])},
         input_data__sort_indices=xnp.array([1, 0, 2]),
         xnp=xnp,
@@ -329,17 +329,17 @@ def test_params_returns_various_value_types():
 # =============================================================================
 # Dependencies property tests
 # =============================================================================
-def test_columns_dependencies():
-    assert columns.dependencies == {
+def test_columns_with_internal_p_ids_dependencies():
+    assert columns_with_internal_p_ids.dependencies == {
         "labels__root_nodes",
         "processed_data",
         "tt_function",
     }
 
 
-def test_columns_with_remapped_ids_dependencies():
-    assert columns_with_remapped_ids.dependencies == {
-        "columns",
+def test_columns_with_original_p_ids_dependencies():
+    assert columns_with_original_p_ids.dependencies == {
+        "columns_with_internal_p_ids",
         "input_data__flat",
         "input_data__sort_indices",
         "xnp",

--- a/tests/interface_dag_elements/test_results.py
+++ b/tests/interface_dag_elements/test_results.py
@@ -141,7 +141,7 @@ def test_restore_original_row_order(
 ):
     """Test that the tree function restores original row order correctly."""
     result = tree(
-        raw_results__columns=raw_results_columns,
+        raw_results__columns_with_remapped_ids=raw_results_columns,
         raw_results__params=raw_results_params,
         raw_results__from_input_data=raw_results_from_input_data,
         input_data__sort_indices=input_data__sort_indices,

--- a/tests/interface_dag_elements/test_results.py
+++ b/tests/interface_dag_elements/test_results.py
@@ -141,7 +141,7 @@ def test_restore_original_row_order(
 ):
     """Test that the tree function restores original row order correctly."""
     result = tree(
-        raw_results__columns_with_remapped_ids=raw_results_columns,
+        raw_results__columns_with_original_p_ids=raw_results_columns,
         raw_results__params=raw_results_params,
         raw_results__from_input_data=raw_results_from_input_data,
         input_data__sort_indices=input_data__sort_indices,

--- a/tests/interface_dag_elements/test_warnings.py
+++ b/tests/interface_dag_elements/test_warnings.py
@@ -147,7 +147,7 @@ def test_warn_if_evaluation_date_set_in_multiple_places_implicitly_added(backend
     }
     with pytest.warns(match="You have specified the evaluation date in more than one"):
         main(
-            main_target=MainTarget.raw_results.columns,
+            main_target=MainTarget.raw_results.columns_with_internal_p_ids,
             policy_environment=policy_environment,
             evaluation_date=datetime.date(2025, 1, 1),
             processed_data={"p_id": xnp.array([0])},
@@ -168,7 +168,7 @@ def test_do_not_need_to_warn_if_evaluation_date_is_set_only_once(backend, xnp):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         main(
-            main_target=MainTarget.raw_results.columns,
+            main_target=MainTarget.raw_results.columns_with_internal_p_ids,
             policy_environment=policy_environment,
             evaluation_date=datetime.date(2025, 1, 1),
             processed_data={"p_id": xnp.array([0])},

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -330,8 +330,12 @@ def test_input_data_classmethods(instance_factory, expected_field_name, xnp):
         ),
         # RawResults
         (
-            lambda xnp: RawResults.columns({"test": xnp.array([1, 2, 3])}),
-            lambda xnp: RawResults(columns={"test": xnp.array([1, 2, 3])}),  # ty: ignore[unknown-argument]
+            lambda xnp: RawResults.columns_with_internal_p_ids(
+                {"test": xnp.array([1, 2, 3])}
+            ),
+            lambda xnp: RawResults(
+                columns_with_internal_p_ids={"test": xnp.array([1, 2, 3])}  # ty: ignore[unknown-argument]
+            ),
         ),
         (
             lambda xnp: RawResults.params({"param": xnp.array([4, 5, 6])}),


### PR DESCRIPTION
Closes #130.

- Split `raw_results.columns` into `raw_results.columns_with_internal_p_ids` (computable from `processed_data` alone, endogenous `p_id_*` columns hold internal indices) and `raw_results.columns_with_original_p_ids` (the reverse-translation from #108, consumed by `results.tree`, so all `results.*` outputs keep returning user-space `p_id`s).
- Both nodes are exposed via `MainTarget` and the `RawResults` main arg.
- New `src_mettsim/tests_middle_earth/test_jittability.py` exercises the `processed_data`-only path over all mettsim column functions.
- Breaking: the target `raw_results.columns` no longer exists; downstream switches to `columns_with_internal_p_ids` (ttsim-dev/gettsim#1196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)