### PR TITLE
Restore PLR vectorization guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,8 @@ per-file-ignores."src/ttsim/typing.py" = [
   "PYI051", # Redundant literal union
 ]
 per-file-ignores."src_mettsim/mettsim/middle_earth/**/*.py" = [
+  "PLR1714", # Consider merging multiple comparisons with `in` — not vectorizable
+  "PLR1716", # Boolean expression may be simplified with chained comparison — not vectorizable
   "PLR2004", # Magic value comparison
   "RET505",  # Vectorizer requires both if/else branches; it rejects the early-return form
 ]

--- a/src_mettsim/mettsim/middle_earth/demographics.py
+++ b/src_mettsim/mettsim/middle_earth/demographics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ttsim.tt import AggType, agg_by_group_function
+from ttsim.tt import AggType, agg_by_group_function, policy_function
 
 
 @agg_by_group_function(agg_type=AggType.COUNT)
@@ -8,3 +8,13 @@ def number_of_individuals_kin(
     kin_id: int,  # noqa: ARG001
 ) -> int:
     return 1
+
+
+@policy_function(vectorization_strategy="vectorize")
+def coming_of_age_celebration(age: int) -> bool:
+    """Whether the person reaches a coming-of-age milestone this year.
+
+    Hobbits come of age at 33 and famously celebrate their eleventy-first
+    (111th) birthday.
+    """
+    return age == 33 or age == 111

--- a/src_mettsim/mettsim/middle_earth/housing_benefits/eligibility/eligibility.py
+++ b/src_mettsim/mettsim/middle_earth/housing_benefits/eligibility/eligibility.py
@@ -80,3 +80,12 @@ def adult(
     max_age_children: int,
 ) -> bool:
     return age > max_age_children
+
+
+@policy_function(vectorization_strategy="vectorize")
+def young_adult(
+    age: int,
+    max_age_children: int,
+) -> bool:
+    """Whether the person is a young adult: past child age but not yet of age."""
+    return max_age_children < age and age < 33


### PR DESCRIPTION
### What problem do you want to solve?

Some guards are used in GETTSIM but not here. Added examples to METTSIM and the corresponding ignores to pyproject.toml.
