### PR TITLE
GEP 10: per-policy-system unit registries

### DIFF
--- a/src/ttsim/entry_point.py
+++ b/src/ttsim/entry_point.py
@@ -39,6 +39,7 @@ from ttsim.main_args import (
     TTTargets,
 )
 from ttsim.main_target import MainTarget, MainTargetABC
+from ttsim.tt.currencies import UnitSystem
 from ttsim.typing import (
     DashedISOString,
     FlatInterfaceObjects,
@@ -68,6 +69,7 @@ def main(
     tt_targets: TTTargets | None = None,
     rounding: bool = True,
     backend: Literal["numpy", "jax"] = "numpy",
+    unit_system: UnitSystem | None = None,
     data_currency: str | None = None,
     evaluation_date_str: DashedISOString | None = None,
     include_fail_nodes: bool = True,

--- a/src/ttsim/interface_dag_elements/currency.py
+++ b/src/ttsim/interface_dag_elements/currency.py
@@ -1,31 +1,28 @@
 from __future__ import annotations
 
 import datetime
-from typing import Literal
 
 from ttsim.interface_dag_elements.interface_node_objects import interface_function
-from ttsim.tt.currencies import base_currency, statutory_currency_for_date
+from ttsim.tt.currencies import UnitSystem
 
 
 @interface_function(leaf_name="data_currency", in_top_level_namespace=True)
-def data_currency(
-    backend: Literal["numpy", "jax"],  # noqa: ARG001
-) -> str:
+def data_currency(unit_system: UnitSystem) -> str:
     """The currency the user's data arrives in and results are returned in.
 
-    Defaults to the registered base currency. Override via ``main(data_currency=...)``
-    with another registered currency. Only input and output data are affected: input
-    columns are converted from this currency into the computation currency, and
-    currency-denominated results are converted back.
+    Defaults to the policy system's base currency. Override via
+    ``main(data_currency=...)`` with another of the system's currencies. Only
+    input and output data are affected: input columns are converted from this
+    currency into the computation currency, and currency-denominated results are
+    converted back.
     """
-    return base_currency()
+    return unit_system.base_currency
 
 
 @interface_function(leaf_name="computation_currency", in_top_level_namespace=True)
-def computation_currency(policy_date: datetime.date) -> str:
+def computation_currency(policy_date: datetime.date, unit_system: UnitSystem) -> str:
     """The currency the computation runs in — the policy date's statutory currency.
 
-    Read off the dated mapping a downstream package registers on import
-    (``register_statutory_currencies``).
+    Read off the dated mapping the policy system declares.
     """
-    return statutory_currency_for_date(policy_date)
+    return unit_system.statutory_currency_for_date(policy_date)

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -42,6 +42,7 @@ from ttsim.tt.column_objects_param_function import (
     ParamFunction,
     PolicyInput,
 )
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.param_objects import (
     PLACEHOLDER_FIELD,
     PLACEHOLDER_VALUE,
@@ -1000,6 +1001,7 @@ def tt_units_are_inconsistent(
     specialized_environment__without_tree_logic_and_with_derived_functions: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
     labels__grouping_levels: OrderedQNames,
     unit_checks__resolved_units: dict[str, pint.Unit | dict[str | int, Any]],
+    unit_system: UnitSystem,
 ) -> None:
     """Fail if a function body infers a unit that contradicts its declaration.
 
@@ -1017,6 +1019,7 @@ def tt_units_are_inconsistent(
     fail_if_environment_units_are_inconsistent(
         env=specialized_environment__without_tree_logic_and_with_derived_functions,
         grouping_levels=labels__grouping_levels,
+        unit_system=unit_system,
         resolved_units=unit_checks__resolved_units,
     )
 
@@ -1046,8 +1049,8 @@ def input_currency_is_not_concrete(
     """Fail if a currency-bearing input column names the agnostic ``CURRENCY``.
 
     Input data, like a parameter, is written in a concrete currency: a currency
-    column must name one (``Unit.EUR``, ``Unit.DM``), never the agnostic
-    ``Unit.CURRENCY`` — which would leave the run unable to tell what the numbers
+    column must name one (``TTSIMUnit.EUR``, ``TTSIMUnit.DM``), never the agnostic
+    ``TTSIMUnit.CURRENCY`` — which would leave the run unable to tell what the numbers
     are denominated in. (Columns and functions are the opposite: agnostic only.)
 
     Raises:
@@ -1063,8 +1066,8 @@ def input_currency_is_not_concrete(
     if agnostic:
         raise UnitConsistencyError(
             "Input data is denominated in a concrete currency, so a currency "
-            "column must name one (e.g. Unit.EUR, Unit.DM), not the agnostic "
-            f"Unit.CURRENCY (GEP 10). These name the agnostic currency: "
+            "column must name one (e.g. TTSIMUnit.EUR, TTSIMUnit.DM), not the agnostic "
+            f"TTSIMUnit.CURRENCY (GEP 10). These name the agnostic currency: "
             f"{', '.join(agnostic)}."
         )
 
@@ -1075,6 +1078,7 @@ def input_currency_is_not_concrete(
 def input_units_are_inconsistent(
     input_data__units: dict[str, pint.Unit],
     unit_checks__resolved_units: dict[str, pint.Unit | dict[str | int, Any]],
+    unit_system: UnitSystem,
 ) -> None:
     """Fail if a tagged input column's unit contradicts its declared unit.
 
@@ -1089,6 +1093,7 @@ def input_units_are_inconsistent(
     fail_if_input_units_are_inconsistent(
         input_units=input_data__units,
         resolved_units=unit_checks__resolved_units,
+        unit_system=unit_system,
     )
 
 

--- a/src/ttsim/interface_dag_elements/input_data.py
+++ b/src/ttsim/interface_dag_elements/input_data.py
@@ -20,8 +20,8 @@ from ttsim.interface_dag_elements.interface_node_objects import (
 from ttsim.interface_dag_elements.processed_data import (
     _canonicalize_input_dtype,
 )
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.units import (
-    UNIT_REGISTRY,
     input_strip_unit,
     resolve_compositional_unit,
     strip_input_quantity_at_boundary,
@@ -82,9 +82,11 @@ def tree_with_unit_annotations() -> NestedData:
     Example::
 
         {
-            "wage_m": UnitAnnotatedColumn(values, unit=Unit.EUR.PER_MONTH),
-            "rent_m_bg": UnitAnnotatedColumn(values, unit=Unit.EUR.PER_MONTH.PER_BG),
-            "p_id": UnitAnnotatedColumn(values, unit=Unit.DIMENSIONLESS),
+            "wage_m": UnitAnnotatedColumn(values, unit=TTSIMUnit.EUR.PER_MONTH),
+            "rent_m_bg": UnitAnnotatedColumn(
+                values, unit=TTSIMUnit.EUR.PER_MONTH.PER_BG
+            ),
+            "p_id": UnitAnnotatedColumn(values, unit=TTSIMUnit.DIMENSIONLESS),
         }
     """
 
@@ -200,13 +202,18 @@ def flat_from_qname(
 def flat_from_tree_with_unit_annotations(
     tree_with_unit_annotations: NestedData,
     data_currency: str,
+    unit_system: UnitSystem,
 ) -> FlatData:
     """The input data as a flat dictionary of arrays."""
+    registry = unit_system.registry
     flat = dt.flatten_to_tree_paths(tree_with_unit_annotations)
     return {
         path: strip_input_quantity_at_boundary(
-            quantity=UNIT_REGISTRY.Quantity(col.values, input_strip_unit(col.unit)),
+            quantity=registry.Quantity(
+                col.values, input_strip_unit(unit=col.unit, registry=registry)
+            ),
             data_currency=data_currency,
+            registry=registry,
             column_label=dt.qname_from_tree_path(path),
         )
         for path, col in flat.items()
@@ -219,6 +226,7 @@ def flat_from_tree_with_unit_annotations(
 )
 def units_from_tree_with_unit_annotations(
     tree_with_unit_annotations: NestedData,
+    unit_system: UnitSystem,
 ) -> dict[str, pint.Unit]:
     """Each input column's resolved (agnostic) tag, with its grouping level, by qname.
 
@@ -230,7 +238,7 @@ def units_from_tree_with_unit_annotations(
     flat = dt.flatten_to_tree_paths(tree_with_unit_annotations)
     return {
         dt.qname_from_tree_path(path): resolve_compositional_unit(
-            unit=col.unit, with_level=True
+            unit=col.unit, registry=unit_system.registry, with_level=True
         )
         for path, col in flat.items()
     }

--- a/src/ttsim/interface_dag_elements/processed_data.py
+++ b/src/ttsim/interface_dag_elements/processed_data.py
@@ -12,7 +12,7 @@ from jaxtyping import Shaped
 
 from ttsim.interface_dag_elements.interface_node_objects import interface_function
 from ttsim.tt.column_objects_param_function import reorder_ids
-from ttsim.tt.currencies import currency_conversion_factor
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.units import (
     UNSET_UNIT,
     CompositeUnit,
@@ -36,6 +36,7 @@ def _canonicalize_input_dtype(
     *,
     column_label: str | None = None,
     data_currency: str | None = None,
+    registry: pint.UnitRegistry | None = None,
 ) -> Shaped[Array | np.ndarray, " n_obs"]:
     """Canonicalize a column to a backend-native dtype the TT DAG can operate on.
 
@@ -61,11 +62,13 @@ def _canonicalize_input_dtype(
     """
     if isinstance(arr, pint.Quantity):
         # A pint-tagged column only ever reaches here via `processed_data`, which
-        # always has a concrete data currency; the currency-less converter callers
-        # (`data_converters`, plain `pd.Series` leaves) never pass a `Quantity`.
+        # always has a concrete data currency and registry; the currency-less
+        # converter callers (`data_converters`, plain `pd.Series` leaves) never
+        # pass a `Quantity`.
         arr = strip_input_quantity_at_boundary(
             quantity=arr,
             data_currency=cast("str", data_currency),
+            registry=cast("pint.UnitRegistry", registry),
             column_label=column_label,
         )
     if isinstance(arr, pd.Series):
@@ -158,6 +161,7 @@ def currency_conversion_factor_and_columns(
     specialized_environment: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
     source_currency: str,
     target_currency: str,
+    unit_system: UnitSystem,
 ) -> tuple[float, set[str]]:
     """The conversion factor and the columns it applies to.
 
@@ -168,7 +172,7 @@ def currency_conversion_factor_and_columns(
     """
     if source_currency == target_currency:
         return 1.0, set()
-    factor = currency_conversion_factor(
+    factor = unit_system.currency_conversion_factor(
         source_currency=source_currency, target_currency=target_currency
     )
     currency_qnames = qnames_with_currency_declarations(
@@ -206,6 +210,7 @@ def processed_data(
     specialized_environment__without_tree_logic_and_with_derived_functions: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,  # noqa: E501
     data_currency: str,
     computation_currency: str,
+    unit_system: UnitSystem,
 ) -> QNameData:
     """The internal processed data for use in the taxes and transfers function.
 
@@ -226,6 +231,7 @@ def processed_data(
         ),
         source_currency=data_currency,
         target_currency=computation_currency,
+        unit_system=unit_system,
     )
 
     orig_p_ids = _canonicalize_input_dtype(
@@ -233,6 +239,7 @@ def processed_data(
         xnp=xnp,
         column_label="p_id",
         data_currency=data_currency,
+        registry=unit_system.registry,
     )
     sorted_orig_p_ids = orig_p_ids[input_data__sort_indices]
     internal_p_ids = xnp.arange(len(orig_p_ids))
@@ -257,6 +264,7 @@ def processed_data(
             xnp=xnp,
             column_label=qname,
             data_currency=data_currency,
+            registry=unit_system.registry,
         )
 
         if path[-1].endswith("_id"):

--- a/src/ttsim/interface_dag_elements/results.py
+++ b/src/ttsim/interface_dag_elements/results.py
@@ -17,6 +17,7 @@ from ttsim.interface_dag_elements.processed_data import (
     currency_conversion_factor_and_columns,
     value_in_target_currency,
 )
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.units import (
     UnitAnnotatedColumn,
     composite_from_resolved_unit,
@@ -45,6 +46,7 @@ def tree(
     specialized_environment__without_tree_logic_and_with_derived_functions: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,  # noqa: E501
     data_currency: str,
     computation_currency: str,
+    unit_system: UnitSystem,
 ) -> NestedResults:
     """The combined results as a tree with original row order restored.
 
@@ -60,6 +62,7 @@ def tree(
         ),
         source_currency=computation_currency,
         target_currency=data_currency,
+        unit_system=unit_system,
     )
 
     restore_order = numpy.empty(len(input_data__sort_indices), dtype=int)
@@ -95,6 +98,7 @@ def tree_with_unit_annotations(
     unit_checks__resolved_units: dict[str, pint.Unit | dict[str | int, Any]],
     data_currency: str,
     computation_currency: str,
+    unit_system: UnitSystem,
 ) -> NestedResults:
     """The combined results as a tree of :class:`UnitAnnotatedColumn` leaves.
 
@@ -108,6 +112,7 @@ def tree_with_unit_annotations(
 
     A leaf with no resolved unit is left bare.
     """
+    registry = unit_system.registry
     resolved = unit_checks__resolved_units
     tagged: dict[str, Any] = {}
     for qname, value in dt.flatten_to_qnames(tree).items():
@@ -117,19 +122,19 @@ def tree_with_unit_annotations(
             continue
         if qname in raw_results__from_input_data:
             result_unit = input_target_unit_in_data_currency(
-                units=unit, data_currency=data_currency
+                units=unit, data_currency=data_currency, registry=registry
             )
         elif qname in raw_results__params:
             result_unit = param_unit_in_computation_currency(
-                units=unit, computation_currency=computation_currency
+                units=unit, computation_currency=computation_currency, registry=registry
             )
         else:
             result_unit = output_unit_in_data_currency(
-                units=unit, data_currency=data_currency
+                units=unit, data_currency=data_currency, registry=registry
             )
         tagged[qname] = UnitAnnotatedColumn(
             values=value,
-            unit=composite_from_resolved_unit(result_unit),
+            unit=composite_from_resolved_unit(units=result_unit, registry=registry),
         )
     return dt.unflatten_from_qnames(tagged)
 

--- a/src/ttsim/interface_dag_elements/specialized_environment_for_plotting_and_templates.py
+++ b/src/ttsim/interface_dag_elements/specialized_environment_for_plotting_and_templates.py
@@ -39,7 +39,7 @@ from ttsim.tt.column_objects_param_function import (
     policy_function,
 )
 from ttsim.tt.param_objects import ParamObject
-from ttsim.tt.units import Unit
+from ttsim.tt.units import TTSIMUnit
 from ttsim.typing import (
     OrderedQNames,
     PolicyEnvironment,
@@ -283,7 +283,7 @@ def dummy_callable(
             end_date=obj.end_date,
             # Placeholder: a ParamObject's unit may be a per-leaf mapping the
             # decorator would reject, and this dummy node's unit is never checked.
-            unit=Unit.DIMENSIONLESS,
+            unit=TTSIMUnit.DIMENSIONLESS,
         )(dummy)
     if isinstance(obj, InterfaceInput):
         original_docstring = obj.docstring

--- a/src/ttsim/interface_dag_elements/unit_checks.py
+++ b/src/ttsim/interface_dag_elements/unit_checks.py
@@ -27,6 +27,7 @@ build time; no live array is ever wrapped.
 from __future__ import annotations
 
 import dataclasses
+import functools
 import inspect
 import re
 import sys
@@ -57,6 +58,7 @@ from ttsim.tt.column_objects_param_function import (
     PolicyFunction,
     PolicyInput,
 )
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.grouping_levels import register_grouping_levels
 from ttsim.tt.param_objects import (
     DictParam,
@@ -76,7 +78,6 @@ from ttsim.tt.units import (
     _QNAME_TIME_SUFFIX_PATTERN,
     PERSON_LEVEL,
     TIME_UNIT_ID_TO_PINT_NAME,
-    UNIT_REGISTRY,
     UNSET_UNIT,
     CompositeUnit,
     UnitAnnotatedColumn,
@@ -214,16 +215,17 @@ _BOOL_KINDS = frozenset({ResolvedKind.BOOL_SCALAR, ResolvedKind.BOOL_COLUMN})
 #: The logical operators a dry-run screens for boolean (dimensionless) operands.
 _LOGICAL_OPS = frozenset({"&", "|", "^", "~"})
 
-#: The dimensionless unit, used when reporting a logical op's bare operand.
-_DIMENSIONLESS_UNIT: pint.Unit = cast(
-    "pint.Unit", UNIT_REGISTRY.Quantity(1.0, "").units
-)
+
+def _dimensionless_unit(registry: pint.UnitRegistry) -> pint.Unit:
+    """The dimensionless unit, used when reporting a logical op's bare operand."""
+    return registry.dimensionless
 
 
 @interface_function()
 def resolved_units(
     specialized_environment__without_tree_logic_and_with_derived_functions: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,  # noqa: E501
     labels__grouping_levels: OrderedQNames,
+    unit_system: UnitSystem,
 ) -> dict[str, pint.Unit | dict[str | int, Any]]:
     """The resolved pint unit of every annotated node in the environment.
 
@@ -235,12 +237,14 @@ def resolved_units(
     return resolve_environment_units(
         env=specialized_environment__without_tree_logic_and_with_derived_functions,
         grouping_levels=labels__grouping_levels,
+        unit_system=unit_system,
     )
 
 
 def resolve_environment_units(
     env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
     grouping_levels: OrderedQNames,
+    unit_system: UnitSystem,
 ) -> dict[str, pint.Unit | dict[str | int, Any]]:
     """Resolve the complete unit of every annotated node in the environment.
 
@@ -253,7 +257,8 @@ def resolve_environment_units(
     A node that declares no unit (still :data:`UNSET_UNIT`) is absent from the
     result; the mandatory-units check reports it.
     """
-    register_grouping_levels(grouping_levels)
+    registry = unit_system.registry
+    register_grouping_levels(names=grouping_levels, registry=registry)
     pattern = get_re_pattern_for_all_time_units_and_groupings(
         time_units=tuple(TIME_UNIT_IDS_TO_LABELS),
         grouping_levels=grouping_levels,
@@ -261,7 +266,11 @@ def resolve_environment_units(
     resolved: dict[str, pint.Unit | dict[str | int, Any]] = {
         # `parse_unit` guides declarations to the DIMENSIONLESS token, so the
         # framework-internal ordinal spelling resolves directly.
-        qname: (_DIMENSIONLESS_UNIT if unit == "dimensionless" else parse_unit(unit))
+        qname: (
+            _dimensionless_unit(registry)
+            if unit == "dimensionless"
+            else parse_unit(unit_str=unit, registry=registry)
+        )
         for qname, unit in FRAMEWORK_DATE_NODE_UNITS.items()
         if qname in env
     }
@@ -273,17 +282,34 @@ def resolve_environment_units(
             match = pattern.fullmatch(leaf_name)
             name_time_unit_id = match.group("time_unit") if match else None
             param_unit = _resolve_param_object_unit(
-                qname=qname, obj=obj, name_time_unit_id=name_time_unit_id
+                qname=qname,
+                obj=obj,
+                registry=registry,
+                name_time_unit_id=name_time_unit_id,
             )
             if param_unit is not None:
                 resolved[qname] = param_unit
         elif isinstance(obj, AggByGroupFunction):
             agg_unit = _resolve_agg_by_group_unit(
-                qname=qname, obj=obj, env=env, pattern=pattern
+                qname=qname, obj=obj, env=env, pattern=pattern, registry=registry
             )
             if agg_unit is not None:
                 resolved[qname] = agg_unit
-        else:  # ColumnObject | ParamFunction
+        elif isinstance(obj, ParamFunction) and _returns_a_schedule(obj):
+            token = getattr(obj, "unit", UNSET_UNIT)
+            if token is not UNSET_UNIT:
+                # A schedule-returning param function's `unit=` is its schedule's
+                # OUTPUT axis (as a require_converter's `output_unit:` is), not a
+                # column unit: resolve it the parameter way — concrete currency
+                # allowed, no name-suffix rules — so `look_up`/`piecewise_polynomial`
+                # consumers screen against it. The raw-axis derivation stays the
+                # fallback when the function declares `unit=UNSET_UNIT` (GEP 10).
+                resolved[qname] = resolve_compositional_param_unit(
+                    unit=cast("CompositeUnit", token),
+                    registry=registry,
+                    where=f"Schedule param function {qname!r}",
+                )
+        else:  # ColumnObject | scalar ParamFunction
             token = getattr(obj, "unit", UNSET_UNIT)
             if token is not UNSET_UNIT:
                 leaf_name = dt.tree_path_from_qname(qname)[-1]
@@ -291,14 +317,21 @@ def resolve_environment_units(
                 resolved[qname] = _resolve_leveled_column_unit(
                     token=cast("CompositeUnit", token),
                     match=match,
+                    registry=registry,
                     is_boolean=node_is_boolean(qname=qname, obj=obj),
                 )
     return resolved
 
 
+def _returns_a_schedule(obj: ParamFunction) -> bool:
+    """Whether a param function is annotated as returning a schedule/lookup value."""
+    return _return_annotation_name(obj.function) in _SCHEDULE_RETURN_TYPE_NAMES
+
+
 def _resolve_leveled_column_unit(
     token: CompositeUnit,
     match: re.Match[str] | None,
+    registry: pint.UnitRegistry,
     *,
     is_boolean: bool = False,
 ) -> pint.Unit:
@@ -320,6 +353,7 @@ def _resolve_leveled_column_unit(
         time_unit_id=time_unit_id,
         grouping_level=grouping_level,
         where="A column/function",
+        registry=registry,
         is_boolean=is_boolean,
     )
 
@@ -337,7 +371,10 @@ def _argument_is_person_pointer(qname: str) -> bool:
 
 
 def _resolve_opted_out_agg_unit(
-    qname: str, obj: AggByGroupFunction, match: re.Match[str] | None
+    qname: str,
+    obj: AggByGroupFunction,
+    match: re.Match[str] | None,
+    registry: pint.UnitRegistry,
 ) -> pint.Unit | None:
     """Resolve an opted-out aggregation from its declared unit, like a column.
 
@@ -351,6 +388,7 @@ def _resolve_opted_out_agg_unit(
     return _resolve_leveled_column_unit(
         token=cast("CompositeUnit", token),
         match=match,
+        registry=registry,
         is_boolean=node_is_boolean(qname=qname, obj=obj),
     )
 
@@ -360,6 +398,7 @@ def _resolve_agg_by_group_unit(
     obj: AggByGroupFunction,
     env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
     pattern: re.Pattern[str],
+    registry: pint.UnitRegistry,
 ) -> pint.Unit | None:
     """Resolve a group-aggregation node's unit, level-aware.
 
@@ -388,14 +427,16 @@ def _resolve_agg_by_group_unit(
     """
     match = pattern.fullmatch(dt.tree_path_from_qname(qname)[-1])
     if not obj.verify_units:
-        return _resolve_opted_out_agg_unit(qname=qname, obj=obj, match=match)
+        return _resolve_opted_out_agg_unit(
+            qname=qname, obj=obj, match=match, registry=registry
+        )
     target_level = _suffix_grouping_level(match)
     agg_type = obj.agg_type
     # COUNT and ANY/ALL are independent of the source's unit, so resolve them
     # before touching the source: well-defined even when the source declares none.
     if agg_type in (AggType.COUNT, AggType.ANY, AggType.ALL):
         return resolved_unit_for_aggregation(
-            agg_type=agg_type, target_level=target_level
+            agg_type=agg_type, target_level=target_level, registry=registry
         )
     sources = {
         p
@@ -422,12 +463,13 @@ def _resolve_agg_by_group_unit(
         is AggType.COUNT
     ):
         return resolved_unit_for_aggregation(
-            agg_type=AggType.COUNT, target_level=target_level
+            agg_type=AggType.COUNT, target_level=target_level, registry=registry
         )
     source_match = pattern.fullmatch(dt.tree_path_from_qname(source_qname)[-1])
     source_unit = _resolve_leveled_column_unit(
         token=cast("CompositeUnit", source_token),
         match=source_match,
+        registry=registry,
         is_boolean=source_is_boolean,
     )
     # Read the source's level off its *resolved* unit, not its declared token: the
@@ -438,6 +480,7 @@ def _resolve_agg_by_group_unit(
         agg_type=agg_type,
         target_level=target_level,
         source_level=source_level,
+        registry=registry,
     )
 
 
@@ -458,7 +501,9 @@ def _has_grouping_level_numerator(unit: pint.Unit) -> bool:
     return any(exponent > 0 for _, exponent in _grouping_levels_with_exponent(unit))
 
 
-def _boolean_level(unit: pint.Unit) -> tuple[bool, str | None]:
+def _boolean_level(
+    unit: pint.Unit, registry: pint.UnitRegistry
+) -> tuple[bool, str | None]:
     """Classify a unit as a (possibly leveled) boolean and read its level.
 
     A boolean is a truth value: dimensionless apart from at most a single grouping
@@ -473,23 +518,23 @@ def _boolean_level(unit: pint.Unit) -> tuple[bool, str | None]:
     """
     if _has_grouping_level_numerator(unit):
         return (False, None)
-    if not UNIT_REGISTRY.Quantity(
-        1.0, _unit_without_grouping_levels(unit)
+    if not registry.Quantity(
+        1.0, _unit_without_grouping_levels(unit=unit, registry=registry)
     ).dimensionless:
         return (False, None)
     return (True, _unit_level_denominator(unit))
 
 
-def _boolean_quantity(level: str | None) -> pint.Quantity:
+def _boolean_quantity(level: str | None, registry: pint.UnitRegistry) -> pint.Quantity:
     """A representative boolean ``Quantity`` at ``level`` — ``1 / [level]``.
 
     ``_boolean_quantity("fam")`` is ``1 / [fam]`` (a fam-level indicator);
     ``_boolean_quantity(None)`` is a plain dimensionless ``1`` (a level-less flag).
     """
-    truth = UNIT_REGISTRY.Quantity(1.0, "")
+    truth = registry.Quantity(1.0, "")
     if level is None:
         return truth
-    return truth / UNIT_REGISTRY.Quantity(1.0, f"{_GROUPING_LEVEL_PREFIX}{level}")
+    return truth / registry.Quantity(1.0, f"{_GROUPING_LEVEL_PREFIX}{level}")
 
 
 def _combined_boolean_level(left: str | None, right: str | None) -> str | None:
@@ -513,7 +558,7 @@ def fail_if_environment_units_are_missing(
 ) -> None:
     """Mandatory-units check over a fully assembled environment.
 
-    Every active node must declare a unit, where ``unit=Unit.DIMENSIONLESS`` /
+    Every active node must declare a unit, where ``unit=TTSIMUnit.DIMENSIONLESS`` /
     ``unit: DIMENSIONLESS`` *is* a declaration (a dimensionless quantity):
 
     - a dict or require_converter parameter with per-leaf units must cover every
@@ -584,6 +629,7 @@ def _agg_declaration_inconsistency(
     qname: str,
     obj: AggByGroupFunction,
     resolved_units: Mapping[str, pint.Unit | dict[str | int, Any]],
+    registry: pint.UnitRegistry,
 ) -> str | None:
     """Error message if an aggregation's declared unit ≠ what it derives.
 
@@ -617,10 +663,12 @@ def _agg_declaration_inconsistency(
     if derived is None or isinstance(derived, dict) or declared_token is UNSET_UNIT:
         return None
     declared_unit = resolve_compositional_param_unit(
-        unit=cast("CompositeUnit", declared_token), where=f"Aggregation {qname!r}"
+        unit=cast("CompositeUnit", declared_token),
+        registry=registry,
+        where=f"Aggregation {qname!r}",
     )
     derived_unit = cast("pint.Unit", derived)
-    if units_are_equivalent(left=declared_unit, right=derived_unit):
+    if units_are_equivalent(left=declared_unit, right=derived_unit, registry=registry):
         return None
     return (
         f"{qname}: declares `{declared_token}` but its {obj.agg_type.name} "
@@ -635,6 +683,7 @@ def _agg_declaration_inconsistency(
 def _aggregation_declaration_errors(
     env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
     resolved_units: Mapping[str, pint.Unit | dict[str | int, Any]],
+    registry: pint.UnitRegistry,
 ) -> list[str]:
     """Declared-vs-derived errors for every group aggregation."""
     return [
@@ -643,7 +692,7 @@ def _aggregation_declaration_errors(
         if isinstance(obj, AggByGroupFunction)
         and (
             error := _agg_declaration_inconsistency(
-                qname=qname, obj=obj, resolved_units=resolved_units
+                qname=qname, obj=obj, resolved_units=resolved_units, registry=registry
             )
         )
         is not None
@@ -681,7 +730,7 @@ def _rounding_spec_declaration_inconsistency(
     if token_is_agnostic_currency(spec.unit):
         return (
             f"{qname}: the rounding spec's magnitudes are written in a concrete "
-            f"currency; declare it (e.g. `Unit.DM.PER_YEAR`), not the agnostic "
+            f"currency; declare it (e.g. `TTSIMUnit.DM.PER_YEAR`), not the agnostic "
             f"`{spec.unit}` (GEP 10)."
         )
     if token_source_currency(spec.unit) is None:
@@ -715,6 +764,7 @@ def _rounding_spec_declaration_errors(
 def fail_if_environment_units_are_inconsistent(
     env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
     grouping_levels: OrderedQNames,
+    unit_system: UnitSystem,
     resolved_units: dict[str, pint.Unit | dict[str | int, Any]] | None = None,
 ) -> None:
     """Conservative body/edge verification over an assembled environment.
@@ -746,12 +796,13 @@ def fail_if_environment_units_are_inconsistent(
             with its declaration, or an aggregation's declared unit disagrees
             with what it derives. All offending nodes are reported together.
     """
+    registry = unit_system.registry
     if resolved_units is None:
         resolved_units = resolve_environment_units(
-            env=env, grouping_levels=grouping_levels
+            env=env, grouping_levels=grouping_levels, unit_system=unit_system
         )
     representative_values = _representative_values_by_qname(
-        env=env, resolved_units=resolved_units
+        env=env, resolved_units=resolved_units, unit_system=unit_system
     )
     boolean_nodes = {
         qname
@@ -760,30 +811,65 @@ def fail_if_environment_units_are_inconsistent(
         and node_is_boolean(qname=qname, obj=obj)
     }
     errors: list[str] = _aggregation_declaration_errors(
-        env=env, resolved_units=resolved_units
+        env=env, resolved_units=resolved_units, registry=registry
     )
     errors.extend(_rounding_spec_declaration_errors(env=env))
     errors.extend(_axes_converter_contract_errors(env=env))
     errors.extend(
-        _structured_annotation_drift_errors(env=env, resolved_units=resolved_units)
+        _structured_annotation_drift_errors(
+            env=env, resolved_units=resolved_units, unit_system=unit_system
+        )
     )
+    errors.extend(
+        _body_verification_errors(
+            env=env,
+            resolved_units=resolved_units,
+            representative_values=representative_values,
+            boolean_nodes=boolean_nodes,
+            unit_system=unit_system,
+        )
+    )
+    if errors:
+        raise UnitConsistencyError(
+            "Environment unit-consistency check failed:\n  " + "\n  ".join(errors)
+        )
+
+
+def _body_verification_errors(
+    env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+    resolved_units: Mapping[str, pint.Unit | dict[str | int, Any]],
+    representative_values: Mapping[str, Any],
+    boolean_nodes: set[str],
+    unit_system: UnitSystem,
+) -> list[str]:
+    """Dry-run every human-written scalar body and collect its inference errors.
+
+    Only ``@policy_function`` / ``@param_function`` bodies are dry-run; everything
+    else (aggregations, time-conversions, group ids) is unit-assigned by
+    construction. A body is skipped when it is an unimplemented-period stub, has
+    no resolved unit, opts out (``verify_units=False``), declares a structured
+    unit, or has an unannotated producer.
+    """
+    registry = unit_system.registry
+    # The helper shims close over this run's registry, so they are built per run
+    # rather than once at import.
+    dry_run_helper_shims, explorer_holder = _dry_run_helper_shims(
+        unit_system=unit_system
+    )
+    errors: list[str] = []
     for qname, obj in env.items():
-        # Only these two have a human-written scalar body; everything else
-        # (aggregations validated above, time-conversions, group ids) is assigned
-        # by construction.
         if not isinstance(obj, PolicyFunction | ParamFunction):
             continue
         if getattr(obj, "fail_msg_if_included", None) is not None:
-            # A placeholder for an unimplemented period: it raises when reached, so
-            # its stub body carries no unit semantics. The declared unit still stands
-            # as the edge contract (like an explicit opt-out).
             continue
-        if qname not in resolved_units:
-            # Still UNSET — the mandatory-units check reports it.
+        if isinstance(obj, ParamFunction) and _returns_a_schedule(obj):
+            # Its body builds a lookup/piecewise table, not a scalar; the declared
+            # unit is the schedule's output contract (screened at the consumer's
+            # `look_up`/`piecewise_polynomial`), so there is no scalar body to infer.
             continue
-        if not obj.verify_units:
-            # Body opted out of unit inference; its declared unit still stands as
-            # the edge contract, so consumers are still checked.
+        if qname not in resolved_units or not obj.verify_units:
+            # Still UNSET (the mandatory-units check reports it), or the body
+            # opted out — its declared unit stays the edge contract either way.
             continue
         declared = resolved_units[qname]
         if isinstance(declared, dict):
@@ -801,7 +887,7 @@ def fail_if_environment_units_are_inconsistent(
         # leveled boolean carries its level into the body while only its truth value
         # is explorer-controlled; an unresolved producer falls back to level-less.
         boolean_values = {
-            name: representative_values.get(name, UNIT_REGISTRY.Quantity(1.0, ""))
+            name: representative_values.get(name, registry.Quantity(1.0, ""))
             for name in boolean_parameters
         }
         error = _verify_one_body(
@@ -810,18 +896,17 @@ def fail_if_environment_units_are_inconsistent(
                 func=obj.function,
                 module="xnp",
                 module_obj=_NON_UNIT_ARGUMENT_VALUES["xnp"],
-                extra_globals=_DRY_RUN_HELPER_SHIMS,
+                extra_globals=dry_run_helper_shims,
             ),
             declared=declared,
             boolean_values=boolean_values,
             base_kwargs=base_kwargs,
+            unit_system=unit_system,
+            explorer_holder=explorer_holder,
         )
         if error is not None:
             errors.append(error)
-    if errors:
-        raise UnitConsistencyError(
-            "Environment unit-consistency check failed:\n  " + "\n  ".join(errors)
-        )
+    return errors
 
 
 def fail_if_not_all_leaves_are_unit_annotated_columns(
@@ -850,7 +935,7 @@ def fail_if_not_all_leaves_are_unit_annotated_columns(
             "input_data__tree_with_unit_annotations requires every leaf to be a "
             "UnitAnnotatedColumn (GEP 10), but these are bare: "
             f"{', '.join(untagged)}. Tag a dimensionless column (an id, a boolean) "
-            "with `UnitAnnotatedColumn(values=arr, unit=Unit.DIMENSIONLESS)`, or "
+            "with `UnitAnnotatedColumn(values=arr, unit=TTSIMUnit.DIMENSIONLESS)`, or "
             "pass untagged data via input_data__tree."
         )
 
@@ -858,11 +943,12 @@ def fail_if_not_all_leaves_are_unit_annotated_columns(
 def fail_if_input_units_are_inconsistent(
     input_units: Mapping[str, pint.Unit],
     resolved_units: Mapping[str, Any],
+    unit_system: UnitSystem,
 ) -> None:
     """Fail if an input column's tag disagrees with the unit declared for it.
 
     Two units meet here: the input column's **tag** (the unit the user attaches
-    to the data, ``UnitAnnotatedColumn(..., unit=Unit.EUR.PER_MONTH)``) and the
+    to the data, ``UnitAnnotatedColumn(..., unit=TTSIMUnit.EUR.PER_MONTH)``) and the
     unit **declared for that column in the policy environment** (its ``unit=`` /
     ``unit:``). They must agree, checked on three axes:
 
@@ -887,13 +973,16 @@ def fail_if_input_units_are_inconsistent(
         UnitConsistencyError: If any tagged column disagrees with the unit
             declared for it. All offending columns are reported together.
     """
+    registry = unit_system.registry
     errors: list[str] = []
     for qname, tag in input_units.items():
         expected = resolved_units.get(qname)
         if not isinstance(expected, pint.Unit):
             # No scalar declared unit (absent, or a dict parameter); nothing to check.
             continue
-        if unit_has_currency_component(tag) != unit_has_currency_component(expected):
+        if unit_has_currency_component(
+            units=tag, registry=registry
+        ) != unit_has_currency_component(units=expected, registry=registry):
             errors.append(
                 f"  {qname}: tagged '{tag}' but declared '{expected}' — one carries "
                 f"a currency and the other does not, so the boundary would silently "
@@ -911,9 +1000,15 @@ def fail_if_input_units_are_inconsistent(
                 f"the name suffix (GEP 10)."
             )
             continue
-        tag_residual = unit_residual_excluding_currency_and_flow_period(tag)
-        expected_residual = unit_residual_excluding_currency_and_flow_period(expected)
-        if not units_are_equivalent(left=tag_residual, right=expected_residual):
+        tag_residual = unit_residual_excluding_currency_and_flow_period(
+            units=tag, registry=registry
+        )
+        expected_residual = unit_residual_excluding_currency_and_flow_period(
+            units=expected, registry=registry
+        )
+        if not units_are_equivalent(
+            left=tag_residual, right=expected_residual, registry=registry
+        ):
             errors.append(
                 f"  {qname}: tagged '{tag}', which is not equivalent to the declared "
                 f"unit '{expected}' (the boundary converts currency and screens the "
@@ -991,6 +1086,7 @@ def _resolve_param_mapping_object_units(
     qname: str,
     obj: ParamMappingObject,
     name_time_unit_id: str | None,
+    registry: pint.UnitRegistry,
 ) -> pint.Unit | None:
     """Resolve a mapping parameter's per-axis unit declarations.
 
@@ -1025,14 +1121,17 @@ def _resolve_param_mapping_object_units(
             qname=qname,
             output_token=output_token,
             name_time_unit_id=name_time_unit_id,
+            registry=registry,
         )
     input_token = tokens["input_unit"]
     if input_token is not UNSET_UNIT:
-        resolve_compositional_param_unit(unit=input_token, where=f"Parameter {qname!r}")
+        resolve_compositional_param_unit(
+            unit=input_token, registry=registry, where=f"Parameter {qname!r}"
+        )
     if output_token is UNSET_UNIT:
         return None
     return resolve_compositional_param_unit(
-        unit=output_token, where=f"Parameter {qname!r}"
+        unit=output_token, registry=registry, where=f"Parameter {qname!r}"
     )
 
 
@@ -1040,6 +1139,7 @@ def _fail_if_name_suffix_disagrees_with_output_axis(
     qname: str,
     output_token: Any,  # noqa: ANN401
     name_time_unit_id: str,
+    registry: pint.UnitRegistry,
 ) -> None:
     """Check the name-suffix ⟺ flow-output coincidence rules.
 
@@ -1054,13 +1154,17 @@ def _fail_if_name_suffix_disagrees_with_output_axis(
             f"`output_unit:` is {_spell_token(output_token)} (GEP 10)."
         )
     resolve_compositional_param_unit(
-        unit=output_token, time_unit_id=name_time_unit_id, where=f"Parameter {qname!r}"
+        unit=output_token,
+        registry=registry,
+        time_unit_id=name_time_unit_id,
+        where=f"Parameter {qname!r}",
     )
 
 
 def _resolve_param_object_unit(
     qname: str,
     obj: ParamObject,
+    registry: pint.UnitRegistry,
     name_time_unit_id: str | None = None,
 ) -> pint.Unit | dict[str | int, Any] | None:
     """Resolve a parameter's declared compositional unit.
@@ -1078,13 +1182,18 @@ def _resolve_param_object_unit(
     """
     if isinstance(obj, ParamMappingObject):
         return _resolve_param_mapping_object_units(
-            qname=qname, obj=obj, name_time_unit_id=name_time_unit_id
+            qname=qname,
+            obj=obj,
+            name_time_unit_id=name_time_unit_id,
+            registry=registry,
         )
     if obj.unit is UNSET_UNIT:
         return None
     if isinstance(obj.unit, Mapping):
         return _resolve_unit_mapping(
-            qname=qname, unit_mapping=cast("Mapping[str | int, Any]", obj.unit)
+            qname=qname,
+            unit_mapping=cast("Mapping[str | int, Any]", obj.unit),
+            registry=registry,
         )
     token = cast("CompositeUnit", obj.unit)
     _fail_if_param_token_is_agnostic_currency(token=token, where=f"Parameter {qname!r}")
@@ -1092,6 +1201,7 @@ def _resolve_param_object_unit(
     # dict/raw parameter has no single name to suffix.
     return resolve_compositional_param_unit(
         unit=token,
+        registry=registry,
         time_unit_id=name_time_unit_id if isinstance(obj, ScalarParam) else None,
         where=f"Parameter {qname!r}",
     )
@@ -1100,6 +1210,7 @@ def _resolve_param_object_unit(
 def _resolve_unit_mapping(
     qname: str,
     unit_mapping: Mapping[str | int, Any],
+    registry: pint.UnitRegistry,
 ) -> dict[str | int, Any]:
     """Resolve a per-leaf ``unit:`` mapping to pint units.
 
@@ -1111,38 +1222,53 @@ def _resolve_unit_mapping(
     resolved: dict[str | int, Any] = {}
     for key, token in unit_mapping.items():
         if isinstance(token, Mapping):
-            resolved[key] = _resolve_unit_mapping(qname=qname, unit_mapping=token)
+            resolved[key] = _resolve_unit_mapping(
+                qname=qname, unit_mapping=token, registry=registry
+            )
             continue
         where = f"Parameter {qname!r}, unit of leaf {key!r}"
         _fail_if_param_token_is_agnostic_currency(token=token, where=where)
         match = _QNAME_TIME_SUFFIX_PATTERN.search(str(key))
         suffix_id = match.group("time_unit") if match else None
         resolved[key] = resolve_compositional_param_unit(
-            unit=cast("CompositeUnit", token), time_unit_id=suffix_id, where=where
+            unit=cast("CompositeUnit", token),
+            registry=registry,
+            time_unit_id=suffix_id,
+            where=where,
         )
     return resolved
 
 
 def _representative_value(
     resolved_unit: pint.Unit | dict[str | int, Any],
+    registry: pint.UnitRegistry,
 ) -> Any:  # noqa: ANN401
     """A representative dry-run value: ``Quantity(1.0, unit)``, or a dict thereof."""
     if isinstance(resolved_unit, dict):
         return {
-            key: _representative_value(cast("pint.Unit | dict[str | int, Any]", unit))
+            key: _representative_value(
+                resolved_unit=cast("pint.Unit | dict[str | int, Any]", unit),
+                registry=registry,
+            )
             for key, unit in resolved_unit.items()
         }
-    return UNIT_REGISTRY.Quantity(1.0, resolved_unit)
+    return registry.Quantity(1.0, resolved_unit)
 
 
-def _uniform_quantity_tree(value: Any, resolved_unit: pint.Unit) -> Any:  # noqa: ANN401
+def _uniform_quantity_tree(
+    value: Any,  # noqa: ANN401
+    resolved_unit: pint.Unit,
+    registry: pint.UnitRegistry,
+) -> Any:  # noqa: ANN401
     """Mirror a dict param's value structure with uniform representative quantities."""
     if isinstance(value, Mapping):
         return {
-            key: _uniform_quantity_tree(value=sub_value, resolved_unit=resolved_unit)
+            key: _uniform_quantity_tree(
+                value=sub_value, resolved_unit=resolved_unit, registry=registry
+            )
             for key, sub_value in value.items()
         }
-    return UNIT_REGISTRY.Quantity(1.0, resolved_unit)
+    return registry.Quantity(1.0, resolved_unit)
 
 
 #: The unqualified return-annotation names the axes contract accepts: the two
@@ -1186,6 +1312,7 @@ def _axes_declaring_raw_dependencies(
 def _resolved_raw_param_axis(
     token: Any,  # noqa: ANN401
     qname: str,
+    registry: pint.UnitRegistry,
 ) -> pint.Unit | None:
     """Resolve one declared axis of an input/output-unit ``require_converter``."""
     if token is UNSET_UNIT:
@@ -1193,7 +1320,9 @@ def _resolved_raw_param_axis(
     where = f"Parameter {qname!r}"
     unit_token = cast("CompositeUnit", token)
     _fail_if_param_token_is_agnostic_currency(token=unit_token, where=where)
-    return resolve_compositional_param_unit(unit=unit_token, where=where)
+    return resolve_compositional_param_unit(
+        unit=unit_token, registry=registry, where=where
+    )
 
 
 def _resolved_return_dataclass(func: Any) -> type | None:  # noqa: ANN401
@@ -1217,19 +1346,14 @@ def _resolved_return_dataclass(func: Any) -> type | None:  # noqa: ANN401
     return obj if isinstance(obj, type) and dataclasses.is_dataclass(obj) else None
 
 
-#: Per-class memo of :func:`_structured_field_kinds`. ``None`` records a class
-#: whose annotations do not resolve at runtime. Field annotations are
-#: currency-agnostic by rule, so a cached resolution never goes stale when a
-#: currency registration is rolled back.
-_STRUCTURED_FIELD_KINDS: dict[type, dict[str, pint.Unit | type] | None] = {}
-
-
-def _structured_field_kinds(cls: type) -> dict[str, pint.Unit | type] | None:
+def _structured_field_kinds(
+    cls: type, unit_system: UnitSystem
+) -> dict[str, pint.Unit | type] | None:
     """Resolve a parameter dataclass's field annotations for the dry-run.
 
     Maps each field to what its pluck yields:
 
-    - an ``Annotated[<scalar>, Unit…]`` field → the resolved unit;
+    - an ``Annotated[<scalar>, TTSIMUnit…]`` field → the resolved unit;
     - a nested-dataclass field → its class (whose plucks resolve recursively);
     - anything else (a bare scalar, dict, array, schedule value) is absent — the
       pluck stays opaque and is cast at the site (GEP 10).
@@ -1237,16 +1361,20 @@ def _structured_field_kinds(cls: type) -> dict[str, pint.Unit | type] | None:
     Returns ``None`` when the annotations do not resolve at runtime (a name
     imported only under ``TYPE_CHECKING``), leaving every pluck opaque.
 
+    Memoized per class on ``unit_system``: a resolved unit belongs to that
+    system's registry, so the memo cannot be shared across systems.
+
     Raises:
         UnitDefinitionError: If a field annotates several units, annotates a
             non-scalar field, or pins a concrete currency.
     """
-    if cls in _STRUCTURED_FIELD_KINDS:
-        return _STRUCTURED_FIELD_KINDS[cls]
+    memo = unit_system.field_units_by_class
+    if cls in memo:
+        return memo[cls]
     try:
         hints = get_type_hints(cls, include_extras=True)
     except NameError:
-        _STRUCTURED_FIELD_KINDS[cls] = None
+        memo[cls] = None
         return None
     kinds: dict[str, pint.Unit | type] = {}
     for field in dataclasses.fields(cls):
@@ -1272,11 +1400,11 @@ def _structured_field_kinds(cls: type) -> dict[str, pint.Unit | type] | None:
                     f"single unit — cast at the pluck instead (GEP 10)."
                 )
             kinds[field.name] = resolve_compositional_field_unit(
-                unit=tokens[0], where=where
+                unit=tokens[0], registry=unit_system.registry, where=where
             )
         elif isinstance(base, type) and dataclasses.is_dataclass(base):
             kinds[field.name] = base
-    _STRUCTURED_FIELD_KINDS[cls] = kinds
+    memo[cls] = kinds
     return kinds
 
 
@@ -1303,12 +1431,16 @@ def _flatten_to_paths(
     return out
 
 
-def _annotated_field_units(cls: type) -> dict[tuple[str, ...], pint.Unit]:
+def _annotated_field_units(
+    cls: type, unit_system: UnitSystem
+) -> dict[tuple[str, ...], pint.Unit]:
     """Flatten a parameter dataclass's annotated field units to field paths."""
     return _flatten_to_paths(
         cls,
         is_leaf=lambda child: isinstance(child, pint.Unit),
-        items=lambda node: (_structured_field_kinds(node) or {}).items(),
+        items=lambda node: (
+            _structured_field_kinds(cls=node, unit_system=unit_system) or {}
+        ).items(),
     )
 
 
@@ -1326,6 +1458,7 @@ def _flattened_unit_mapping(
 def _structured_annotation_drift_errors(
     env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
     resolved_units: Mapping[str, pint.Unit | dict[str | int, Any]],
+    unit_system: UnitSystem,
 ) -> list[str]:
     """YAML-vs-annotation drift check for dataclass-building converters.
 
@@ -1345,7 +1478,7 @@ def _structured_annotation_drift_errors(
         cls = _resolved_return_dataclass(obj.function)
         if cls is None:
             continue
-        field_units = _annotated_field_units(cls)
+        field_units = _annotated_field_units(cls=cls, unit_system=unit_system)
         if not field_units:
             continue
         for dep in sorted(obj.dependencies):
@@ -1360,7 +1493,7 @@ def _structured_annotation_drift_errors(
             for path, field_unit in sorted(field_units.items()):
                 leaf_unit = leaf_units.get(path)
                 if leaf_unit is None or units_are_equivalent(
-                    left=leaf_unit, right=field_unit
+                    left=leaf_unit, right=field_unit, registry=unit_system.registry
                 ):
                     continue
                 errors.append(
@@ -1377,6 +1510,7 @@ def _param_function_stand_in(
     qname: str,
     obj: ParamFunction,
     env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+    unit_system: UnitSystem,
 ) -> _DryRunSchedule | _DryRunStructuredValue:
     """The dry-run stand-in for a structured param-function output (GEP 10).
 
@@ -1398,16 +1532,23 @@ def _param_function_stand_in(
         and _return_annotation_name(obj.function) in _SCHEDULE_RETURN_TYPE_NAMES
     ):
         raw_qname, raw = axes_deps[0]
-        output_unit = _resolved_raw_param_axis(token=raw.output_unit, qname=raw_qname)
+        output_unit = _resolved_raw_param_axis(
+            token=raw.output_unit, qname=raw_qname, registry=unit_system.registry
+        )
         if output_unit is not None:
             return _DryRunSchedule(
                 input_unit=_resolved_raw_param_axis(
-                    token=raw.input_unit, qname=raw_qname
+                    token=raw.input_unit,
+                    qname=raw_qname,
+                    registry=unit_system.registry,
                 ),
                 output_unit=output_unit,
+                unit_system=unit_system,
             )
     return _DryRunStructuredValue(
-        producer=qname, cls=_resolved_return_dataclass(obj.function)
+        producer=qname,
+        unit_system=unit_system,
+        cls=_resolved_return_dataclass(obj.function),
     )
 
 
@@ -1478,7 +1619,9 @@ def _axes_converter_contract_errors(
     return errors
 
 
-def _resolve_schedule_input_unit(obj: ParamMappingObject) -> pint.Unit | None:
+def _resolve_schedule_input_unit(
+    obj: ParamMappingObject, registry: pint.UnitRegistry
+) -> pint.Unit | None:
     """The resolved ``input_unit`` of a schedule/lookup parameter, or ``None``.
 
     Resolved the same way as the ``output_unit`` the environment exposes, so a
@@ -1488,13 +1631,16 @@ def _resolve_schedule_input_unit(obj: ParamMappingObject) -> pint.Unit | None:
     if obj.input_unit is UNSET_UNIT:
         return None
     return resolve_compositional_param_unit(
-        unit=cast("CompositeUnit", obj.input_unit), where="A schedule input axis"
+        unit=cast("CompositeUnit", obj.input_unit),
+        registry=registry,
+        where="A schedule input axis",
     )
 
 
 def _representative_values_by_qname(
     env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
     resolved_units: Mapping[str, pint.Unit | dict[str | int, Any]],
+    unit_system: UnitSystem,
 ) -> dict[str, Any]:
     """Representative dry-run values for every unit-resolved node.
 
@@ -1509,23 +1655,41 @@ def _representative_values_by_qname(
       declares input and output units for it, a :class:`_DryRunStructuredValue`
       otherwise.
     """
+    registry = unit_system.registry
     out: dict[str, Any] = {}
     for qname, unit in resolved_units.items():
         obj = env.get(qname)
         if isinstance(obj, ParamMappingObject) and not isinstance(unit, dict):
             out[qname] = _DryRunSchedule(
-                input_unit=_resolve_schedule_input_unit(obj),
+                input_unit=_resolve_schedule_input_unit(obj=obj, registry=registry),
                 output_unit=cast("pint.Unit", unit),
+                unit_system=unit_system,
+            )
+        elif (
+            isinstance(obj, ParamFunction)
+            and _returns_a_schedule(obj)
+            and not isinstance(unit, dict)
+        ):
+            # A schedule param function that declares its own output unit: its
+            # `look_up`/`piecewise_polynomial` yields that unit, the key unscreened.
+            out[qname] = _DryRunSchedule(
+                input_unit=None,
+                output_unit=cast("pint.Unit", unit),
+                unit_system=unit_system,
             )
         elif isinstance(obj, DictParam | RawParam) and not isinstance(unit, dict):
             out[qname] = _uniform_quantity_tree(
-                value=obj.value, resolved_unit=cast("pint.Unit", unit)
+                value=obj.value,
+                resolved_unit=cast("pint.Unit", unit),
+                registry=registry,
             )
         else:
-            out[qname] = _representative_value(unit)
+            out[qname] = _representative_value(resolved_unit=unit, registry=registry)
     for qname, obj in env.items():
         if isinstance(obj, ParamFunction) and obj.unit is UNSET_UNIT:
-            out[qname] = _param_function_stand_in(qname=qname, obj=obj, env=env)
+            out[qname] = _param_function_stand_in(
+                qname=qname, obj=obj, env=env, unit_system=unit_system
+            )
     return out
 
 
@@ -1686,7 +1850,7 @@ class _DryRunQuantity:
     the declaration — so the wrapper can never produce a false positive.
     """
 
-    __slots__ = ("_explorer", "_label", "q")
+    __slots__ = ("_explorer", "_label", "_unit_system", "q")
     # Keep NumPy from broadcasting over us: defer binary ops with a NumPy operand
     # to our reflected dunders instead.
     __array_ufunc__ = None
@@ -1697,24 +1861,37 @@ class _DryRunQuantity:
         self,
         q: Any,  # noqa: ANN401
         explorer: _PathExplorer,
+        unit_system: UnitSystem,
         label: str | None = None,
     ) -> None:
         self.q = q
         self._explorer = explorer
+        # The system whose registry `q` lives in — every unit the wrapper mints
+        # (a boolean's level, a dimensionless truth value) must land there too.
+        self._unit_system = unit_system
         # How the body's author would name this value — the argument name for a
         # direct input, a composed description for a comparison or logical
         # combination, ``None`` once arithmetic has mixed it beyond naming. Used
         # to report the branch a failure sits on (`_PathExplorer.branch_detail`).
         self._label = label
 
+    @property
+    def _registry(self) -> pint.UnitRegistry:
+        return self._unit_system.registry
+
     def _wrap(self, q: Any) -> _DryRunQuantity:  # noqa: ANN401
-        return _DryRunQuantity(q=q, explorer=self._explorer)
+        return _DryRunQuantity(
+            q=q, explorer=self._explorer, unit_system=self._unit_system
+        )
 
     def _controlled_bool_at(
         self, level: str | None, label: str | None = None
     ) -> _DryRunQuantity:
         return _DryRunQuantity(
-            q=_boolean_quantity(level), explorer=self._explorer, label=label
+            q=_boolean_quantity(level=level, registry=self._registry),
+            explorer=self._explorer,
+            unit_system=self._unit_system,
+            label=label,
         )
 
     def _composed_label(self, other: Any, op: str) -> str | None:  # noqa: ANN401
@@ -1757,13 +1934,15 @@ class _DryRunQuantity:
         mismatch downcasts to the per-person level. A bare literal carries no unit
         and stays a lenient, level-less boolean.
         """
-        self_is_boolean, self_level = _boolean_level(cast("pint.Unit", self.q.units))
+        self_is_boolean, self_level = _boolean_level(
+            unit=cast("pint.Unit", self.q.units), registry=self._registry
+        )
         other_q = _unwrap(other)
         if isinstance(other_q, _DryRunStructuredValue):
             other_q._raise_used_as_quantity(op)  # noqa: SLF001
         if isinstance(other_q, pint.Quantity):
             other_is_boolean, other_level = _boolean_level(
-                cast("pint.Unit", other_q.units)
+                unit=cast("pint.Unit", other_q.units), registry=self._registry
             )
         else:
             other_is_boolean, other_level = True, None
@@ -1771,7 +1950,7 @@ class _DryRunQuantity:
             right = (
                 cast("pint.Unit", other_q.units)
                 if isinstance(other_q, pint.Quantity)
-                else _DIMENSIONLESS_UNIT
+                else _dimensionless_unit(self._registry)
             )
             raise _UnitMixError(
                 op=op, left=cast("pint.Unit", self.q.units), right=right
@@ -1803,9 +1982,11 @@ class _DryRunQuantity:
         other_q = _unwrap(other)
         if isinstance(other_q, _DryRunStructuredValue):
             other_q._raise_used_as_quantity(op)  # noqa: SLF001
-        self_is_point = is_calendar_point_unit(cast("pint.Unit", self.q.units))
+        self_is_point = is_calendar_point_unit(
+            unit=cast("pint.Unit", self.q.units), registry=self._registry
+        )
         other_is_point = isinstance(other_q, pint.Quantity) and is_calendar_point_unit(
-            cast("pint.Unit", other_q.units)
+            unit=cast("pint.Unit", other_q.units), registry=self._registry
         )
         if (
             self_is_point
@@ -1813,6 +1994,7 @@ class _DryRunQuantity:
             and not units_are_equivalent(
                 left=cast("pint.Unit", self.q.units),
                 right=cast("pint.Unit", other_q.units),
+                registry=self._registry,
             )
         ):
             raise _UnitMixError(
@@ -1846,6 +2028,7 @@ class _DryRunQuantity:
         if isinstance(other_q, pint.Quantity) and not units_are_equivalent(
             left=cast("pint.Unit", self.q.units),
             right=cast("pint.Unit", other_q.units),
+            registry=self._registry,
         ):
             raise _UnitMixError(op=op, left=self.q.units, right=other_q.units)
         if (
@@ -1856,7 +2039,7 @@ class _DryRunQuantity:
             raise _UnitMixError(
                 op=op,
                 left=cast("pint.Unit", self.q.units),
-                right=_DIMENSIONLESS_UNIT,
+                right=_dimensionless_unit(self._registry),
                 literal=other_q,
             )
 
@@ -1939,10 +2122,14 @@ class _DryRunQuantity:
         return self._logical_result(other=other, op="^")
 
     def __invert__(self) -> _DryRunQuantity:
-        is_boolean, level = _boolean_level(cast("pint.Unit", self.q.units))
+        is_boolean, level = _boolean_level(
+            unit=cast("pint.Unit", self.q.units), registry=self._registry
+        )
         if not is_boolean:
             raise _UnitMixError(
-                op="~", left=cast("pint.Unit", self.q.units), right=_DIMENSIONLESS_UNIT
+                op="~",
+                left=cast("pint.Unit", self.q.units),
+                right=_dimensionless_unit(self._registry),
             )
         return self._controlled_bool_at(
             level=level,
@@ -2010,6 +2197,7 @@ class _DryRunQuantity:
 def _wrap_for_dry_run(
     value: Any,  # noqa: ANN401
     explorer: _PathExplorer,
+    unit_system: UnitSystem,
     label: str | None = None,
 ) -> Any:  # noqa: ANN401
     """Wrap unit-carrying representative values; pass framework args through.
@@ -2022,10 +2210,13 @@ def _wrap_for_dry_run(
     branch like any other operand.
     """
     if isinstance(value, pint.Quantity):
-        return _DryRunQuantity(q=value, explorer=explorer, label=label)
+        return _DryRunQuantity(
+            q=value, explorer=explorer, unit_system=unit_system, label=label
+        )
     if isinstance(value, _DryRunStructuredValue):
         return _DryRunStructuredValue(
             producer=value._producer,  # noqa: SLF001
+            unit_system=unit_system,
             cls=value._cls,  # noqa: SLF001
             explorer=explorer,
             label=label,
@@ -2035,6 +2226,7 @@ def _wrap_for_dry_run(
             key: _wrap_for_dry_run(
                 value=leaf,
                 explorer=explorer,
+                unit_system=unit_system,
                 label=f"{label}[{key!r}]" if label is not None else None,
             )
             for key, leaf in value.items()
@@ -2073,7 +2265,7 @@ class _DryRunStructuredValue:
     demanding a ``cast_unit`` at the pluck.
     """
 
-    __slots__ = ("_cls", "_explorer", "_label", "_producer")
+    __slots__ = ("_cls", "_explorer", "_label", "_producer", "_unit_system")
     # Defer binary NumPy ops to our (raising) reflected dunders.
     __array_ufunc__ = None
     __array_priority__ = 1000
@@ -2082,11 +2274,16 @@ class _DryRunStructuredValue:
     def __init__(
         self,
         producer: str,
+        unit_system: UnitSystem,
         cls: type | None = None,
         explorer: _PathExplorer | None = None,
         label: str | None = None,
     ) -> None:
         self._producer = producer
+        # An annotated field's pluck resolves to a unit, so the stand-in needs
+        # the system to resolve it in — an object graph, not a call tree, so it
+        # carries the system rather than receiving it per call.
+        self._unit_system = unit_system
         self._cls = cls
         self._explorer = explorer
         self._label = label
@@ -2095,25 +2292,37 @@ class _DryRunStructuredValue:
         raise _StructuredValueUsedAsQuantityError(producer=self._producer, op=op)
 
     def _opaque(self) -> _DryRunStructuredValue:
-        return _DryRunStructuredValue(producer=self._producer)
+        return _DryRunStructuredValue(
+            producer=self._producer, unit_system=self._unit_system
+        )
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
         # Refuse protocol probes (``__array__``, copy/pickle hooks, …).
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
-        kinds = _structured_field_kinds(self._cls) if self._cls is not None else None
+        kinds = (
+            _structured_field_kinds(cls=self._cls, unit_system=self._unit_system)
+            if self._cls is not None
+            else None
+        )
         resolved = (kinds or {}).get(name)
         label = f"{self._label}.{name}" if self._label is not None else None
         if isinstance(resolved, pint.Unit):
             # An annotated field's pluck is a known quantity; with the run's
             # explorer it screens and branches like any other operand.
-            quantity = UNIT_REGISTRY.Quantity(1.0, resolved)
+            quantity = self._unit_system.registry.Quantity(1.0, resolved)
             if self._explorer is None:
                 return quantity
-            return _DryRunQuantity(q=quantity, explorer=self._explorer, label=label)
+            return _DryRunQuantity(
+                q=quantity,
+                explorer=self._explorer,
+                unit_system=self._unit_system,
+                label=label,
+            )
         if resolved is not None:
             return _DryRunStructuredValue(
                 producer=self._producer,
+                unit_system=self._unit_system,
                 cls=resolved,
                 explorer=self._explorer,
                 label=label,
@@ -2191,11 +2400,17 @@ class _DryRunSchedule:
     unset, in which case the domain is not screened.
     """
 
-    __slots__ = ("input_unit", "output_unit")
+    __slots__ = ("input_unit", "output_unit", "unit_system")
 
-    def __init__(self, input_unit: pint.Unit | None, output_unit: pint.Unit) -> None:
+    def __init__(
+        self,
+        input_unit: pint.Unit | None,
+        output_unit: pint.Unit,
+        unit_system: UnitSystem,
+    ) -> None:
         self.input_unit = input_unit
         self.output_unit = output_unit
+        self.unit_system = unit_system
 
     def _produce(self, domain_args: tuple[Any, ...]) -> _DryRunQuantity:
         explorer: _PathExplorer | None = None
@@ -2203,7 +2418,9 @@ class _DryRunSchedule:
             if isinstance(arg, _DryRunQuantity):
                 explorer = arg._explorer  # noqa: SLF001
                 if self.input_unit is not None and not units_are_equivalent(
-                    left=cast("pint.Unit", arg.q.units), right=self.input_unit
+                    left=cast("pint.Unit", arg.q.units),
+                    right=self.input_unit,
+                    registry=self.unit_system.registry,
                 ):
                     raise _UnitMixError(
                         op="look-up",
@@ -2215,7 +2432,9 @@ class _DryRunSchedule:
             # literal index): not dry-runnable, fall back to the opt-out.
             raise _ScheduleNotDryRunnableError
         return _DryRunQuantity(
-            q=UNIT_REGISTRY.Quantity(1.0, self.output_unit), explorer=explorer
+            q=self.unit_system.registry.Quantity(1.0, self.output_unit),
+            explorer=explorer,
+            unit_system=self.unit_system,
         )
 
     def look_up(self, *args: Any) -> _DryRunQuantity:  # noqa: ANN401
@@ -2256,29 +2475,40 @@ def _join_dry_run(
     raise _ScheduleNotDryRunnableError
 
 
-def _cast_unit_dry_run(value: Any, unit: str | CompositeUnit) -> Any:  # noqa: ANN401
+def _cast_unit_dry_run(
+    value: Any,  # noqa: ANN401
+    unit: str | CompositeUnit,
+    unit_system: UnitSystem,
+    explorer_holder: list[_PathExplorer | None],
+) -> Any:  # noqa: ANN401
     """Dry-run shim for ``cast_unit``.
 
     The cast is total: whatever flowed in — a quantity at another unit or
     level, a bare literal, an attribute plucked off a structured value — the
     stand-in flowing out carries the stated unit, resolved like a declaration
-    (currency-agnostic, the person leaf implied). A ``_DryRunQuantity`` input
-    keeps its explorer, so branch decisions stay on the run's path; any other
-    input anchors a plain representative quantity, which a wrapped operand
-    combines with like any parameter value. A malformed token raises a
-    :class:`UnitDefinitionError`, which :func:`_verify_one_body` re-raises
-    rather than misreporting as an un-evaluable body.
+    (currency-agnostic, the person leaf implied). The result stays on the body's
+    path: a ``_DryRunQuantity`` input keeps its explorer, and any other input
+    (a bare literal) is wrapped with the body's explorer (``explorer_holder``),
+    so a cast literal orders and combines like any quantity — ``max(x,
+    cast_unit(0, …))`` screens instead of reading as un-evaluable. A malformed
+    token raises a :class:`UnitDefinitionError`, which :func:`_verify_one_body`
+    re-raises rather than misreporting as an un-evaluable body.
     """
     token = coerce_to_composite_unit(value=unit, where="A `cast_unit` call")
-    resolved = resolve_compositional_cast_unit(unit=token, where="A `cast_unit` call")
-    quantity = UNIT_REGISTRY.Quantity(1.0, resolved)
+    resolved = resolve_compositional_cast_unit(
+        unit=token, registry=unit_system.registry, where="A `cast_unit` call"
+    )
+    quantity = unit_system.registry.Quantity(1.0, resolved)
     if isinstance(value, _DryRunQuantity):
         return value._wrap(quantity)  # noqa: SLF001
-    return quantity
+    explorer = explorer_holder[0]
+    if explorer is None:
+        return quantity
+    return _DryRunQuantity(q=quantity, explorer=explorer, unit_system=unit_system)
 
 
 def _time_conversion_shim(
-    from_pint: str, to_pint: str, *, is_flow: bool
+    from_pint: str, to_pint: str, registry: pint.UnitRegistry, *, is_flow: bool
 ) -> Callable[[Any], Any]:
     """Build a dry-run shim for one ``ttsim.unit_converters`` time converter.
 
@@ -2291,8 +2521,8 @@ def _time_conversion_shim(
     unchanged; a value whose period does not match the converter produces a
     mismatched unit that the declared-vs-inferred check then reports.
     """
-    from_q = UNIT_REGISTRY.Quantity(1.0, from_pint)
-    to_q = UNIT_REGISTRY.Quantity(1.0, to_pint)
+    from_q = registry.Quantity(1.0, from_pint)
+    to_q = registry.Quantity(1.0, to_pint)
 
     def shim(value: Any) -> Any:  # noqa: ANN401
         if not isinstance(value, _DryRunQuantity):
@@ -2303,7 +2533,7 @@ def _time_conversion_shim(
     return shim
 
 
-def _time_conversion_shims() -> dict[str, Any]:
+def _time_conversion_shims(registry: pint.UnitRegistry) -> dict[str, Any]:
     """A dry-run shim for every ``<a>_to_<b>`` / ``per_<a>_to_per_<b>`` converter."""
     shims: dict[str, Any] = {}
     for from_id, from_pint in TIME_UNIT_ID_TO_PINT_NAME.items():
@@ -2311,21 +2541,67 @@ def _time_conversion_shims() -> dict[str, Any]:
             if from_id == to_id:
                 continue
             shims[f"{from_id}_to_{to_id}"] = _time_conversion_shim(
-                from_pint=from_pint, to_pint=to_pint, is_flow=False
+                from_pint=from_pint,
+                to_pint=to_pint,
+                registry=registry,
+                is_flow=False,
             )
             shims[f"per_{from_id}_to_per_{to_id}"] = _time_conversion_shim(
-                from_pint=from_pint, to_pint=to_pint, is_flow=True
+                from_pint=from_pint,
+                to_pint=to_pint,
+                registry=registry,
+                is_flow=True,
             )
     return shims
 
 
-#: Module-level helpers swapped for unit-only shims in a dry-run body's scope.
-_DRY_RUN_HELPER_SHIMS: Mapping[str, Any] = {
-    "piecewise_polynomial": _piecewise_polynomial_dry_run,
-    "join": _join_dry_run,
-    "cast_unit": _cast_unit_dry_run,
-    **_time_conversion_shims(),
-}
+def _dry_run_helper_shims(
+    unit_system: UnitSystem,
+) -> tuple[Mapping[str, Any], list[_PathExplorer | None]]:
+    """The module-level helpers swapped for unit-only shims in a body's scope.
+
+    Each shim mints quantities in ``unit_system``'s registry, so the set is
+    built per run rather than shared. The returned ``explorer_holder`` lets the
+    ``cast_unit`` shim reach the explorer of the body currently under
+    verification — :func:`_verify_one_body` sets it per body — so a cast literal
+    becomes an explorer-carrying quantity rather than a bare pint one.
+    """
+    explorer_holder: list[_PathExplorer | None] = [None]
+    shims: Mapping[str, Any] = {
+        "piecewise_polynomial": _piecewise_polynomial_dry_run,
+        "join": _join_dry_run,
+        "cast_unit": functools.partial(
+            _cast_unit_dry_run,
+            unit_system=unit_system,
+            explorer_holder=explorer_holder,
+        ),
+        "max": _scalar_clamp_dry_run(op="maximum"),
+        "min": _scalar_clamp_dry_run(op="minimum"),
+        **_time_conversion_shims(unit_system.registry),
+    }
+    return shims, explorer_holder
+
+
+def _scalar_clamp_dry_run(op: str) -> Any:  # noqa: ANN401
+    """Shim the scalar ``max``/``min`` builtins to screen like the vectorized ops.
+
+    A scalar body's ``max(a, b)``/``min(a, b)`` runs the Python builtin, which
+    returns one operand *whole* — so on the branch where a bare ``0`` floor wins
+    the result is a unit-less ``0`` and a downstream ``/`` or ``*`` corrupts the
+    unit. Routing through :func:`_clamping_op` (the vectorizer's own path for
+    ``xnp.maximum``/``xnp.minimum``) makes the result carry the quantity's unit
+    on every branch, so a zero floor needs no ``cast_unit``. The two-argument and
+    one-iterable spellings (GEP 1) both fold through the same screen.
+    """
+
+    def shim(*args: Any) -> Any:  # noqa: ANN401
+        items = list(args[0]) if len(args) == 1 else list(args)
+        result = items[0]
+        for item in items[1:]:
+            result = _clamping_op(left=result, right=item, op=op)
+        return result
+
+    return shim
 
 
 def _clamping_op(left: Any, right: Any, op: str) -> Any:  # noqa: ANN401
@@ -2401,7 +2677,7 @@ def _structured_pluck_message(
         f"{qname}: uses a value plucked off the structured parameter "
         f"'{error.producer}' as a quantity ('{error.op}'), but such a value "
         f"carries no unit. State its unit at the structure — annotate the "
-        f"dataclass field (`Annotated[float, Unit…]`) — or at the pluck with "
+        f"dataclass field (`Annotated[float, TTSIMUnit…]`) — or at the pluck with "
         f"`cast_unit(<pluck>, <unit>)`, or opt out of body inference with "
         f"`verify_units=False` (GEP 10)."
     )
@@ -2481,6 +2757,8 @@ def _verify_one_body(
     declared: pint.Unit,
     boolean_values: Mapping[str, Any],
     base_kwargs: dict[str, Any],
+    unit_system: UnitSystem,
+    explorer_holder: list[_PathExplorer | None],
 ) -> str | None:
     """Dry-run one body on every reachable branch path; return an error or ``None``.
 
@@ -2501,6 +2779,9 @@ def _verify_one_body(
     combinations fail as well.
     """
     explorer = _PathExplorer()
+    # The `cast_unit` shim reaches this body's explorer here, so a cast literal
+    # (`max(x, cast_unit(0, …))`) becomes an explorer-carrying quantity.
+    explorer_holder[0] = explorer
     paths = 0
     branch_errors: list[str] = []
     clean_paths = 0
@@ -2516,7 +2797,12 @@ def _verify_one_body(
         paths += 1
         explorer.start_run()
         kwargs = {
-            name: _wrap_for_dry_run(value=value, explorer=explorer, label=name)
+            name: _wrap_for_dry_run(
+                value=value,
+                explorer=explorer,
+                unit_system=unit_system,
+                label=name,
+            )
             for name, value in {**base_kwargs, **boolean_values}.items()
         }
         error, terminal = _run_one_path(
@@ -2525,6 +2811,7 @@ def _verify_one_body(
             declared=declared,
             kwargs=kwargs,
             explorer=explorer,
+            unit_system=unit_system,
         )
         if terminal:
             return error
@@ -2545,6 +2832,7 @@ def _run_one_path(
     declared: pint.Unit,
     kwargs: dict[str, Any],
     explorer: _PathExplorer,
+    unit_system: UnitSystem,
 ) -> tuple[str | None, bool]:
     """Run the body once along the explorer's current path.
 
@@ -2585,6 +2873,7 @@ def _run_one_path(
         inferred=_unwrap(result),
         declared=declared,
         detail=explorer.branch_detail(),
+        unit_system=unit_system,
     ), False
 
 
@@ -2636,6 +2925,7 @@ def _bare_literal_result_error(
     inferred: Any,  # noqa: ANN401
     declared: pint.Unit,
     detail: str,
+    registry: pint.UnitRegistry,
 ) -> str | None:
     """The literal-return screen for a plain (non-``Quantity``) scalar result.
 
@@ -2647,7 +2937,7 @@ def _bare_literal_result_error(
         isinstance(inferred, int | float | numpy.number)
         and not isinstance(inferred, bool | numpy.bool_)
         and inferred != 0
-        and not UNIT_REGISTRY.Quantity(1.0, declared).dimensionless
+        and not registry.Quantity(1.0, declared).dimensionless
     ):
         return (
             f"{qname}: returns the bare literal {inferred}{detail} under the "
@@ -2690,6 +2980,7 @@ def _inferred_result_error(
     inferred: Any,  # noqa: ANN401
     declared: pint.Unit,
     detail: str,
+    unit_system: UnitSystem,
 ) -> str | None:
     """Check one dry-run result against the declaration.
 
@@ -2716,20 +3007,26 @@ def _inferred_result_error(
     ``CURRENCY``) stay lenient; a non-zero literal return and a dimensionless
     claim on a group-owned declaration are rejected.
     """
+    registry = unit_system.registry
     if not isinstance(
         inferred, pint.Quantity | int | float | numpy.number | numpy.bool_
     ):
         return _non_quantity_result_error(qname=qname, inferred=inferred)
     if not isinstance(inferred, pint.Quantity):
         return _bare_literal_result_error(
-            qname=qname, inferred=inferred, declared=declared, detail=detail
+            qname=qname,
+            inferred=inferred,
+            declared=declared,
+            detail=detail,
+            registry=registry,
         )
     if inferred.dimensionless:
         return _dimensionless_claim_error(qname=qname, declared=declared, detail=detail)
     inferred_unit = cast("pint.Unit", inferred.units)
     if not units_are_equivalent(
-        left=_unit_without_grouping_levels(inferred_unit),
-        right=_unit_without_grouping_levels(declared),
+        left=_unit_without_grouping_levels(unit=inferred_unit, registry=registry),
+        right=_unit_without_grouping_levels(unit=declared, registry=registry),
+        registry=registry,
     ):
         return (
             f"{qname}: declares '{declared}' but its body infers "

--- a/src/ttsim/interface_dag_elements/unit_system.py
+++ b/src/ttsim/interface_dag_elements/unit_system.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from ttsim.interface_dag_elements.interface_node_objects import interface_input
+from ttsim.tt.currencies import UnitSystem
+
+
+@interface_input(in_top_level_namespace=True)
+def unit_system() -> UnitSystem:
+    """The policy system's currencies, statutory-currency mapping, and levels.
+
+    A user-supplied leaf, like ``orig_policy_objects__root``: a policy package
+    declares one :class:`~ttsim.tt.currencies.UnitSystem` at import and passes it
+    to ``main(unit_system=...)``. Packages wrapping ``main`` (GETTSIM) default it
+    to their own, so their users never name it.
+    """

--- a/src/ttsim/interface_dag_elements/warn_if.py
+++ b/src/ttsim/interface_dag_elements/warn_if.py
@@ -11,7 +11,7 @@ from ttsim.interface_dag_elements.fail_if import (
 )
 from ttsim.interface_dag_elements.interface_node_objects import warn_function
 from ttsim.tt.column_objects_param_function import PolicyInput
-from ttsim.tt.currencies import base_currency
+from ttsim.tt.currencies import UnitSystem
 from ttsim.warnings import PotentialCurrencyMismatchWarning
 
 if TYPE_CHECKING:
@@ -32,15 +32,18 @@ if TYPE_CHECKING:
         "computation_currency",
         "data_currency",
         "policy_date",
+        "unit_system",
     ]
 )
 def statutory_currency_and_base_currency_differ(
     computation_currency: str,
     data_currency: str,
     policy_date: datetime.date,
+    unit_system: UnitSystem,
 ) -> None:
     """Warn if the statutory currency and base currency differ."""
-    if computation_currency != base_currency() and data_currency == base_currency():
+    base_currency = unit_system.base_currency
+    if computation_currency != base_currency and data_currency == base_currency:
         msg = (
             f"The statutory currency for {policy_date} is {computation_currency}, "
             f"but the currency of the input and output data is {data_currency}. Make "

--- a/src/ttsim/main_args.py
+++ b/src/ttsim/main_args.py
@@ -159,9 +159,9 @@ class InputData(MainArg):
         converted to the data currency, its period is checked against the column's
         time suffix, and its dimension and grouping level are checked against the
         column's declared unit. A currency column names a concrete currency
-        (``unit=Unit.EUR.PER_MONTH``, never the agnostic ``Unit.CURRENCY``); tag
-        a dimensionless column (an id, a boolean) with
-        ``UnitAnnotatedColumn(values=arr, unit=Unit.DIMENSIONLESS)``; use
+        (``unit=TTSIMUnit.EUR.PER_MONTH``, never the agnostic
+        ``TTSIMUnit.CURRENCY``); tag a dimensionless column (an id, a boolean) with
+        ``UnitAnnotatedColumn(values=arr, unit=TTSIMUnit.DIMENSIONLESS)``; use
         :meth:`tree` for untagged data.
         """
         return _set_single_field(

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -224,6 +224,7 @@ class MainTarget(MainTargetABC):
     tt_targets: type[Targets] = field(default=Targets)
     len_p_id: str = "len_p_id"
     backend: str = "backend"
+    unit_system: str = "unit_system"
     data_currency: str = "data_currency"
     computation_currency: str = "computation_currency"
     evaluation_date_str: str = "evaluation_date_str"

--- a/src/ttsim/plot/dag/interface.py
+++ b/src/ttsim/plot/dag/interface.py
@@ -49,6 +49,7 @@ INTERFACE_COLORMAP: dict[tuple[str, ...] | str, str] = {
     ("data_currency",): "lightgray",
     ("dnp",): "lightgray",
     ("len_p_id",): "lightgray",
+    ("unit_system",): "lightgray",
     ("xnp",): "lightgray",
 }
 

--- a/src/ttsim/plot/dag/tt.py
+++ b/src/ttsim/plot/dag/tt.py
@@ -24,6 +24,7 @@ from ttsim.tt import (
     ParamFunction,
     ParamObject,
     TimeConversionFunction,
+    UnitSystem,
 )
 from ttsim.typing import (
     DashedISOString,
@@ -48,6 +49,7 @@ def tt(
     # Elements of main
     policy_date_str: DashedISOString | None = None,
     orig_policy_objects: OrigPolicyObjects | None = None,
+    unit_system: UnitSystem | None = None,
     input_data: InputData | None = None,
     processed_data: QNameData | None = None,
     labels: Labels | None = None,
@@ -112,6 +114,7 @@ def tt(
             hierarchy.
         policy_date_str: The date for which to plot the DAG.
         orig_policy_objects: The orig policy objects.
+        unit_system: The policy system's currencies and grouping levels.
         input_data: The input data.
         processed_data: The processed data.
         labels: The labels.
@@ -136,6 +139,7 @@ def tt(
         policy_date_str=policy_date_str,
         policy_environment=policy_environment,
         orig_policy_objects=orig_policy_objects,
+        unit_system=unit_system,
         processed_data=processed_data,
         labels=labels,
         backend=backend,
@@ -166,6 +170,7 @@ def _get_tt_dag_with_node_metadata(
     policy_date_str: DashedISOString | None = None,
     policy_environment: PolicyEnvironment | None = None,
     orig_policy_objects: OrigPolicyObjects | None = None,
+    unit_system: UnitSystem | None = None,
     processed_data: QNameData | None = None,
     labels: Labels | None = None,
     backend: Literal["numpy", "jax"] = "numpy",
@@ -192,6 +197,7 @@ def _get_tt_dag_with_node_metadata(
         ],
         policy_date_str=policy_date_str,
         orig_policy_objects=orig_policy_objects,
+        unit_system=unit_system,
         policy_environment=policy_environment,
         tt_targets=tt_targets,
         input_data=input_data,

--- a/src/ttsim/testing_utils.py
+++ b/src/ttsim/testing_utils.py
@@ -27,6 +27,7 @@ from ttsim.interface_dag_elements.unit_checks import (
     fail_if_environment_units_are_missing,
 )
 from ttsim.main_args import InputData, OrigPolicyObjects, TTTargets
+from ttsim.tt.currencies import UnitSystem
 from ttsim.typing import (
     FlatColumnObjectsParamFunctions,
     FlatOrigParamSpecs,
@@ -45,11 +46,13 @@ def cached_policy_environment(
     policy_date: datetime.date,
     root: Path,
     backend: Literal["numpy", "jax"],
+    unit_system: UnitSystem,
 ) -> PolicyEnvironment:
     return main(
         main_target="policy_environment",
         policy_date=policy_date,
         orig_policy_objects=OrigPolicyObjects.root(root),
+        unit_system=unit_system,
         backend=backend,
         include_fail_nodes=True,
         include_warn_nodes=False,
@@ -103,12 +106,14 @@ def execute_test(
     test: PolicyTest,
     root: Path,
     backend: Literal["numpy", "jax"],
+    unit_system: UnitSystem,
     default_data_currency: str | None = None,
 ) -> None:
     environment = cached_policy_environment(
         policy_date=test.policy_date,
         root=root,
         backend=backend,
+        unit_system=unit_system,
     )
     if test.target_structure:
         result_df = main(
@@ -119,6 +124,7 @@ def execute_test(
             tt_targets=TTTargets.tree(test.target_structure),
             rounding=True,
             backend=backend,
+            unit_system=unit_system,
             data_currency=test.info.get("data_currency", default_data_currency),
             include_fail_nodes=True,
             include_warn_nodes=False,
@@ -255,11 +261,13 @@ def check_env_completeness(
     orig_policy_objects: dict[
         str, FlatColumnObjectsParamFunctions | FlatOrigParamSpecs
     ],
+    unit_system: UnitSystem,
 ) -> None:
     qname_env_with_derived_functions = main(
         main_target="specialized_environment_for_plotting_and_templates__without_tree_logic_and_with_derived_functions",
         policy_date=policy_date,
         orig_policy_objects=OrigPolicyObjects(**orig_policy_objects),
+        unit_system=unit_system,
         backend="numpy",
     )
     all_nodes = {
@@ -299,6 +307,7 @@ def check_env_units(
     orig_policy_objects: dict[
         str, FlatColumnObjectsParamFunctions | FlatOrigParamSpecs
     ],
+    unit_system: UnitSystem,
 ) -> None:
     """Run the unit checks over the full environment at a policy date.
 
@@ -319,6 +328,7 @@ def check_env_units(
         ],
         policy_date=policy_date,
         orig_policy_objects=OrigPolicyObjects(**orig_policy_objects),
+        unit_system=unit_system,
         backend="numpy",
     )
     env = targets["specialized_environment_for_plotting_and_templates"][
@@ -326,4 +336,6 @@ def check_env_units(
     ]
     grouping_levels = targets["labels"]["grouping_levels"]
     fail_if_environment_units_are_missing(env=env, grouping_levels=grouping_levels)
-    fail_if_environment_units_are_inconsistent(env=env, grouping_levels=grouping_levels)
+    fail_if_environment_units_are_inconsistent(
+        env=env, grouping_levels=grouping_levels, unit_system=unit_system
+    )

--- a/src/ttsim/tt/__init__.py
+++ b/src/ttsim/tt/__init__.py
@@ -17,7 +17,7 @@ from ttsim.tt.column_objects_param_function import (
     policy_function,
     policy_input,
 )
-from ttsim.tt.currencies import register_currency, register_statutory_currencies
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.grouping_levels import register_unit_builder_levels
 from ttsim.tt.interval_utils import intervals_to_thresholds, merge_piecewise_intervals
 from ttsim.tt.param_objects import (
@@ -45,7 +45,7 @@ from ttsim.tt.shared import join
 from ttsim.tt.units import (
     UNSET_UNIT,
     CompositeUnit,
-    Unit,
+    TTSIMUnit,
     UnitAnnotatedColumn,
     cast_unit,
 )
@@ -74,9 +74,10 @@ __all__ = [
     "RawParam",
     "RoundingSpec",
     "ScalarParam",
+    "TTSIMUnit",
     "TimeConversionFunction",
-    "Unit",
     "UnitAnnotatedColumn",
+    "UnitSystem",
     "agg_by_group_function",
     "agg_by_p_id_function",
     "cast_unit",
@@ -93,7 +94,5 @@ __all__ = [
     "piecewise_polynomial",
     "policy_function",
     "policy_input",
-    "register_currency",
-    "register_statutory_currencies",
     "register_unit_builder_levels",
 ]

--- a/src/ttsim/tt/column_objects_param_function.py
+++ b/src/ttsim/tt/column_objects_param_function.py
@@ -63,7 +63,6 @@ from ttsim.tt.type_resolution import (
 from ttsim.tt.units import (
     UNSET_UNIT,
     CompositeUnit,
-    unit_for_aggregation,
 )
 from ttsim.tt.vectorization import vectorize_function
 from ttsim.typing import DashedISOString, IntColumn, UnorderedQNames
@@ -637,7 +636,7 @@ def group_creation_function(
         reorder: Whether the created Group ID's should be reordered to be
             consecutively numbered starting from 0.
         unit: The group id's compositional unit. A group id is a dimensionless
-            identifier, so this is ``Unit.DIMENSIONLESS``.
+            identifier, so this is ``TTSIMUnit.DIMENSIONLESS``.
 
     """
     start_date, end_date = _convert_and_validate_dates(
@@ -758,15 +757,6 @@ def agg_by_group_function(
         group_ids = {p for p in args if p.endswith("_id")}
         _fail_if_group_id_is_invalid(group_ids=group_ids, orig_location=orig_location)
         group_id = group_ids.pop()
-        # An aggregation's unit follows from its type, so when the decorator leaves
-        # it UNSET it is derived here via `unit_for_aggregation`.
-        node_unit = unit
-        if node_unit is UNSET_UNIT:
-            node_unit = unit_for_aggregation(
-                source_unit=UNSET_UNIT,
-                agg_type=agg_type,
-                target_level=group_id.removesuffix("_id"),
-            )
         other_args = args - {group_id, "num_segments", "backend"}
         column_name: str | None
         if agg_type == AggType.COUNT:
@@ -781,6 +771,11 @@ def agg_by_group_function(
             )
             column_name = other_args.pop()
             mapper = {"group_id": group_id, "column": column_name}
+        _fail_if_unit_is_unset(
+            unit=unit,
+            decorator_name="@agg_by_group_function",
+            orig_location=orig_location,
+        )
         agg_func = _make_typed_aggregation_function(
             primitive=agg_registry[agg_type],
             mapper=mapper,
@@ -799,12 +794,31 @@ def agg_by_group_function(
             orig_location=f"{func.__module__}.{func.__name__}",  # ty: ignore[unresolved-attribute]
             warn_msg_if_included=warn_msg_if_included,
             fail_msg_if_included=fail_msg_if_included,
-            unit=node_unit,
+            unit=unit,
             verify_units=verify_units,
             agg_type=agg_type,
         )
 
     return inner
+
+
+def _fail_if_unit_is_unset(
+    unit: CompositeUnit,
+    decorator_name: str,
+    orig_location: str,
+) -> None:
+    """Fail if an aggregation does not declare a unit.
+
+    Aggregations declare their ``unit`` explicitly like every other declaration
+    (GEP 10); the framework then verifies it against the aggregated source and
+    the aggregation type.
+    """
+    if unit is UNSET_UNIT:
+        msg = (
+            f"{decorator_name} at {orig_location} must declare a `unit=` (GEP 10). "
+            f"Every aggregation states its unit explicitly, whatever the operation."
+        )
+        raise AggregationDefinitionError(msg)
 
 
 def _fail_if_group_id_is_invalid(
@@ -966,10 +980,6 @@ def agg_by_p_id_function(
     start_date, end_date = _convert_and_validate_dates(
         start_date=start_date, end_date=end_date
     )
-    # When the decorator leaves the unit UNSET it is derived from the aggregation
-    # type via `unit_for_aggregation`.
-    if unit is UNSET_UNIT:
-        unit = unit_for_aggregation(source_unit=UNSET_UNIT, agg_type=agg_type)
 
     agg_registry: dict[AggType, Callable[..., Any]] = {
         AggType.SUM: sum_by_p_id,
@@ -1023,6 +1033,11 @@ def agg_by_p_id_function(
                 "num_segments": "num_segments",
                 "backend": "backend",
             }
+        _fail_if_unit_is_unset(
+            unit=unit,
+            decorator_name="@agg_by_p_id_function",
+            orig_location=orig_location,
+        )
         agg_func = _make_typed_aggregation_function(
             primitive=agg_registry[agg_type],
             mapper=mapper,

--- a/src/ttsim/tt/currencies.py
+++ b/src/ttsim/tt/currencies.py
@@ -79,7 +79,9 @@ class UnitSystem:
     start date it applies from (until the next entry's). Mandatory: a run for a
     policy date with no statutory currency fails."""
 
-    other_currencies: Mapping[str, str] = MappingProxyType({})
+    other_currencies: Mapping[str, str] = dataclasses.field(
+        default_factory=lambda: MappingProxyType({})
+    )
     """Each further currency, mapped to a pint-parseable definition relative to
     an already-defined currency of this system (``{"DM": "EUR / 1.95583"}``).
     Definitions are applied in order, so one may reference an earlier one."""

--- a/src/ttsim/tt/currencies.py
+++ b/src/ttsim/tt/currencies.py
@@ -1,326 +1,300 @@
-"""Currency registration and boundary conversion.
+"""A policy system's currencies, and the boundary conversion between them.
 
-The registration and conversion *operations* of the ``[currency]`` dimension. The
-currency vocabulary itself — the ``CURRENCY`` token, the ``Unit`` builder, and the state
-a declaration is resolved against — lives in :mod:`ttsim.tt.units`; this module reads
-and mutates that shared state.
+A :class:`UnitSystem` is the value a policy package builds once, at import, and
+hands to ``main(unit_system=...)``: its currencies, the dated statutory-currency
+mapping, the grouping levels its declarations spell — and the pint registry all
+of those are defined in.
 
-A downstream package registers its currencies on import: one base currency, any number
-of others defined relative to an already-registered one, and the dated
-statutory-currency mapping.
+The registry is per system, so two policy systems coexist in one process, each
+with its own base currency. "Exactly one currency is the base" (GEP 10) holds
+within a system, by construction: the base is a constructor argument, not
+something a second import could contradict.
+
+The unit *vocabulary* a declaration is spelled in — the ``CURRENCY`` token, the
+``TTSIMUnit`` builder, the :class:`CompositeUnit` grammar — is shared and lives in
+:mod:`ttsim.tt.units`.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
-import math
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
+from types import MappingProxyType
 
 import pint
 from pint.util import to_units_container
 
 from ttsim.exceptions import UnitDefinitionError
+from ttsim.tt.grouping_levels import register_grouping_levels
 from ttsim.tt.units import (
     _ALLOWED_UNIT_TOKENS,
-    _REL_TOL,
     CURRENCY_TOKEN,
-    UNIT_REGISTRY,
     CompositeUnit,
-    Unit,
+    TTSIMUnit,
     _registered_currencies,
+    _unit_is_currency,
+    build_registry,
 )
 
-_base_currency: list[str] = []
 
-#: The statutory-currency mapping: ``(start_date, currency)`` pairs sorted by
-#: start date, each applying from its start date until the next entry's. Empty
-#: until a downstream package registers its mapping.
-_statutory_currencies: list[tuple[datetime.date, str]] = []
+@dataclasses.dataclass(frozen=True, eq=False, kw_only=True)
+class UnitSystem:
+    """The currencies, statutory-currency mapping, and registry of one policy system.
 
+    A package builds one system and exports it as a singleton, so a system is
+    identified by object identity: ``eq=False`` keeps the inherited
+    identity-based ``__hash__``, which lets a system key an ``lru_cache`` (its
+    ``statutory_currencies`` mapping is otherwise unhashable).
 
-def base_currency() -> str:
-    """The registered base currency — the default data currency.
+    A policy package declares its system once and exports it::
 
-    A downstream package registers its base currency on import (gettsim's
-    ``euro``, mettsim's ``CASTAR``), and user data is assumed to arrive in it —
-    users need not pass ``data_currency=`` themselves.
+        UNIT_SYSTEM = UnitSystem(
+            base_currency="EUR",
+            other_currencies={"DM": "EUR / 1.95583"},
+            statutory_currencies={"0001-01-01": "DM", "2002-01-01": "EUR"},
+            grouping_levels=["hh", "bg", "fg"],
+        )
+
+    All of a system's currencies are interconvertible
+    (:meth:`currency_conversion_factor`); a currency of *another* system is not,
+    and is rejected rather than silently taken to be worth the same.
 
     Raises:
-        UnitDefinitionError: If no base currency is registered — the data
-            currency must be a concrete currency (GEP 10).
+        UnitDefinitionError: If a currency name clashes with a unit the shared
+            vocabulary already defines, if a definition does not resolve to the
+            ``[currency]`` dimension or does not reference exactly one of this
+            system's currencies, or if the statutory-currency mapping is empty
+            or names a currency the system does not have.
     """
-    if not _base_currency:
-        raise UnitDefinitionError(
-            "No base currency is registered, so the data currency is undefined. "
-            "A package must register one with `register_currency(name=..., "
-            "base=True)` before the system can run (GEP 10)."
-        )
-    return _base_currency[0]
 
+    base_currency: str
+    """The system's unit of account, and the default data currency. Defined as
+    factor 1 against the abstract ``[currency]`` reference; every other currency
+    is defined relative to it or to another already-defined one."""
 
-def register_statutory_currencies(currency_by_start_date: Mapping[str, str]) -> None:
-    """Declare the statutory currency at each start date.
+    statutory_currencies: Mapping[str, str]
+    """The currency statutes denominate their numbers in, keyed by the dashed ISO
+    start date it applies from (until the next entry's). Mandatory: a run for a
+    policy date with no statutory currency fails."""
 
-    A downstream package calls this on import, after registering the currencies
-    it references. Each entry applies from its start date (a dashed ISO string)
-    until the next entry's start date; the computation for a policy date runs in
-    the statutory currency at that date (:func:`statutory_currency_for_date`),
-    and the build guard requires every parameter to be declared in it.
+    other_currencies: Mapping[str, str] = MappingProxyType({})
+    """Each further currency, mapped to a pint-parseable definition relative to
+    an already-defined currency of this system (``{"DM": "EUR / 1.95583"}``).
+    Definitions are applied in order, so one may reference an earlier one."""
 
-    Example:
-        register_statutory_currencies({"1948-06-21": "DM", "2002-01-01": "EUR"})
+    grouping_levels: Sequence[str] = ()
+    """The group levels this system's declarations spell (``["hh", "bg"]``). The
+    individual ``person`` leaf is always present. A build discovers further
+    levels from the policy environment's ``*_id`` columns and registers them
+    then."""
 
-    The mapping is mandatory: a run for a policy date with no registered
-    statutory currency fails.
+    registry: pint.UnitRegistry = dataclasses.field(init=False, repr=False)
+    """The system's own pint registry: the shared vocabulary plus this system's
+    currency definitions and grouping-level dimensions."""
 
-    Raises:
-        UnitDefinitionError: If the mapping is empty, references an unregistered
-            currency, or a different mapping is already registered.
-    """
-    if not currency_by_start_date:
-        raise UnitDefinitionError(
-            "register_statutory_currencies requires at least one entry; got an "
-            "empty mapping (GEP 10)."
-        )
-    unregistered = sorted(
-        {
-            name
-            for name in currency_by_start_date.values()
-            if name not in _registered_currencies
-        }
+    currencies: frozenset[str] = dataclasses.field(init=False)
+    """Every currency name this system defines — the base and the others."""
+
+    statutory_currency_by_start_date: tuple[tuple[datetime.date, str], ...] = (
+        dataclasses.field(init=False, repr=False)
     )
-    if unregistered:
-        raise UnitDefinitionError(
-            f"register_statutory_currencies references "
-            f"{', '.join(repr(name) for name in unregistered)}, which "
-            f"{'is' if len(unregistered) == 1 else 'are'} not registered. "
-            f"Register every statutory currency with `register_currency` first "
-            f"(GEP 10)."
-        )
-    entries = sorted(
-        (datetime.date.fromisoformat(start_date), name)
-        for start_date, name in currency_by_start_date.items()
+    """:attr:`statutory_currencies` parsed and sorted by start date."""
+
+    field_units_by_class: dict[type, dict[str, pint.Unit | type] | None] = (
+        dataclasses.field(init=False, repr=False, default_factory=dict)
     )
-    if _statutory_currencies and _statutory_currencies != entries:
-        raise UnitDefinitionError(
-            f"A different statutory-currency mapping is already registered "
-            f"({_statutory_currencies}). A process has a single statutory-"
-            f"currency mapping (GEP 10)."
+    """Memo of the resolved unit annotations of each parameter dataclass the
+    dry-run has seen. The units are this system's registry's, so the memo is the
+    system's."""
+
+    def __post_init__(self) -> None:
+        registry = build_registry()
+        object.__setattr__(self, "registry", registry)
+        object.__setattr__(
+            self,
+            "currencies",
+            frozenset({self.base_currency, *self.other_currencies}),
         )
-    _statutory_currencies[:] = entries
-
-
-def statutory_currency_for_date(policy_date: datetime.date) -> str:
-    """The statutory currency at a given policy date.
-
-    Raises:
-        UnitDefinitionError: If no mapping is registered, or ``policy_date``
-            lies before the mapping's first entry.
-    """
-    if not _statutory_currencies:
-        raise UnitDefinitionError(
-            "No statutory-currency mapping is registered, so the computation "
-            "currency is undefined. A package must register one with "
-            "`register_statutory_currencies({start_date: currency, ...})` "
-            "before the system can run (GEP 10)."
+        self._define_currencies()
+        object.__setattr__(
+            self,
+            "statutory_currency_by_start_date",
+            self._parsed_statutory_currencies(),
         )
-    for start_date, name in reversed(_statutory_currencies):
-        if policy_date >= start_date:
-            return name
-    raise UnitDefinitionError(
-        f"The statutory-currency mapping starts at "
-        f"{_statutory_currencies[0][0].isoformat()}, so the statutory currency "
-        f"at {policy_date.isoformat()} is undefined. Extend the mapping "
-        f"registered with `register_statutory_currencies` (GEP 10)."
-    )
+        register_grouping_levels(names=self.grouping_levels, registry=registry)
 
+    def currency_conversion_factor(
+        self, *, source_currency: str, target_currency: str
+    ) -> float:
+        """The factor converting ``source_currency`` into ``target_currency``.
 
-def _fail_if_definition_references_no_registered_currency(
-    name: str, definition: str
-) -> None:
-    """Reject a currency definition that does not chain to a registered currency.
+        Used only where data enters and leaves the computation: input columns are
+        converted from the data currency to the computation currency, and
+        currency-denominated results are converted back (GEP 10). pint is the
+        single source of truth for the rate. Both currencies must belong to this
+        system; all of a system's currencies are interconvertible.
 
-    Every non-base currency is defined relative to exactly one already-registered
-    concrete currency (``"CASTAR / 4"``). A definition against the abstract
-    :data:`CURRENCY_TOKEN` reference alone, or against no currency at all, would
-    start a second, unconnected base — which the single-base model forbids.
-
-    Raises:
-        UnitDefinitionError: If the definition references an unregistered unit,
-            no registered currency, or more than one.
-    """
-    try:
-        parsed_definition = UNIT_REGISTRY.parse_expression(definition)
-    except pint.UndefinedUnitError as error:
-        raise UnitDefinitionError(
-            f"Currency {name!r} is defined as {definition!r}, which "
-            f"references an unregistered unit. Define a currency relative "
-            f"to an already-registered one (GEP 10)."
-        ) from error
-    referenced = sorted(
-        str(token)
-        for token in to_units_container(parsed_definition.units)
-        if str(token) in _registered_currencies
-    )
-    if len(referenced) > 1:
-        raise UnitDefinitionError(
-            f"Currency {name!r} must be defined relative to exactly one "
-            f"registered currency; {definition!r} references "
-            f"{', '.join(referenced)} (GEP 10)."
+        Raises:
+            UnitDefinitionError: If either currency is not one of this system's.
+        """
+        for name in (source_currency, target_currency):
+            if name not in self.currencies:
+                raise UnitDefinitionError(
+                    f"Cannot convert currency: {name!r} is not a registered "
+                    f"currency of this policy system. Its currencies are "
+                    f"{', '.join(sorted(self.currencies))} (GEP 10)."
+                )
+        return (
+            self.registry.Quantity(1.0, source_currency).to(target_currency).magnitude
         )
-    if not referenced:
+
+    def statutory_currency_for_date(self, policy_date: datetime.date) -> str:
+        """The statutory currency at a given policy date.
+
+        Raises:
+            UnitDefinitionError: If ``policy_date`` lies before the mapping's
+                first entry.
+        """
+        for start_date, name in reversed(self.statutory_currency_by_start_date):
+            if policy_date >= start_date:
+                return name
         raise UnitDefinitionError(
-            f"Currency {name!r} defined as {definition!r} references no "
-            f"registered currency. Define it relative to an already-registered "
-            f"one (e.g. the base currency) (GEP 10)."
+            f"The statutory-currency mapping starts at "
+            f"{self.statutory_currency_by_start_date[0][0].isoformat()}, so the "
+            f"statutory currency at {policy_date.isoformat()} is undefined. "
+            f"Extend the mapping this policy system declares (GEP 10)."
+        )
+
+    def _define_currencies(self) -> None:
+        """Define the base and every other currency in the system's registry.
+
+        The base is factor 1 against the abstract :data:`CURRENCY_TOKEN`
+        reference; every other currency is defined relative to an
+        already-defined one, so all of them chain back to the base and are
+        interconvertible.
+        """
+        self._define_one_currency(name=self.base_currency, definition=CURRENCY_TOKEN)
+        defined = {self.base_currency}
+        for name, definition in self.other_currencies.items():
+            self._fail_if_definition_references_no_known_currency(
+                name=name, definition=definition, defined=defined
+            )
+            self._define_one_currency(name=name, definition=definition)
+            defined.add(name)
+        for name in self.currencies:
+            _ALLOWED_UNIT_TOKENS.add(name)
+            _registered_currencies.add(name)
+            # Surface the concrete currency on the `TTSIMUnit` builder (`TTSIMUnit.EUR`,
+            # `TTSIMUnit.DM`, `TTSIMUnit.SILVER_PENNY`) so it can tag a
+            # `UnitAnnotatedColumn` of input data. A column/function declaration
+            # still rejects a concrete base (`resolve_compositional_column_unit`);
+            # this only makes it reachable.
+            setattr(TTSIMUnit, name.upper(), CompositeUnit(base=name.upper()))
+
+    def _define_one_currency(self, name: str, definition: str) -> None:
+        """Define one currency in the registry, checking it lands in ``[currency]``."""
+        if name in self.registry:
+            raise UnitDefinitionError(
+                f"Cannot define currency {name!r}: a unit of that name already "
+                f"exists ({self.registry.Quantity(1.0, name).dimensionality}). "
+                f"Pick a name outside the shared unit vocabulary (GEP 10)."
+            )
+        self.registry.define(f"{name} = {definition}")
+        if not _unit_is_currency(self.registry.parse_units(name)):
+            raise UnitDefinitionError(
+                f"Currency {name!r} defined as {definition!r} does not resolve "
+                f"to the [currency] dimension."
+            )
+
+    def _fail_if_definition_references_no_known_currency(
+        self, name: str, definition: str, defined: set[str]
+    ) -> None:
+        """Reject a currency definition that does not chain to a known currency.
+
+        Every non-base currency is defined relative to exactly one currency this
+        system has already defined (``"CASTAR / 4"``). A definition against the
+        abstract :data:`CURRENCY_TOKEN` reference alone, or against no currency
+        at all, would start a second, unconnected base — which the single-base
+        model forbids.
+
+        Raises:
+            UnitDefinitionError: If the definition references a unit the registry
+                does not know, no currency of this system, or more than one.
+        """
+        try:
+            parsed = self.registry.parse_expression(definition)
+        except pint.UndefinedUnitError as error:
+            raise UnitDefinitionError(
+                f"Currency {name!r} is defined as {definition!r}, which "
+                f"references a unit this policy system does not define. Define a "
+                f"currency relative to one of its own (GEP 10)."
+            ) from error
+        referenced = sorted(
+            str(token)
+            for token in to_units_container(parsed.units)
+            if str(token) in defined
+        )
+        if len(referenced) > 1:
+            raise UnitDefinitionError(
+                f"Currency {name!r} must be defined relative to exactly one "
+                f"currency of this policy system; {definition!r} references "
+                f"{', '.join(referenced)} (GEP 10)."
+            )
+        if not referenced:
+            raise UnitDefinitionError(
+                f"Currency {name!r} defined as {definition!r} references no "
+                f"currency of this policy system. Define it relative to one "
+                f"already defined (e.g. the base currency) (GEP 10)."
+            )
+
+    def _parsed_statutory_currencies(self) -> tuple[tuple[datetime.date, str], ...]:
+        """Parse and sort the statutory-currency mapping.
+
+        Raises:
+            UnitDefinitionError: If the mapping is empty or names a currency this
+                system does not define.
+        """
+        if not self.statutory_currencies:
+            raise UnitDefinitionError(
+                "`statutory_currencies` requires at least one entry; got an "
+                "empty mapping (GEP 10)."
+            )
+        unknown = sorted(set(self.statutory_currencies.values()) - self.currencies)
+        if unknown:
+            raise UnitDefinitionError(
+                f"`statutory_currencies` references "
+                f"{', '.join(repr(name) for name in unknown)}, which "
+                f"{'is' if len(unknown) == 1 else 'are'} not a currency of this "
+                f"policy system. Declare every statutory currency as the "
+                f"`base_currency` or in `other_currencies` (GEP 10)."
+            )
+        return tuple(
+            sorted(
+                (datetime.date.fromisoformat(start_date), name)
+                for start_date, name in self.statutory_currencies.items()
+            )
         )
 
 
 @contextmanager
 def isolated_currency_registration() -> Iterator[None]:
-    """Restore the currency bookkeeping on exit (a test isolation tool).
+    """Restore the shared unit vocabulary on exit (a test isolation tool).
 
-    Registrations made inside the block do not leak: the currency set, the base
-    currency, the statutory-currency mapping, and the token vocabulary are
-    restored. The pint definitions
-    created inside the block cannot be removed, but without the bookkeeping
-    they are inert, and a later *consistent* re-registration is tolerated
-    (:func:`register_currency`).
+    A :class:`UnitSystem` keeps its currency definitions and level dimensions to
+    itself, but it also widens the process-global vocabulary — the currency
+    *names* a declaration may spell and the pint tokens a unit may combine — so
+    that a `CompositeUnit` can be classified without a system in scope. This
+    block restores both sets, so a system built inside it leaves the vocabulary
+    as it found it.
     """
     saved_currencies = set(_registered_currencies)
-    saved_base = list(_base_currency)
-    saved_statutory = list(_statutory_currencies)
     saved_tokens = set(_ALLOWED_UNIT_TOKENS)
     try:
         yield
     finally:
         _registered_currencies.clear()
         _registered_currencies.update(saved_currencies)
-        _base_currency[:] = saved_base
-        _statutory_currencies[:] = saved_statutory
         _ALLOWED_UNIT_TOKENS.clear()
         _ALLOWED_UNIT_TOKENS.update(saved_tokens)
-
-
-def register_currency(
-    name: str,
-    *,
-    base: bool = False,
-    definition: str | None = None,
-) -> None:
-    """Register a concrete currency in the ``[currency]`` dimension.
-
-    Downstream packages call this on import. Exactly one currency is the *base*
-    currency (factor 1 against the abstract :data:`CURRENCY_TOKEN` reference);
-    every other currency is defined relative to an already-known currency. All
-    currencies are interconvertible (:func:`currency_conversion_factor`), and the
-    base is the default data currency (the ``data_currency`` interface node).
-
-    The registered currency becomes a valid compositional *base* — its
-    upper-cased name (``register_currency("DM", ...)`` makes ``DM``,
-    ``DM_PER_MONTH``, … parseable) — so parameters can pin down the concrete
-    currency their numbers are written in.
-
-    Args:
-        name: The currency's unit name (e.g. ``"euro"``, ``"DM"``).
-        base: Whether this is the base currency. Mutually exclusive with
-            ``definition``.
-        definition: A pint-parseable definition relative to an already-registered
-            currency (e.g. ``"euro / 1.95583"``). Mutually exclusive with
-            ``base``.
-
-    Raises:
-        UnitDefinitionError: If the arguments are inconsistent, if a different
-            base currency is already registered, if the definition does not
-            resolve to the ``[currency]`` dimension, or if it does not reference
-            exactly one registered currency.
-    """
-    if base == (definition is not None):
-        raise UnitDefinitionError(
-            "register_currency requires exactly one of `base=True` or "
-            f"`definition=...`; got base={base!r}, definition={definition!r}."
-        )
-    if base and _base_currency and _base_currency[0] != name:
-        raise UnitDefinitionError(
-            f"Cannot register {name!r} as the base currency: {_base_currency[0]!r} "
-            f"is already the base. A process has a single base currency (GEP 10)."
-        )
-    if definition is not None:
-        _fail_if_definition_references_no_registered_currency(
-            name=name, definition=definition
-        )
-
-    currency_dim = UNIT_REGISTRY.Quantity(1.0, CURRENCY_TOKEN).dimensionality
-    if name in UNIT_REGISTRY:
-        # Idempotent re-registration (e.g. a re-imported module). Tolerate it
-        # only if the existing definition is consistent with this call — same
-        # dimension *and* same conversion factor: checking the dimension alone
-        # would silently keep the old factor and invalidate later conversions.
-        existing_dim = UNIT_REGISTRY.Quantity(1.0, name).dimensionality
-        if existing_dim != currency_dim:
-            raise UnitDefinitionError(
-                f"Cannot register currency {name!r}: a non-currency unit of "
-                f"that name already exists ({existing_dim})."
-            )
-        existing_factor = UNIT_REGISTRY.Quantity(1.0, name).to(CURRENCY_TOKEN).magnitude
-        if definition is not None:
-            requested_factor = (
-                UNIT_REGISTRY.parse_expression(definition).to(CURRENCY_TOKEN).magnitude
-            )
-        else:
-            requested_factor = 1.0
-        if not math.isclose(existing_factor, requested_factor, rel_tol=_REL_TOL):
-            requested_desc = "base (factor 1)" if base else f"{definition!r}"
-            raise UnitDefinitionError(
-                f"Cannot re-register currency {name!r}: it already converts to "
-                f"{existing_factor} {CURRENCY_TOKEN}, but this call ({requested_desc}) "
-                f"requests {requested_factor}. A currency's factor against "
-                f"{CURRENCY_TOKEN} must be consistent across registrations (GEP 10)."
-            )
-    else:
-        UNIT_REGISTRY.define(
-            f"{name} = {CURRENCY_TOKEN}" if base else f"{name} = {definition}"
-        )
-        if UNIT_REGISTRY.Quantity(1.0, name).dimensionality != currency_dim:
-            raise UnitDefinitionError(
-                f"Currency {name!r} defined as {definition!r} does not resolve "
-                f"to the [currency] dimension."
-            )
-
-    _ALLOWED_UNIT_TOKENS.add(name)
-    _registered_currencies.add(name)
-    if base:
-        _base_currency[:] = [name]
-    # Surface the concrete currency on the `Unit` builder (`Unit.EUR`, `Unit.DM`,
-    # `Unit.SILVER_PENNY`) so it can tag a `UnitAnnotatedColumn` of input data.
-    # A column/function declaration still rejects a concrete base
-    # (`resolve_compositional_column_unit`); this only makes it reachable.
-    setattr(Unit, name.upper(), CompositeUnit(base=name.upper()))
-
-
-def currency_conversion_factor(source_currency: str, target_currency: str) -> float:
-    """The factor converting a value from ``source_currency`` to ``target_currency``.
-
-    Used only where data enters and leaves the computation: input columns are
-    converted from the data currency to the computation currency, and
-    currency-denominated results are converted back (GEP 10). pint is the
-    single source of truth for the rate. Both currencies must be registered;
-    all registered currencies are interconvertible.
-
-    Raises:
-        UnitDefinitionError: If either currency is unknown or not a currency.
-    """
-    for name in (source_currency, target_currency):
-        if name not in _registered_currencies:
-            raise UnitDefinitionError(
-                f"Cannot convert currency: {name!r} is not a registered currency."
-            )
-    try:
-        return (
-            UNIT_REGISTRY.Quantity(1.0, source_currency).to(target_currency).magnitude
-        )
-    except pint.DimensionalityError as e:
-        raise UnitDefinitionError(
-            f"Cannot convert {source_currency!r} to {target_currency!r}: {e}"
-        ) from e

--- a/src/ttsim/tt/grouping_levels.py
+++ b/src/ttsim/tt/grouping_levels.py
@@ -1,22 +1,23 @@
 """Registration of grouping levels as pint base dimensions (GEP 10).
 
 The registration *operations* for the per-build grouping levels (the individual
-``person`` leaf and one per ``*_id`` group column). The level state and the
-dimension helpers a declaration is resolved against live in
-:mod:`ttsim.tt.units`; this module reads and mutates that shared state.
+``person`` leaf and one per ``*_id`` group column). A level's *dimension* lives
+in a policy system's registry, so :func:`register_grouping_levels` takes one;
+the fluent builder step it also adds sits on :class:`CompositeUnit`, which is a
+plain value shared by every system.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable
 
+import pint
+
 from ttsim.tt.units import (
     _ALLOWED_UNIT_TOKENS,
     PERSON_LEVEL,
-    UNIT_REGISTRY,
     CompositeUnit,
     _grouping_level_unit_name,
-    _registered_grouping_levels,
     _unit_builder_levels,
 )
 
@@ -40,8 +41,8 @@ def register_unit_builder_levels(names: Iterable[str]) -> None:
         )
 
 
-def register_grouping_levels(names: Iterable[str]) -> None:
-    """Register grouping levels as base dimensions in the registry.
+def register_grouping_levels(names: Iterable[str], registry: pint.UnitRegistry) -> None:
+    """Register grouping levels as base dimensions in a policy system's registry.
 
     Each grouping level — the individual ``person`` (the leaf, identified by
     ``p_id``) and one per ``*_id`` group column (``hh``, ``bg``, ``fg``, …) — is
@@ -57,20 +58,21 @@ def register_grouping_levels(names: Iterable[str]) -> None:
 
     Each level is defined under an internal :data:`_GROUPING_LEVEL_PREFIX`-prefixed
     pint name anchoring a fresh base dimension and added to the closed pint-token
-    vocabulary. Re-registering an already-known level is a tolerated no-op,
-    mirroring :func:`register_currency`.
+    vocabulary. Whether a level is already known is asked of ``registry`` itself,
+    so every system's registry gets its own dimension for the levels it uses —
+    including the ``person`` leaf every system shares. Re-registering an
+    already-known level is a tolerated no-op.
 
     Args:
         names: The grouping-level names to register (e.g. ``["hh", "bg"]``).
             ``person`` is added unconditionally.
+        registry: The policy system's registry to define the dimensions in.
     """
     for name in (PERSON_LEVEL, *names):
-        if name in _registered_grouping_levels:
-            continue
         unit_name = _grouping_level_unit_name(name)
-        UNIT_REGISTRY.define(f"{unit_name} = [{unit_name}]")
+        if unit_name not in registry:
+            registry.define(f"{unit_name} = [{unit_name}]")
         _ALLOWED_UNIT_TOKENS.add(unit_name)
-        _registered_grouping_levels.add(name)
     # Packages that use the builder at import time call
     # `register_unit_builder_levels` directly, before their declarations run.
     register_unit_builder_levels(names)

--- a/src/ttsim/tt/units.py
+++ b/src/ttsim/tt/units.py
@@ -3,6 +3,12 @@
 Establishes the closed unit vocabulary that checks the dimensional soundness of
 the taxes-and-transfers DAG, plus the build-time machinery that runs the check.
 
+The vocabulary here is spelled in :class:`CompositeUnit` values, which carry no
+registry reference — ``TTSIMUnit.CURRENCY.PER_MONTH`` is a pure value. Resolving one
+to a :class:`pint.Unit` needs a registry, which a policy system owns
+(:class:`ttsim.tt.currencies.UnitSystem`); every helper below that resolves,
+parses, or compares takes that registry explicitly.
+
 pint is a build-time tool only — it never wraps a live array (a
 :class:`pint.Quantity` is not a JAX pytree and does not trace under ``jit``). It
 serves two build-time jobs:
@@ -19,7 +25,8 @@ grouping level, in that canonical order. It
 has two round-tripping spellings (via :func:`parse_compositional_unit` /
 :func:`str`):
 
-- fluent, off the :class:`Unit` namespace (``Unit.CURRENCY.PER_MONTH.PER_BG``);
+- fluent, off the :class:`TTSIMUnit` namespace
+  (``TTSIMUnit.CURRENCY.PER_MONTH.PER_BG``);
 - flat canonical string, in YAML (``CURRENCY_PER_MONTH_PER_BG``).
 
 The base is ``CURRENCY`` on columns and functions; on parameters it is a
@@ -105,7 +112,7 @@ class CompositeUnit:
     (``.PER_BG.PER_MONTH``) is a definition error. Two round-tripping spellings
     (via :func:`str`):
 
-    - fluent, off a base (``Unit.CURRENCY.PER_MONTH.PER_BG``);
+    - fluent, off a base (``TTSIMUnit.CURRENCY.PER_MONTH.PER_BG``);
     - flat canonical string, parsed by :func:`parse_compositional_unit`
       (``"CURRENCY_PER_MONTH_PER_BG"``).
 
@@ -173,7 +180,7 @@ class CompositeUnit:
 
     @property
     def PER_HOURS(self) -> CompositeUnit:  # noqa: N802 (DSL: mirrors the token)
-        """This unit per working hour (``Unit.CURRENCY.PER_HOURS``, a wage floor).
+        """This unit per working hour (``TTSIMUnit.CURRENCY.PER_HOURS``, a wage floor).
 
         Shares the physical-denominator slot with the area: a price is per at
         most one physical thing.
@@ -287,9 +294,9 @@ def base_is_level_carrying(base: str) -> bool:
 
 
 def resolve_compositional_unit(
-    unit: CompositeUnit, *, with_level: bool = True
+    unit: CompositeUnit, *, registry: pint.UnitRegistry, with_level: bool = True
 ) -> pint.Unit:
-    """Resolve a compositional unit to its pint unit.
+    """Resolve a compositional unit to its pint unit in ``registry``.
 
     Each denominator divides the base in turn:
 
@@ -302,37 +309,42 @@ def resolve_compositional_unit(
     (the concrete currency drives the build-time conversion, not the check).
 
     Raises:
-        UnitDefinitionError: If a level denominator names an unregistered
-            grouping level.
+        UnitDefinitionError: If a level denominator names a grouping level the
+            registry does not define.
     """
     if _is_currency_base(unit.base):
-        resolved = UNIT_REGISTRY.parse_units(CURRENCY_TOKEN)
+        resolved = registry.parse_units(CURRENCY_TOKEN)
     elif unit.base == "PERSON_COUNT":
         # Via the helper so an un-built registry fails loudly.
-        resolved = _grouping_level_unit(PERSON_LEVEL)
+        resolved = _grouping_level_unit(name=PERSON_LEVEL, registry=registry)
     else:
         base = _COMPOSITIONAL_BASE_TO_PINT[unit.base]
         resolved = (
-            UNIT_REGISTRY.dimensionless
-            if base is None
-            else UNIT_REGISTRY.parse_units(base)
+            registry.dimensionless if base is None else registry.parse_units(base)
         )
     if unit.area is not None:
         resolved = _divide_by_period(
-            non_time_unit=resolved, period_pint_name=_AREA_TOKEN_TO_PINT[unit.area]
+            non_time_unit=resolved,
+            period_pint_name=_AREA_TOKEN_TO_PINT[unit.area],
+            registry=registry,
         )
     if unit.period is not None:
         resolved = _divide_by_period(
-            non_time_unit=resolved, period_pint_name=_PERIOD_TOKEN_TO_PINT[unit.period]
+            non_time_unit=resolved,
+            period_pint_name=_PERIOD_TOKEN_TO_PINT[unit.period],
+            registry=registry,
         )
     if with_level and unit.level is not None:
-        resolved = divide_by_grouping_level(unit=resolved, level=unit.level.lower())
+        resolved = divide_by_grouping_level(
+            unit=resolved, level=unit.level.lower(), registry=registry
+        )
     return resolved
 
 
 def _attach_implied_person_leaf(
     resolved: pint.Unit,
     unit: CompositeUnit,
+    registry: pint.UnitRegistry,
     *,
     is_boolean: bool = False,
 ) -> pint.Unit:
@@ -353,7 +365,9 @@ def _attach_implied_person_leaf(
     if unit.level is not None:
         return resolved
     if is_boolean or (base_is_level_carrying(unit.base) and unit.area is None):
-        return divide_by_grouping_level(unit=resolved, level=PERSON_LEVEL)
+        return divide_by_grouping_level(
+            unit=resolved, level=PERSON_LEVEL, registry=registry
+        )
     return resolved
 
 
@@ -363,6 +377,7 @@ def resolve_compositional_column_unit(
     time_unit_id: str | None,
     grouping_level: str,
     where: str,
+    registry: pint.UnitRegistry,
     is_boolean: bool = False,
 ) -> pint.Unit:
     """Resolve a column/function's compositional unit, validating the name suffix.
@@ -412,9 +427,9 @@ def resolve_compositional_column_unit(
             f"aggregation suffix implies {grouping_level.upper()!r}; a spelled "
             f"group level must not contradict the suffix (GEP 10)."
         )
-    resolved = resolve_compositional_unit(unit=unit, with_level=True)
+    resolved = resolve_compositional_unit(unit=unit, registry=registry, with_level=True)
     return _attach_implied_person_leaf(
-        resolved=resolved, unit=unit, is_boolean=is_boolean
+        resolved=resolved, unit=unit, registry=registry, is_boolean=is_boolean
     )
 
 
@@ -434,6 +449,7 @@ def unit_with_rebased_period(unit: CompositeUnit, time_unit_id: str) -> Composit
 def resolve_compositional_param_unit(
     unit: CompositeUnit,
     *,
+    registry: pint.UnitRegistry,
     time_unit_id: str | None = None,
     where: str,
 ) -> pint.Unit:
@@ -462,12 +478,12 @@ def resolve_compositional_param_unit(
                 f"{where}: the unit spells period {unit.period!r} but the name's "
                 f"time suffix implies {expected_period!r}; they must agree (GEP 10)."
             )
-    resolved = resolve_compositional_unit(unit=unit, with_level=True)
-    return _attach_implied_person_leaf(resolved=resolved, unit=unit)
+    resolved = resolve_compositional_unit(unit=unit, registry=registry, with_level=True)
+    return _attach_implied_person_leaf(resolved=resolved, unit=unit, registry=registry)
 
 
 def _resolve_agnostic_body_unit(
-    unit: CompositeUnit, *, where: str, what: str
+    unit: CompositeUnit, *, registry: pint.UnitRegistry, where: str, what: str
 ) -> pint.Unit:
     """Resolve a code-side compositional unit with no name to validate against.
 
@@ -485,33 +501,38 @@ def _resolve_agnostic_body_unit(
             f"the agnostic {CURRENCY_TOKEN} — only parameters and rounding specs "
             f"pin down concrete currencies (GEP 10)."
         )
-    resolved = resolve_compositional_unit(unit=unit, with_level=True)
-    return _attach_implied_person_leaf(resolved=resolved, unit=unit)
+    resolved = resolve_compositional_unit(unit=unit, registry=registry, with_level=True)
+    return _attach_implied_person_leaf(resolved=resolved, unit=unit, registry=registry)
 
 
-def resolve_compositional_cast_unit(unit: CompositeUnit, *, where: str) -> pint.Unit:
+def resolve_compositional_cast_unit(
+    unit: CompositeUnit, *, registry: pint.UnitRegistry, where: str
+) -> pint.Unit:
     """Resolve the target unit of a :func:`cast_unit` call inside a body."""
     return _resolve_agnostic_body_unit(
-        unit=unit, where=where, what="a cast inside a body"
+        unit=unit, registry=registry, where=where, what="a cast inside a body"
     )
 
 
-def resolve_compositional_field_unit(unit: CompositeUnit, *, where: str) -> pint.Unit:
+def resolve_compositional_field_unit(
+    unit: CompositeUnit, *, registry: pint.UnitRegistry, where: str
+) -> pint.Unit:
     """Resolve a parameter dataclass field annotation's compositional unit (GEP 10)."""
     return _resolve_agnostic_body_unit(
-        unit=unit, where=where, what="a field annotation"
+        unit=unit, registry=registry, where=where, what="a field annotation"
     )
 
 
 class _UnitNamespaceMeta(type):
-    """Metaclass for :class:`Unit` so ``ty`` accepts dynamically-added bases.
+    """Metaclass for :class:`TTSIMUnit` so ``ty`` accepts dynamically-added bases.
 
-    Concrete currency bases (``Unit.EUR``, ``Unit.DM``, ``Unit.SILVER_PENNY``)
-    are injected onto :class:`Unit` by :func:`register_currency` at registration
+    Concrete currency bases (``TTSIMUnit.EUR``, ``TTSIMUnit.DM``,
+    ``TTSIMUnit.SILVER_PENNY``)
+    are injected onto :class:`TTSIMUnit` by :func:`register_currency` at registration
     time — they cannot be hard-wired class attributes because the currency
     vocabulary is discovered per package. At runtime an injected base is a real
     attribute, so this metaclass adds no ``__getattr__``; under type checking it
-    declares one so ``Unit.EUR`` type-checks (mirroring
+    declares one so ``TTSIMUnit.EUR`` type-checks (mirroring
     :class:`CompositeUnit`'s builder-step hint).
     """
 
@@ -520,42 +541,42 @@ class _UnitNamespaceMeta(type):
         def __getattr__(cls, name: str) -> CompositeUnit: ...
 
 
-class Unit(metaclass=_UnitNamespaceMeta):
+class TTSIMUnit(metaclass=_UnitNamespaceMeta):
     """The builder namespace of unit *bases*.
 
-    Each attribute is a bare :class:`CompositeUnit` — ``Unit.CURRENCY`` *is*
+    Each attribute is a bare :class:`CompositeUnit` — ``TTSIMUnit.CURRENCY`` *is*
     ``CompositeUnit(base="CURRENCY")`` — that heads a ``.per_*`` builder chain
     enforcing the canonical order ``base _PER_ <area> _PER_ <period> _PER_
-    <level>`` (``Unit.CURRENCY.PER_MONTH.PER_BG``).
+    <level>`` (``TTSIMUnit.CURRENCY.PER_MONTH.PER_BG``).
 
     The agnostic currency base ``CURRENCY`` lives here permanently; each concrete
     currency base (``EUR``, ``DM``, ``SILVER_PENNY``) is injected by
     :func:`register_currency` when its package registers it, so concrete bases
-    can tag a :class:`UnitAnnotatedColumn` of input data (``Unit.EUR.PER_MONTH``)
+    can tag a :class:`UnitAnnotatedColumn` of input data (``TTSIMUnit.EUR.PER_MONTH``)
     even though a column/function declaration must stay agnostic.
     """
 
     CURRENCY = CompositeUnit(base=CURRENCY_TOKEN)
     """An amount of currency (agnostic): wages, claims, benefits, wealth. A
-    period denominator makes it a flow (``Unit.CURRENCY.PER_MONTH``)."""
+    period denominator makes it a flow (``TTSIMUnit.CURRENCY.PER_MONTH``)."""
 
     DIMENSIONLESS = CompositeUnit(base="DIMENSIONLESS")
     """A plain dimensionless number: a share, a rate. A boolean declares
     ``DIMENSIONLESS`` too — bare for a person-level indicator, its group level
-    spelled for a group one (``Unit.DIMENSIONLESS.PER_FAM``)."""
+    spelled for a group one (``TTSIMUnit.DIMENSIONLESS.PER_FAM``)."""
 
     PERSON_COUNT = CompositeUnit(base="PERSON_COUNT")
     """The individual (leaf) count base — the numerator of a head count
     (``[person]``). With a level denominator it is a head count per group:
-    ``Unit.PERSON_COUNT.PER_BG`` resolves to ``[person] / [bg]``."""
+    ``TTSIMUnit.PERSON_COUNT.PER_BG`` resolves to ``[person] / [bg]``."""
 
     HOURS = CompositeUnit(base="HOURS")
     """Working hours (the isolated ``[hours]`` dimension). A period denominator
-    re-bases them (``Unit.HOURS.PER_WEEK``)."""
+    re-bases them (``TTSIMUnit.HOURS.PER_WEEK``)."""
 
     SQUARE_METER = CompositeUnit(base="SQUARE_METER")
     """An area in square meters; also the lone *area* denominator
-    (``Unit.CURRENCY.PER_SQUARE_METER``)."""
+    (``TTSIMUnit.CURRENCY.PER_SQUARE_METER``)."""
 
     HECTARE = CompositeUnit(base="HECTARE")
     """An area in hectares: land."""
@@ -587,10 +608,11 @@ class UnitAnnotatedColumn:
 
     The leaf type of the unit-annotated input *and* result trees (GEP 10). On the
     way in, the user hand-authors one per column —
-    ``UnitAnnotatedColumn(values=[2000.0, 0.0], unit=Unit.EUR.PER_MONTH)`` — and
-    a currency column must name a **concrete** currency (``Unit.EUR``,
-    ``Unit.DM``), exactly as a parameter does; the agnostic ``Unit.CURRENCY`` is
-    rejected at the boundary. On the way out, each result leaf is wrapped the same
+    ``UnitAnnotatedColumn(values=[2000.0, 0.0], unit=TTSIMUnit.EUR.PER_MONTH)`` — and
+    a currency column must name a **concrete** currency (``TTSIMUnit.EUR``,
+    ``TTSIMUnit.DM``), exactly as a parameter does; the agnostic
+    ``TTSIMUnit.CURRENCY`` is rejected at the boundary. On the way out, each result
+    leaf is wrapped the same
     way, its ``unit`` the node's resolved unit — a column's in the concrete data
     currency, a parameter's in its statutory currency.
 
@@ -600,7 +622,7 @@ class UnitAnnotatedColumn:
     Args:
         values: The column data — any leaf the ordinary input tree accepts (a
             list, a numpy/JAX array, a ``pd.Series``); canonicalized downstream.
-        unit: The column's compositional unit, built off :class:`Unit`.
+        unit: The column's compositional unit, built off :class:`TTSIMUnit`.
     """
 
     values: Any
@@ -634,7 +656,7 @@ def cast_unit(
 
     Args:
         value: The expression to re-tag; returned unchanged.
-        unit: The stated unit — built off :class:`Unit` or the flat
+        unit: The stated unit — built off :class:`TTSIMUnit` or the flat
             compositional spelling.
 
     Returns:
@@ -737,8 +759,12 @@ def coerce_to_composite_unit(
     )
 
 
-def _build_registry() -> pint.UnitRegistry:
-    """Create the module-level registry with the units TTSIM knows about.
+def build_registry() -> pint.UnitRegistry:
+    """Create a registry holding the units TTSIM knows about.
+
+    One registry per policy system (:class:`ttsim.tt.currencies.UnitSystem`),
+    which then defines its own currencies and grouping levels into it. The
+    vocabulary built here is the part every system shares.
 
     pint's defaults already provide the ``[time]`` units (``year``, ``month``,
     ``week``, ``day`` — with the per-year factors GETTSIM uses: 12, 365.25/7,
@@ -763,8 +789,9 @@ def _build_registry() -> pint.UnitRegistry:
       ever uses magnitude ``1.0`` and the runtime path is bare arrays — so we
       pick the 1900-01-01 epoch, aligned across the three axes. Subtracting two
       points yields pint's companion ``delta_calendar_*`` *duration* unit, which
-      :attr:`Unit.YEARS` / :attr:`Unit.MONTHS` / :attr:`Unit.DAYS` resolve to
-      (each is ratio 1 against ``year`` / ``month`` / ``day``).
+      :attr:`TTSIMUnit.YEARS` / :attr:`TTSIMUnit.MONTHS` /
+      :attr:`TTSIMUnit.DAYS` resolve to (each is ratio 1 against
+      ``year`` / ``month`` / ``day``).
 
     pint's remaining built-ins parse, but :func:`parse_unit` rejects every
     token outside :data:`_ALLOWED_UNIT_TOKENS`, so they cannot appear in a
@@ -780,19 +807,31 @@ def _build_registry() -> pint.UnitRegistry:
     return ureg
 
 
-#: The single module-level registry. Downstream packages mutate it by calling
-#: :func:`register_currency`; nothing else should call ``UNIT_REGISTRY.define``.
-UNIT_REGISTRY = _build_registry()
+#: The dimension names :func:`build_registry` mints for currency and takes from
+#: pint for time. Every registry spells them the same way, and a pint
+#: dimensionality compares by content, so the boundary helpers pick a unit's
+#: currency / flow-period component out by matching against these directly —
+#: no registry needed.
+_CURRENCY_DIMENSIONALITY: Mapping[str, Any] = {"[currency]": 1}
+_TIME_DIMENSIONALITY: Mapping[str, Any] = {"[time]": 1}
 
-#: Reference dimensionalities, computed once against the built registry. The
-#: ``[currency]`` dimension and ``[time]`` (named via ``year``) are process
-#: constants; the boundary helpers compare a unit's components against them to
-#: pick out its currency / flow-period part.
-_CURRENCY_DIMENSIONALITY = UNIT_REGISTRY.Quantity(1.0, CURRENCY_TOKEN).dimensionality
-_TIME_DIMENSIONALITY = UNIT_REGISTRY.Quantity(1.0, "year").dimensionality
+
+def _unit_is_currency(unit: pint.Unit) -> bool:
+    """Whether a pint unit is exactly one power of the ``[currency]`` dimension."""
+    return dict(unit.dimensionality) == _CURRENCY_DIMENSIONALITY
+
+
+def _unit_is_time(unit: pint.Unit) -> bool:
+    """Whether a pint unit is exactly one power of the ``[time]`` dimension."""
+    return dict(unit.dimensionality) == _TIME_DIMENSIONALITY
+
 
 #: The unit tokens a declaration may combine: TTSIM rejects any unit it does not
-#: know about. :func:`register_currency` adds each registered concrete currency.
+#: know about. Each policy system adds its concrete currencies and grouping
+#: levels. The set is global and additive: a token is a *name*, and two systems'
+#: names are disjoint but for the shared vocabulary, so admitting the union costs
+#: only precision in the error message for a token of the wrong system — which
+#: the system's own registry then rejects anyway.
 #: ``meter`` is admitted for areas (``meter ** 2``).
 _ALLOWED_UNIT_TOKENS: set[str] = {
     CURRENCY_TOKEN,
@@ -813,21 +852,15 @@ _ALLOWED_UNIT_TOKENS: set[str] = {
     "delta_calendar_day",
 }
 
-#: The concrete currencies registered so far (their pint unit names). A currency
-#: is a valid compositional *base* (its upper-cased name); on a parameter the
-#: base also names the currency the numbers are written in.
+#: The concrete currencies of every policy system built so far (their pint unit
+#: names). A currency is a valid compositional *base* (its upper-cased name); on
+#: a parameter the base also names the currency the numbers are written in. Names
+#: only — which currencies are *interconvertible* is a per-system question the
+#: system's registry answers.
 _registered_currencies: set[str] = set()
 
 #: Tolerance for the magnitude part of a unit-equivalence comparison.
 _REL_TOL = 1e-9
-
-
-#: The grouping levels registered so far (the bare names, e.g. ``"person"``,
-#: ``"hh"``), populated by :func:`register_grouping_levels`. ``person`` (the
-#: individual leaf, doubling as the ``[person]`` count dimension) is always
-#: present once any level has been registered. The set is discovered per build
-#: from the policy environment's ``*_id`` columns; ttsim ships no fixed list.
-_registered_grouping_levels: set[str] = set()
 
 
 def _grouping_level_unit_name(name: str) -> str:
@@ -835,10 +868,28 @@ def _grouping_level_unit_name(name: str) -> str:
     return f"{_GROUPING_LEVEL_PREFIX}{name}"
 
 
-def _fail_if_grouping_level_is_unknown(name: str) -> None:
-    """Reject a grouping-level name that has not been registered."""
-    if name not in _registered_grouping_levels:
-        known = ", ".join(sorted(_registered_grouping_levels)) or "(none registered)"
+def registered_grouping_levels(registry: pint.UnitRegistry) -> set[str]:
+    """The grouping levels a registry defines a dimension for.
+
+    The bare names (``"person"``, ``"hh"``, …). ``person`` — the individual leaf,
+    doubling as the ``[person]`` count dimension — is present once any level has
+    been registered. The set is discovered per build from the policy
+    environment's ``*_id`` columns; ttsim ships no fixed list.
+    """
+    return {
+        name.removeprefix(_GROUPING_LEVEL_PREFIX)
+        for name in registry
+        if name.startswith(_GROUPING_LEVEL_PREFIX)
+    }
+
+
+def _fail_if_grouping_level_is_unknown(name: str, registry: pint.UnitRegistry) -> None:
+    """Reject a grouping level the registry defines no dimension for."""
+    if _grouping_level_unit_name(name) not in registry:
+        known = (
+            ", ".join(sorted(registered_grouping_levels(registry)))
+            or "(none registered)"
+        )
         raise UnitDefinitionError(
             f"Unknown grouping level {name!r}; expected one of {known}. Grouping "
             f"levels are discovered per build from the `*_id` columns and "
@@ -846,17 +897,19 @@ def _fail_if_grouping_level_is_unknown(name: str) -> None:
         )
 
 
-def _grouping_level_unit(name: str) -> pint.Unit:
+def _grouping_level_unit(name: str, registry: pint.UnitRegistry) -> pint.Unit:
     """The pint unit of a registered grouping level.
 
     Raises:
         UnitDefinitionError: If the level has not been registered.
     """
-    _fail_if_grouping_level_is_unknown(name)
-    return UNIT_REGISTRY.parse_units(_grouping_level_unit_name(name))
+    _fail_if_grouping_level_is_unknown(name=name, registry=registry)
+    return registry.parse_units(_grouping_level_unit_name(name))
 
 
-def divide_by_grouping_level(unit: pint.Unit, level: str) -> pint.Unit:
+def divide_by_grouping_level(
+    unit: pint.Unit, level: str, registry: pint.UnitRegistry
+) -> pint.Unit:
     """Return ``unit`` divided by a grouping level's unit.
 
     A leveled quantity carries its level as a denominator, exactly as a flow
@@ -873,10 +926,12 @@ def divide_by_grouping_level(unit: pint.Unit, level: str) -> pint.Unit:
     Raises:
         UnitDefinitionError: If the level has not been registered.
     """
-    return unit / _grouping_level_unit(level)
+    return unit / _grouping_level_unit(name=level, registry=registry)
 
 
-def grouping_level_count_unit(target_level: str) -> pint.Unit:
+def grouping_level_count_unit(
+    target_level: str, registry: pint.UnitRegistry
+) -> pint.Unit:
     """The unit of a head count over ``target_level``.
 
     A head count is the ``[person]`` *count* dimension over the group it counts
@@ -887,10 +942,12 @@ def grouping_level_count_unit(target_level: str) -> pint.Unit:
     Raises:
         UnitDefinitionError: If ``person`` or ``target_level`` is not registered.
     """
-    return _grouping_level_unit(PERSON_LEVEL) / _grouping_level_unit(target_level)
+    return _grouping_level_unit(
+        name=PERSON_LEVEL, registry=registry
+    ) / _grouping_level_unit(name=target_level, registry=registry)
 
 
-def parse_unit(unit_str: str) -> pint.Unit:
+def parse_unit(unit_str: str, registry: pint.UnitRegistry) -> pint.Unit:
     """Parse a pint unit string, enforcing the closed pint-token vocabulary.
 
     Internal: declarations are :class:`CompositeUnit`\\ s, never pint syntax. This
@@ -916,13 +973,13 @@ def parse_unit(unit_str: str) -> pint.Unit:
             f"A unit must be given as a string, got {unit_str!r}."
         )
     try:
-        unit = UNIT_REGISTRY.parse_units(unit_str)
+        unit = registry.parse_units(unit_str)
     except (pint.errors.PintError, AssertionError, ValueError, TypeError) as e:
         raise UnitDefinitionError(f"Could not parse unit {unit_str!r}: {e}") from e
     _fail_if_unit_tokens_are_unknown(unit=unit, unit_str=unit_str)
     if not to_units_container(unit):
         raise UnitDefinitionError(
-            f"Unit {unit_str!r} resolves to the dimensionless unit. A "
+            f"TTSIMUnit {unit_str!r} resolves to the dimensionless unit. A "
             f"dimensionless quantity (a share, a rate, a head count) declares "
             f"`DIMENSIONLESS` (GEP 10)."
         )
@@ -945,31 +1002,23 @@ def _fail_if_unit_tokens_are_unknown(
     )
     if offending:
         raise UnitDefinitionError(
-            f"Unit {unit_str!r} involves unit token(s) TTSIM does not know "
+            f"TTSIMUnit {unit_str!r} involves unit token(s) TTSIM does not know "
             f"about: {', '.join(offending)}. Known units are "
             f"{', '.join(sorted(_ALLOWED_UNIT_TOKENS))} (GEP 10)."
         )
 
 
-def _divide_by_period(non_time_unit: pint.Unit, period_pint_name: str) -> pint.Unit:
+def _divide_by_period(
+    non_time_unit: pint.Unit, period_pint_name: str, registry: pint.UnitRegistry
+) -> pint.Unit:
     """Return ``non_time_unit / period`` as a pint unit."""
-    period = UNIT_REGISTRY.Quantity(1.0, period_pint_name)
-    return (UNIT_REGISTRY.Quantity(1.0, non_time_unit) / period).units
+    period = registry.Quantity(1.0, period_pint_name)
+    return (registry.Quantity(1.0, non_time_unit) / period).units
 
 
-def _token_base_unit(token: CompositeUnit) -> pint.Unit:
-    """The pint unit of a unit's physical kind — its period and grouping level
-    stripped (its area kept).
-
-    A currency base resolves to the agnostic :data:`CURRENCY_TOKEN` unit: for
-    dimensionality a registered currency means exactly what its agnostic
-    counterpart means — the concrete currency only drives the build-time
-    conversion of the numbers.
-    """
-    return resolve_compositional_unit(replace(token, period=None, level=None))
-
-
-def units_are_equivalent(left: pint.Unit, right: pint.Unit) -> bool:
+def units_are_equivalent(
+    left: pint.Unit, right: pint.Unit, registry: pint.UnitRegistry
+) -> bool:
     """Whether two units are interchangeable on a DAG edge.
 
     Equivalent iff they share a dimensionality *and* a magnitude (their ratio is
@@ -990,8 +1039,8 @@ def units_are_equivalent(left: pint.Unit, right: pint.Unit) -> bool:
       ``year`` / ``delta_calendar_year`` duration nor to a ``calendar_month``
       point on another axis.
     """
-    left_quantity = UNIT_REGISTRY.Quantity(1.0, left)
-    right_quantity = UNIT_REGISTRY.Quantity(1.0, right)
+    left_quantity = registry.Quantity(1.0, left)
+    right_quantity = registry.Quantity(1.0, right)
     if left_quantity.dimensionality != right_quantity.dimensionality:
         return False
     try:
@@ -1001,7 +1050,7 @@ def units_are_equivalent(left: pint.Unit, right: pint.Unit) -> bool:
     return math.isclose(ratio.magnitude, 1.0, rel_tol=_REL_TOL)
 
 
-def is_calendar_point_unit(unit: pint.Unit) -> bool:
+def is_calendar_point_unit(unit: pint.Unit, registry: pint.UnitRegistry) -> bool:
     """Whether a resolved unit is an affine calendar *point*.
 
     A calendar point (``calendar_year`` and its month/day siblings) is a pint
@@ -1019,7 +1068,7 @@ def is_calendar_point_unit(unit: pint.Unit) -> bool:
     ``point + duration``. Detection is by the very property that defines an offset
     unit: it cannot be divided by itself.
     """
-    quantity = UNIT_REGISTRY.Quantity(1.0, unit)
+    quantity = registry.Quantity(1.0, unit)
     try:
         quantity / quantity
     except pint.OffsetUnitCalculusError:
@@ -1027,7 +1076,9 @@ def is_calendar_point_unit(unit: pint.Unit) -> bool:
     return False
 
 
-def _currency_component_of(units: pint.Unit) -> pint.Unit | None:
+def _currency_component_of(
+    units: pint.Unit, registry: pint.UnitRegistry
+) -> pint.Unit | None:
     """Return the currency component of a (possibly composite) unit, or ``None``.
 
     Used at the input boundary to convert a pint-tagged column's currency to the
@@ -1035,21 +1086,20 @@ def _currency_component_of(units: pint.Unit) -> pint.Unit | None:
     ``DM / month``.
     """
     for token in to_units_container(units):
-        candidate = UNIT_REGISTRY.parse_units(token)
-        if (
-            UNIT_REGISTRY.Quantity(1.0, candidate).dimensionality
-            == _CURRENCY_DIMENSIONALITY
-        ):
+        candidate = registry.parse_units(token)
+        if _unit_is_currency(candidate):
             return candidate
     return None
 
 
-def unit_has_currency_component(units: pint.Unit) -> bool:
+def unit_has_currency_component(units: pint.Unit, registry: pint.UnitRegistry) -> bool:
     """Whether a (possibly composite) unit carries a currency component."""
-    return _currency_component_of(units) is not None
+    return _currency_component_of(units=units, registry=registry) is not None
 
 
-def unit_has_agnostic_currency_component(units: pint.Unit) -> bool:
+def unit_has_agnostic_currency_component(
+    units: pint.Unit, registry: pint.UnitRegistry
+) -> bool:
     """Whether a unit's currency component is the agnostic ``CURRENCY`` token.
 
     Distinguishes the two currency spellings when results are returned: a
@@ -1058,10 +1108,8 @@ def unit_has_agnostic_currency_component(units: pint.Unit) -> bool:
     its concrete statutory currency (never converted, labelled as declared) —
     GEP 10.
     """
-    component = _currency_component_of(units)
-    return component is not None and component == UNIT_REGISTRY.parse_units(
-        CURRENCY_TOKEN
-    )
+    component = _currency_component_of(units=units, registry=registry)
+    return component is not None and component == registry.parse_units(CURRENCY_TOKEN)
 
 
 #: The dimensionality-key prefix of a grouping-level dimension: the internal pint
@@ -1077,14 +1125,16 @@ def _grouping_levels_with_exponent(unit: pint.Unit) -> Iterator[tuple[str, Any]]
     numerator level (a ``[person]`` head count). Non-grouping dimensions and
     pint's (never-occurring here) complex exponents are skipped.
     """
-    for dimension, exponent in UNIT_REGISTRY.Quantity(1.0, unit).dimensionality.items():
+    for dimension, exponent in unit.dimensionality.items():
         if isinstance(exponent, complex):  # pint exponents are real; narrow for ty
             continue
         if dimension.startswith(_GROUPING_LEVEL_DIM_PREFIX):
             yield dimension[len(_GROUPING_LEVEL_DIM_PREFIX) : -1], exponent
 
 
-def _unit_without_grouping_levels(unit: pint.Unit) -> pint.Unit:
+def _unit_without_grouping_levels(
+    unit: pint.Unit, registry: pint.UnitRegistry
+) -> pint.Unit:
     """A unit with every grouping level (numerator and denominator) divided out.
 
     Stripping a level is index bookkeeping on the unit's container, not quantity
@@ -1092,7 +1142,7 @@ def _unit_without_grouping_levels(unit: pint.Unit) -> pint.Unit:
     """
     container = to_units_container(unit)
     level_keys = [k for k in container if k.startswith(_GROUPING_LEVEL_PREFIX)]
-    return UNIT_REGISTRY.Unit(container.remove(level_keys))
+    return registry.Unit(container.remove(level_keys))
 
 
 def _unit_level_denominator(unit: pint.Unit) -> str | None:
@@ -1115,7 +1165,9 @@ def _unit_level_denominator(unit: pint.Unit) -> str | None:
     )
 
 
-def _substitute_currency(units: pint.Unit, currency: str) -> pint.Unit:
+def _substitute_currency(
+    units: pint.Unit, currency: str, registry: pint.UnitRegistry
+) -> pint.Unit:
     """Swap a unit's currency component for ``currency``; a no-op if it has none.
 
     The one currency move input and output handling share: the period, area
@@ -1123,14 +1175,14 @@ def _substitute_currency(units: pint.Unit, currency: str) -> pint.Unit:
     currency (:func:`output_unit_in_data_currency`); for tagged input data it
     is the tag's concrete currency (:func:`input_strip_unit`).
     """
-    component = _currency_component_of(units)
+    component = _currency_component_of(units=units, registry=registry)
     if component is None:
         return units
-    return units / component * UNIT_REGISTRY.parse_units(currency)
+    return units / component * registry.parse_units(currency)
 
 
 def input_target_unit_in_data_currency(
-    units: pint.Unit, data_currency: str
+    units: pint.Unit, data_currency: str, registry: pint.UnitRegistry
 ) -> pint.Unit:
     """Restate the unit of an input column requested as a target.
 
@@ -1140,10 +1192,12 @@ def input_target_unit_in_data_currency(
     holding the user's euro values). The label follows the value, so any
     currency component is substituted with the data currency (GEP 10).
     """
-    return _substitute_currency(units=units, currency=data_currency)
+    return _substitute_currency(units=units, currency=data_currency, registry=registry)
 
 
-def output_unit_in_data_currency(units: pint.Unit, data_currency: str) -> pint.Unit:
+def output_unit_in_data_currency(
+    units: pint.Unit, data_currency: str, registry: pint.UnitRegistry
+) -> pint.Unit:
     """Restate a computed result column's resolved unit in the data currency.
 
     A computed column is converted to the data currency before being returned,
@@ -1154,13 +1208,13 @@ def output_unit_in_data_currency(units: pint.Unit, data_currency: str) -> pint.U
     not pass through here: their value is never converted, so they keep their
     statutory currency (:func:`param_unit_in_computation_currency`).
     """
-    if not unit_has_agnostic_currency_component(units):
+    if not unit_has_agnostic_currency_component(units=units, registry=registry):
         return units
-    return _substitute_currency(units=units, currency=data_currency)
+    return _substitute_currency(units=units, currency=data_currency, registry=registry)
 
 
 def param_unit_in_computation_currency(
-    units: pint.Unit, computation_currency: str
+    units: pint.Unit, computation_currency: str, registry: pint.UnitRegistry
 ) -> pint.Unit:
     """Restate a requested parameter's resolved unit in its statutory currency.
 
@@ -1170,7 +1224,9 @@ def param_unit_in_computation_currency(
     agnostic ``CURRENCY`` component is spelled in the computation currency, not
     the data currency; a non-currency unit is returned unchanged (GEP 10).
     """
-    return _substitute_currency(units=units, currency=computation_currency)
+    return _substitute_currency(
+        units=units, currency=computation_currency, registry=registry
+    )
 
 
 #: Reverse of the forward token→pint maps, for :func:`composite_from_resolved_unit`.
@@ -1182,7 +1238,9 @@ _PINT_NAME_TO_BASE_TOKEN = {
 }
 
 
-def composite_from_resolved_unit(units: pint.Unit) -> CompositeUnit:
+def composite_from_resolved_unit(
+    units: pint.Unit, registry: pint.UnitRegistry
+) -> CompositeUnit:
     """Reconstruct the compositional spelling of a *resolved* pint unit.
 
     The output-side inverse of :func:`resolve_compositional_unit`: it labels a
@@ -1202,8 +1260,8 @@ def composite_from_resolved_unit(units: pint.Unit) -> CompositeUnit:
     (:func:`output_unit_in_data_currency`) so the base is a concrete currency
     (``EUR``), never the agnostic ``CURRENCY``.
     """
-    currency = _currency_component_of(units)
-    period = _flow_period_of(units)
+    currency = _currency_component_of(units=units, registry=registry)
+    period = _flow_period_of(units=units, registry=registry)
     base = str(currency).upper() if currency is not None else "DIMENSIONLESS"
     area: str | None = None
     level: str | None = None
@@ -1213,7 +1271,9 @@ def composite_from_resolved_unit(units: pint.Unit) -> CompositeUnit:
         elif name != PERSON_LEVEL and exponent < 0:
             level = name.upper()
         # A `grouping_level_person` denominator is the implied leaf — dropped.
-    physical = to_units_container(_unit_without_grouping_levels(units))
+    physical = to_units_container(
+        _unit_without_grouping_levels(unit=units, registry=registry)
+    )
     for token, exponent in physical.items():
         if isinstance(exponent, complex):  # pint exponents are real; narrow for ty
             continue
@@ -1232,29 +1292,27 @@ def composite_from_resolved_unit(units: pint.Unit) -> CompositeUnit:
     )
 
 
-def _flow_period_of(units: pint.Unit) -> pint.Unit | None:
+def _flow_period_of(units: pint.Unit, registry: pint.UnitRegistry) -> pint.Unit | None:
     """Return a unit's flow period — its time component in the *denominator*.
 
     The ``month`` of ``CURRENCY / month``, the ``week`` of ``working_hour /
     week``. A
-    *numerator* time unit (the ``year`` of an age, ``Unit.YEARS``) is not a flow
+    *numerator* time unit (the ``year`` of an age, ``TTSIMUnit.YEARS``) is not a flow
     period and is ignored, so an intrinsically-temporal column is not mistaken
     for a flow. Returns ``None`` for a unit with no per-period part.
     """
     for token, exponent in to_units_container(units).items():
         if isinstance(exponent, complex):  # pint exponents are real; narrow for ty
             continue
-        candidate = UNIT_REGISTRY.parse_units(token)
-        if (
-            exponent < 0
-            and UNIT_REGISTRY.Quantity(1.0, candidate).dimensionality
-            == _TIME_DIMENSIONALITY
-        ):
+        candidate = registry.parse_units(token)
+        if exponent < 0 and _unit_is_time(candidate):
             return candidate
     return None
 
 
-def unit_residual_excluding_currency_and_flow_period(units: pint.Unit) -> pint.Unit:
+def unit_residual_excluding_currency_and_flow_period(
+    units: pint.Unit, registry: pint.UnitRegistry
+) -> pint.Unit:
     """A unit's *measurement* residual: currency, flow period, and levels removed.
 
     The input check screens measurement (the numerator scale — area, intrinsic
@@ -1268,14 +1326,16 @@ def unit_residual_excluding_currency_and_flow_period(units: pint.Unit) -> pint.U
     ``HECTARE`` column tagged ``m²`` shares the area dimension but is a
     10,000-fold level error).
     """
-    currency = _currency_component_of(units)
+    currency = _currency_component_of(units=units, registry=registry)
     residual = units / currency if currency is not None else units
-    period = _flow_period_of(residual)
+    period = _flow_period_of(units=residual, registry=registry)
     residual = residual * period if period is not None else residual
-    return _unit_without_grouping_levels(residual)
+    return _unit_without_grouping_levels(unit=residual, registry=registry)
 
 
-def _suffix_period_of(column_label: str | None) -> pint.Unit | None:
+def _suffix_period_of(
+    column_label: str | None, registry: pint.UnitRegistry
+) -> pint.Unit | None:
     """Return the flow period named by a column's GEP-1 time suffix.
 
     ``…_m`` → ``month``; a name with no time suffix → ``None``.
@@ -1285,13 +1345,11 @@ def _suffix_period_of(column_label: str | None) -> pint.Unit | None:
     match = _QNAME_TIME_SUFFIX_PATTERN.search(column_label)
     if match is None:
         return None
-    return UNIT_REGISTRY.parse_units(
-        TIME_UNIT_ID_TO_PINT_NAME[match.group("time_unit")]
-    )
+    return registry.parse_units(TIME_UNIT_ID_TO_PINT_NAME[match.group("time_unit")])
 
 
 def _fail_if_tag_period_disagrees_with_suffix(
-    units: pint.Unit, *, column_label: str | None
+    units: pint.Unit, *, column_label: str | None, registry: pint.UnitRegistry
 ) -> None:
     """Strict period guard: a pint tag's flow period must match the column's
     GEP-1 time suffix exactly — including both absent.
@@ -1300,13 +1358,15 @@ def _fail_if_tag_period_disagrees_with_suffix(
     no period. This catches a contradictory period that would otherwise be
     stripped silently (e.g. a ``_m`` column tagged ``DM / year`` — a 12-fold error).
     """
-    tag_period = _flow_period_of(units)
-    suffix_period = _suffix_period_of(column_label)
+    tag_period = _flow_period_of(units=units, registry=registry)
+    suffix_period = _suffix_period_of(column_label=column_label, registry=registry)
     matches = (
         tag_period is None
         if suffix_period is None
         else tag_period is not None
-        and units_are_equivalent(left=tag_period, right=suffix_period)
+        and units_are_equivalent(
+            left=tag_period, right=suffix_period, registry=registry
+        )
     )
     if matches:
         return
@@ -1321,7 +1381,7 @@ def _fail_if_tag_period_disagrees_with_suffix(
     )
 
 
-def input_strip_unit(unit: CompositeUnit) -> pint.Unit:
+def input_strip_unit(unit: CompositeUnit, registry: pint.UnitRegistry) -> pint.Unit:
     """The concrete pint unit used to strip a :class:`UnitAnnotatedColumn`.
 
     Resolves the tag with its concrete currency and flow period — the two axes the
@@ -1329,12 +1389,14 @@ def input_strip_unit(unit: CompositeUnit) -> pint.Unit:
     is screened against the name suffix. Grouping levels do not affect the
     magnitude and are omitted, so this needs no registered level dimension.
     """
-    resolved = resolve_compositional_unit(unit=unit, with_level=False)
+    resolved = resolve_compositional_unit(
+        unit=unit, registry=registry, with_level=False
+    )
     concrete = token_source_currency(unit)
     return (
         resolved
         if concrete is None
-        else _substitute_currency(units=resolved, currency=concrete)
+        else _substitute_currency(units=resolved, currency=concrete, registry=registry)
     )
 
 
@@ -1342,6 +1404,7 @@ def strip_input_quantity_at_boundary(
     quantity: Any,  # noqa: ANN401 (a pint Quantity wrapping an input column)
     *,
     data_currency: str,
+    registry: pint.UnitRegistry,
     column_label: str | None = None,
 ) -> Any:  # noqa: ANN401
     """Convert a pint-tagged input column to the data currency, then strip it.
@@ -1381,12 +1444,12 @@ def strip_input_quantity_at_boundary(
         where = f" on input column {column_label!r}" if column_label else ""
         raise UnitDefinitionError(f"pint-tagged input{where}: {e}") from e
     _fail_if_tag_period_disagrees_with_suffix(
-        units=quantity.units, column_label=column_label
+        units=quantity.units, column_label=column_label, registry=registry
     )
-    source_currency = _currency_component_of(quantity.units)
+    source_currency = _currency_component_of(units=quantity.units, registry=registry)
     if source_currency is None:
         return quantity.magnitude
-    data_currency_unit = UNIT_REGISTRY.parse_units(data_currency)
+    data_currency_unit = registry.parse_units(data_currency)
     if source_currency == data_currency_unit:
         return quantity.magnitude
     target = quantity.units / source_currency * data_currency_unit
@@ -1399,7 +1462,7 @@ def head_count_from_boolean_sum(
     """Normalise a ``SUM`` over a boolean to a ``COUNT`` for unit purposes.
 
     Summing a boolean counts the persons its flag is true for, so its unit is a
-    head count's — the same :attr:`Unit.PERSON_COUNT` a ``COUNT`` mints. Every
+    head count's — the same :attr:`TTSIMUnit.PERSON_COUNT` a ``COUNT`` mints. Every
     other aggregation keeps its own type. This is the single source of truth used
     by both the declared-token minter (:func:`unit_for_aggregation`) and the
     resolved-unit deriver
@@ -1420,12 +1483,13 @@ def unit_for_aggregation(
 ) -> CompositeUnit:
     """Auto-assign the *declared* unit of an aggregation node.
 
-    The single source of truth for an aggregation node's auto-assigned token,
-    consumed by both ``agg_by_group_function`` and ``agg_by_p_id_function``:
+    The single source of truth for an automatically added aggregation's token
+    (``my_col`` → ``my_col_hh``); author-written ``@agg_by_group_function`` /
+    ``@agg_by_p_id_function`` nodes declare their unit explicitly (GEP 10):
 
     - a **head count** — ``COUNT``, or a ``SUM`` over a boolean source
       (``source_is_boolean``, counting the persons its flag is true for) — is the
-      ``[person]`` count base at its target level: :attr:`Unit.PERSON_COUNT` per
+      ``[person]`` count base at its target level: :attr:`TTSIMUnit.PERSON_COUNT` per
       ``target_level``;
     - ``SUM`` / ``MIN`` / ``MAX`` over a non-boolean source are properties of the
       **target** group whatever the source's base (GEP 10): they keep the
@@ -1437,11 +1501,11 @@ def unit_for_aggregation(
       (``MEAN = SUM / COUNT`` cancels the group), so it takes the individual
       spelling: the source token with any group level stripped;
     - ``ANY`` / ``ALL`` yield a boolean, a leveled dimensionless quantity at the
-      target level: bare :attr:`Unit.DIMENSIONLESS` for an individual result,
+      target level: bare :attr:`TTSIMUnit.DIMENSIONLESS` for an individual result,
       ``DIMENSIONLESS_PER_<target_level>`` for a group one.
 
     A ``PERSON_COUNT`` head count at the individual :data:`PERSON_LEVEL` (an
-    ``agg_by_p_id`` ``COUNT``) is the bare :attr:`Unit.PERSON_COUNT`, which
+    ``agg_by_p_id`` ``COUNT``) is the bare :attr:`TTSIMUnit.PERSON_COUNT`, which
     resolves to ``[person] / [person]`` = dimensionless.
 
     Args:
@@ -1456,9 +1520,9 @@ def unit_for_aggregation(
 
     Returns:
         The auto-assigned unit. ``PERSON_COUNT_PER_<target_level>`` for a ``COUNT`` head
-        count (the bare :attr:`Unit.PERSON_COUNT` at the individual level),
+        count (the bare :attr:`TTSIMUnit.PERSON_COUNT` at the individual level),
         ``DIMENSIONLESS_PER_<target_level>`` for a boolean ``ANY`` / ``ALL`` result
-        (bare :attr:`Unit.DIMENSIONLESS` at the individual level); otherwise the
+        (bare :attr:`TTSIMUnit.DIMENSIONLESS` at the individual level); otherwise the
         source token at the target (``SUM`` / ``MIN`` / ``MAX``) or individual
         (``MEAN``) level (:data:`UNSET_UNIT` when the source itself lacks a
         declaration, which the mandatory-units check then reports against the
@@ -1469,15 +1533,15 @@ def unit_for_aggregation(
     )
     if agg_type is AggType.COUNT:
         return (
-            Unit.PERSON_COUNT
+            TTSIMUnit.PERSON_COUNT
             if target_level == PERSON_LEVEL
-            else Unit.PERSON_COUNT.PER_LEVEL(target_level)
+            else TTSIMUnit.PERSON_COUNT.PER_LEVEL(target_level)
         )
     if agg_type in (AggType.ANY, AggType.ALL):
         return (
-            Unit.DIMENSIONLESS
+            TTSIMUnit.DIMENSIONLESS
             if target_level == PERSON_LEVEL
-            else Unit.DIMENSIONLESS.PER_LEVEL(target_level)
+            else TTSIMUnit.DIMENSIONLESS.PER_LEVEL(target_level)
         )
     if source_unit is UNSET_UNIT:
         return source_unit
@@ -1490,6 +1554,7 @@ def resolved_unit_for_aggregation(
     *,
     agg_type: AggType,
     target_level: str,
+    registry: pint.UnitRegistry,
     source_unit: pint.Unit | None = None,
     source_level: str | None = None,
 ) -> pint.Unit:
@@ -1541,10 +1606,10 @@ def resolved_unit_for_aggregation(
     """
     if agg_type in (AggType.ANY, AggType.ALL):
         return divide_by_grouping_level(
-            unit=UNIT_REGISTRY.dimensionless, level=target_level
+            unit=registry.dimensionless, level=target_level, registry=registry
         )
     if agg_type is AggType.COUNT:
-        return grouping_level_count_unit(target_level=target_level)
+        return grouping_level_count_unit(target_level=target_level, registry=registry)
     if source_unit is None:
         msg = (
             f"A value aggregation ({agg_type}) needs a source_unit; only "
@@ -1556,15 +1621,19 @@ def resolved_unit_for_aggregation(
     stripped = (
         source_unit
         if source_level is None
-        else source_unit * _grouping_level_unit(source_level)
+        else source_unit * _grouping_level_unit(name=source_level, registry=registry)
     )
     if agg_type is AggType.MEAN:
         if source_level is None or not to_units_container(stripped):
             return stripped
-        return divide_by_grouping_level(unit=stripped, level=PERSON_LEVEL)
+        return divide_by_grouping_level(
+            unit=stripped, level=PERSON_LEVEL, registry=registry
+        )
     if target_level == PERSON_LEVEL and source_level is None:
         return stripped
-    return divide_by_grouping_level(unit=stripped, level=target_level)
+    return divide_by_grouping_level(
+        unit=stripped, level=target_level, registry=registry
+    )
 
 
 def fail_if_units_are_missing(
@@ -1572,7 +1641,7 @@ def fail_if_units_are_missing(
 ) -> None:
     """Data-independent check that every node declares a unit.
 
-    A missing unit is a definition error. :attr:`Unit.DIMENSIONLESS` is *not*
+    A missing unit is a definition error. :attr:`TTSIMUnit.DIMENSIONLESS` is *not*
     missing — it declares a dimensionless quantity; a node without any declaration
     maps to :data:`UNSET_UNIT`. This is the leaf check that
     :func:`ttsim.interface_dag_elements.unit_checks.fail_if_environment_units_are_missing`
@@ -1587,6 +1656,6 @@ def fail_if_units_are_missing(
     if missing:
         raise UnitDefinitionError(
             "The following nodes are missing a mandatory `unit=` declaration "
-            f"(GEP 10; declare `unit=Unit.DIMENSIONLESS` / `unit: DIMENSIONLESS` "
+            f"(GEP 10; declare `unit=TTSIMUnit.DIMENSIONLESS` / `unit: DIMENSIONLESS` "
             f"for a dimensionless quantity): {', '.join(missing)}."
         )

--- a/src/ttsim/unit_converters.py
+++ b/src/ttsim/unit_converters.py
@@ -5,9 +5,10 @@ from typing import Any, overload
 
 import numpy as np
 import pandas as pd
+import pint
 from jaxtyping import Float, Int
 
-from ttsim.tt.units import UNIT_REGISTRY
+from ttsim.tt.units import build_registry
 
 # `jax` is an optional runtime dependency; the NumPy-only test envs do not
 # install it. Resolve `Array` to a backend-agnostic union of the (optional)
@@ -30,13 +31,10 @@ TIME_UNIT_IDS_TO_LABELS = {
 }
 
 
-def _ratio(numerator: str, denominator: str) -> float:
+def _ratio(numerator: str, denominator: str, registry: pint.UnitRegistry) -> float:
     """Dimensionless magnitude of ``1 numerator / 1 denominator``, from pint."""
     return (
-        (
-            UNIT_REGISTRY.Quantity(1.0, numerator)
-            / UNIT_REGISTRY.Quantity(1.0, denominator)
-        )
+        (registry.Quantity(1.0, numerator) / registry.Quantity(1.0, denominator))
         .to("dimensionless")
         .magnitude
     )
@@ -52,12 +50,29 @@ def _as_int_if_whole(magnitude: float) -> int | float:
     return rounded if math.isclose(magnitude, rounded) else magnitude
 
 
-# The week factor is composed via days (365.25 / 7) so it matches GEP 1's
-# canonical value bit-for-bit rather than pint's direct year/week reduction.
-_Q_PER_Y = _as_int_if_whole(_ratio(numerator="year", denominator="quarter_year"))
-_M_PER_Y = _as_int_if_whole(_ratio(numerator="year", denominator="month"))
-_D_PER_Y = _ratio(numerator="year", denominator="day")
-_W_PER_Y = _D_PER_Y / _ratio(numerator="week", denominator="day")
+def _periods_per_year() -> tuple[int | float, int | float, float, float]:
+    """The quarter / month / day / week factors against a year, read off pint.
+
+    The ratio between two periods is part of the vocabulary every policy system
+    shares, so it is read off a throwaway registry rather than any system's; the
+    factors it yields are plain numbers and outlive it.
+
+    The week factor is composed via days (365.25 / 7) so it matches GEP 1's
+    canonical value bit-for-bit rather than pint's direct year/week reduction.
+    """
+    registry = build_registry()
+    quarters = _as_int_if_whole(
+        _ratio(numerator="year", denominator="quarter_year", registry=registry)
+    )
+    months = _as_int_if_whole(
+        _ratio(numerator="year", denominator="month", registry=registry)
+    )
+    days = _ratio(numerator="year", denominator="day", registry=registry)
+    weeks = days / _ratio(numerator="week", denominator="day", registry=registry)
+    return quarters, months, days, weeks
+
+
+_Q_PER_Y, _M_PER_Y, _D_PER_Y, _W_PER_Y = _periods_per_year()
 
 
 # --- Year conversions (stocks) ---

--- a/tests/interface_dag_elements/test_automatically_added_functions.py
+++ b/tests/interface_dag_elements/test_automatically_added_functions.py
@@ -9,7 +9,7 @@ from ttsim.interface_dag_elements.automatically_added_functions import (
     create_agg_by_group_functions,
     create_time_conversion_functions,
 )
-from ttsim.tt import Unit, policy_function, policy_input
+from ttsim.tt import TTSIMUnit, policy_function, policy_input
 from ttsim.unit_converters import (
     per_d_to_per_m,
     per_d_to_per_w,
@@ -58,7 +58,9 @@ def test_should_create_functions_for_other_time_units(
 ) -> None:
     time_conversion_functions = create_time_conversion_functions(
         qname_policy_environment={
-            name: policy_function(leaf_name=name, unit=Unit.DIMENSIONLESS)(return_one),
+            name: policy_function(leaf_name=name, unit=TTSIMUnit.DIMENSIONLESS)(
+                return_one
+            ),
         },
         input_columns=set(),
         grouping_levels=("sn", "kin"),
@@ -71,9 +73,9 @@ def test_should_create_functions_for_other_time_units(
 def test_should_not_create_functions_automatically_that_exist_already() -> None:
     time_conversion_functions = create_time_conversion_functions(
         qname_policy_environment={
-            "test1_d": policy_function(leaf_name="test1_d", unit=Unit.DIMENSIONLESS)(
-                return_one
-            ),
+            "test1_d": policy_function(
+                leaf_name="test1_d", unit=TTSIMUnit.DIMENSIONLESS
+            )(return_one),
         },
         input_columns={"test2_y"},
         grouping_levels=("sn", "kin"),
@@ -86,7 +88,7 @@ def test_should_not_create_functions_automatically_that_exist_already() -> None:
 def test_should_overwrite_with_data_cols_differing_only_in_time_period() -> None:
     time_conversion_functions = create_time_conversion_functions(
         qname_policy_environment={
-            "test_d": policy_function(leaf_name="test_d", unit=Unit.DIMENSIONLESS)(
+            "test_d": policy_function(leaf_name="test_d", unit=TTSIMUnit.DIMENSIONLESS)(
                 return_one
             ),
         },
@@ -124,7 +126,9 @@ def test_time_conversions_should_not_create_cycle():
 
     time_conversion_functions = create_time_conversion_functions(
         qname_policy_environment={
-            "test_d": policy_function(leaf_name="test_d", unit=Unit.DIMENSIONLESS)(x)
+            "test_d": policy_function(leaf_name="test_d", unit=TTSIMUnit.DIMENSIONLESS)(
+                x
+            )
         },
         input_columns=set(),
         grouping_levels=(),
@@ -134,11 +138,11 @@ def test_time_conversions_should_not_create_cycle():
 
 
 def test_grouping_functions_should_not_create_cycle():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def x(x_hh: int) -> int:
         return x_hh
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def some_other_function_requiring_x_hh(x_hh: int) -> int:
         return x_hh
 
@@ -167,29 +171,29 @@ def test_grouping_functions_should_not_create_cycle():
     [
         (
             {
-                "foo": policy_function(leaf_name="foo", unit=Unit.DIMENSIONLESS)(
+                "foo": policy_function(leaf_name="foo", unit=TTSIMUnit.DIMENSIONLESS)(
                     return_x_kin
                 )
             },
-            {"x": policy_input(unit=Unit.DIMENSIONLESS)(return_one)},
+            {"x": policy_input(unit=TTSIMUnit.DIMENSIONLESS)(return_one)},
             {},
             {"x"},
             ("x_kin"),
         ),
         (
             {
-                "n2__foo": policy_function(leaf_name="foo", unit=Unit.DIMENSIONLESS)(
-                    return_n1__x_kin
-                )
+                "n2__foo": policy_function(
+                    leaf_name="foo", unit=TTSIMUnit.DIMENSIONLESS
+                )(return_n1__x_kin)
             },
-            {"n1__x": policy_input(unit=Unit.DIMENSIONLESS)(return_one)},
+            {"n1__x": policy_input(unit=TTSIMUnit.DIMENSIONLESS)(return_one)},
             {},
             {"n1__x"},
             ("n1__x_kin"),
         ),
         (
             {},
-            {"x": policy_input(unit=Unit.DIMENSIONLESS)(return_one)},
+            {"x": policy_input(unit=TTSIMUnit.DIMENSIONLESS)(return_one)},
             {"x_kin": None},
             {"x"},
             ("x_kin"),
@@ -231,7 +235,7 @@ def test_agg_by_group_resolves_source_dtype_from_sibling_time_unit() -> None:
     result = create_agg_by_group_functions(
         column_functions={},
         qname_policy_environment={
-            "bonus_m": policy_input(unit=Unit.DIMENSIONLESS)(return_one_float)
+            "bonus_m": policy_input(unit=TTSIMUnit.DIMENSIONLESS)(return_one_float)
         },
         input_columns={"bonus_y"},
         tt_targets={"bonus_y_kin": None},

--- a/tests/interface_dag_elements/test_data_converters.py
+++ b/tests/interface_dag_elements/test_data_converters.py
@@ -5,6 +5,7 @@ import datetime
 import numpy
 import pandas as pd
 import pytest
+from mettsim import middle_earth
 from numpy.testing import assert_array_equal
 
 from ttsim import (
@@ -20,7 +21,7 @@ from ttsim.interface_dag_elements.data_converters import (
 )
 from ttsim.tt import (
     ScalarParam,
-    Unit,
+    TTSIMUnit,
     param_function,
     policy_function,
 )
@@ -40,17 +41,17 @@ _GENERIC_PARAM_SPEC = {
 }
 
 
-@policy_function(unit=Unit.DIMENSIONLESS)
+@policy_function(unit=TTSIMUnit.DIMENSIONLESS)
 def int_policy_function() -> int:
     return 1
 
 
-@policy_function(unit=Unit.DIMENSIONLESS)
+@policy_function(unit=TTSIMUnit.DIMENSIONLESS)
 def another_int_policy_function() -> int:
     return 1
 
 
-@param_function(unit=Unit.DIMENSIONLESS)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS)
 def int_param_function() -> int:
     return 1
 
@@ -232,6 +233,7 @@ def test_nested_data_to_dataframe(
         tt_targets=TTTargets.tree(tt_targets__tree),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     result_df = nested_data_to_df_with_mapped_columns(
         nested_data_to_convert=results__tree,

--- a/tests/interface_dag_elements/test_endogenous_p_id_targets.py
+++ b/tests/interface_dag_elements/test_endogenous_p_id_targets.py
@@ -12,9 +12,10 @@ import datetime
 from typing import TYPE_CHECKING
 
 import pandas as pd
+from mettsim import middle_earth
 
 from ttsim import InputData, MainTarget, TTTargets, main
-from ttsim.tt import FKType, ScalarParam, Unit, policy_function, policy_input
+from ttsim.tt import FKType, ScalarParam, TTSIMUnit, policy_function, policy_input
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -55,7 +56,7 @@ def test_endogenous_p_id_target_returns_user_space_p_ids(
         start_date=_DATE,
         end_date=_DATE,
         leaf_name="p_id_recipient",
-        unit=Unit.DIMENSIONLESS,
+        unit=TTSIMUnit.DIMENSIONLESS,
     )(_identity)
 
     result = main(
@@ -68,6 +69,7 @@ def test_endogenous_p_id_target_returns_user_space_p_ids(
         tt_targets=TTTargets.tree({"p_id_recipient": None}),
         input_data=InputData.tree(tree={"p_id": xnp.array([20, 10, 30])}),
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     expected = pd.DataFrame(
@@ -95,11 +97,11 @@ def test_endogenous_p_id_target_collapses_arbitrary_negative_to_sentinel(
         start_date=_DATE,
         end_date=_DATE,
         leaf_name="p_id_recipient",
-        unit=Unit.DIMENSIONLESS,
+        unit=TTSIMUnit.DIMENSIONLESS,
         vectorization_strategy="vectorize",
     )(_recipient_or_negative_two)
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def is_recipient() -> bool:
         pass
 
@@ -119,6 +121,7 @@ def test_endogenous_p_id_target_collapses_arbitrary_negative_to_sentinel(
             }
         ),
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     expected = pd.DataFrame(
@@ -141,11 +144,11 @@ def test_endogenous_p_id_target_preserves_minus_one_sentinel(
         start_date=_DATE,
         end_date=_DATE,
         leaf_name="p_id_recipient",
-        unit=Unit.DIMENSIONLESS,
+        unit=TTSIMUnit.DIMENSIONLESS,
         vectorization_strategy="vectorize",
     )(_recipient_or_minus_one)
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def is_recipient() -> bool:
         pass
 
@@ -165,6 +168,7 @@ def test_endogenous_p_id_target_preserves_minus_one_sentinel(
             }
         ),
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     expected = pd.DataFrame(
@@ -185,7 +189,9 @@ def test_exogenous_p_id_pointer_as_input_target_is_unchanged(
     computed-column path.
     """
 
-    @policy_input(foreign_key_type=FKType.MAY_POINT_TO_SELF, unit=Unit.DIMENSIONLESS)
+    @policy_input(
+        foreign_key_type=FKType.MAY_POINT_TO_SELF, unit=TTSIMUnit.DIMENSIONLESS
+    )
     def p_id_parent_1() -> int:
         pass
 
@@ -204,6 +210,7 @@ def test_exogenous_p_id_pointer_as_input_target_is_unchanged(
             }
         ),
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     expected = pd.DataFrame(
@@ -225,7 +232,7 @@ def test_endogenous_p_id_target_mixed_with_regular_column(
         start_date=_DATE,
         end_date=_DATE,
         leaf_name="p_id_recipient",
-        unit=Unit.DIMENSIONLESS,
+        unit=TTSIMUnit.DIMENSIONLESS,
     )(_identity)
 
     @policy_function(
@@ -233,12 +240,12 @@ def test_endogenous_p_id_target_mixed_with_regular_column(
         end_date=_DATE,
         leaf_name="doubled_m",
         vectorization_strategy="vectorize",
-        unit=Unit.CURRENCY.PER_MONTH,
+        unit=TTSIMUnit.CURRENCY.PER_MONTH,
     )
     def doubled_m(income_m: float) -> float:
         return income_m * 2.0
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def income_m() -> float:
         pass
 
@@ -259,6 +266,7 @@ def test_endogenous_p_id_target_mixed_with_regular_column(
             }
         ),
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     expected = pd.DataFrame(

--- a/tests/interface_dag_elements/test_failures.py
+++ b/tests/interface_dag_elements/test_failures.py
@@ -41,7 +41,7 @@ from ttsim.tt import (
     DictParam,
     PiecewisePolynomialParam,
     PiecewisePolynomialParamValue,
-    Unit,
+    TTSIMUnit,
     group_creation_function,
     param_function,
     policy_function,
@@ -158,6 +158,7 @@ def mettsim_environment(backend) -> PolicyEnvironment:
     return main(
         main_target="policy_environment",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         policy_date=datetime.date(2025, 1, 1),
         backend=backend,
     )
@@ -166,7 +167,7 @@ def mettsim_environment(backend) -> PolicyEnvironment:
 @group_creation_function(
     leaf_name="sp_id",
     fail_msg_if_included="""This should fail.""",
-    unit=Unit.DIMENSIONLESS,
+    unit=TTSIMUnit.DIMENSIONLESS,
 )
 def should_fail_sp_id(
     p_id: IntColumn, p_id_spouse: IntColumn, xnp: ModuleType
@@ -179,12 +180,14 @@ def should_fail_sp_id(
     return xnp.maximum(p_id, p_id_spouse) + xnp.minimum(p_id, p_id_spouse) * n
 
 
-@policy_input(fail_msg_if_included="""This should fail.""", unit=Unit.DIMENSIONLESS)
+@policy_input(
+    fail_msg_if_included="""This should fail.""", unit=TTSIMUnit.DIMENSIONLESS
+)
 def p_id_spouse() -> IntColumn:
     """Just to test that we can pass a policy input with `fail_msg_if_included` set."""
 
 
-@group_creation_function(leaf_name="fam_id", unit=Unit.DIMENSIONLESS)
+@group_creation_function(leaf_name="fam_id", unit=TTSIMUnit.DIMENSIONLESS)
 def dummy_fam_id(sp_id: IntColumn, xnp: ModuleType) -> IntColumn:  # noqa: ARG001
     """
     Just want to use this as a drop-in replacement for `fam_id` from METTSIM with
@@ -197,12 +200,12 @@ def some_x(x):
     return x
 
 
-@param_function(unit=Unit.DIMENSIONLESS, verify_units=False)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS, verify_units=False)
 def some_param_func_returning_array_of_length_2(xnp: ModuleType) -> Float[Array, 2]:
     return xnp.array([1, 2])
 
 
-@param_function(unit=Unit.DIMENSIONLESS, verify_units=False)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS, verify_units=False)
 def some_param_func_returning_list_of_length_2() -> list[int]:
     return [1, 2]
 
@@ -251,13 +254,13 @@ def test_assert_valid_ttsim_pytree(tree, leaf_checker, err_substr):
                     start_date="2023-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("c", "b"): policy_function(
                     start_date="2023-02-01",
                     end_date="2023-02-28",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {
@@ -274,13 +277,13 @@ def test_assert_valid_ttsim_pytree(tree, leaf_checker, err_substr):
                     start_date="2023-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("x", "c", "b"): policy_function(
                     start_date="2023-01-01",
                     end_date="2023-02-28",
                     leaf_name="g",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {
@@ -296,12 +299,12 @@ def test_assert_valid_ttsim_pytree(tree, leaf_checker, err_substr):
                 ("x", "c", "f"): policy_function(
                     start_date="2023-01-01",
                     end_date="2023-01-31",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("x", "d", "f"): policy_function(
                     start_date="2023-02-01",
                     end_date="2023-02-28",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {
@@ -318,13 +321,13 @@ def test_assert_valid_ttsim_pytree(tree, leaf_checker, err_substr):
                     start_date="2023-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("y", "a", "b"): policy_function(
                     start_date="2023-01-01",
                     end_date="2023-02-28",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {
@@ -355,13 +358,13 @@ def test_assert_valid_ttsim_pytree(tree, leaf_checker, err_substr):
                     start_date="2012-01-01",
                     end_date="2015-12-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("c", "b"): policy_function(
                     start_date="2023-02-01",
                     end_date="2023-02-28",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {
@@ -439,13 +442,13 @@ def test_fail_if_active_periods_overlap_passes(
                     start_date="2023-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("b",): policy_function(
                     start_date="2023-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {},
@@ -457,13 +460,13 @@ def test_fail_if_active_periods_overlap_passes(
                     start_date="2023-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("b"): policy_function(
                     start_date="2021-01-02",
                     end_date="2023-02-01",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {},
@@ -475,13 +478,13 @@ def test_fail_if_active_periods_overlap_passes(
                     start_date="2023-01-02",
                     end_date="2023-02-01",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("b",): policy_function(
                     start_date="2022-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {},
@@ -493,13 +496,13 @@ def test_fail_if_active_periods_overlap_passes(
                     start_date="2023-01-02",
                     end_date="2023-02-01",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("d", "b"): policy_function(
                     start_date="2022-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {},
@@ -510,12 +513,12 @@ def test_fail_if_active_periods_overlap_passes(
                 ("c", "f"): policy_function(
                     start_date="2023-01-02",
                     end_date="2023-02-01",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("d", "f"): policy_function(
                     start_date="2022-01-01",
                     end_date="2023-01-31",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {},
@@ -527,13 +530,13 @@ def test_fail_if_active_periods_overlap_passes(
                     start_date="2023-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("c", "b"): policy_function(
                     start_date="2023-02-01",
                     end_date="2023-02-28",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {
@@ -550,13 +553,13 @@ def test_fail_if_active_periods_overlap_passes(
                     start_date="2023-01-01",
                     end_date="2023-01-31",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
                 ("x", "a", "c"): policy_function(
                     start_date="2023-02-01",
                     end_date="2023-02-28",
                     leaf_name="f",
-                    unit=Unit.DIMENSIONLESS,
+                    unit=TTSIMUnit.DIMENSIONLESS,
                 )(identity),
             },
             {
@@ -622,6 +625,7 @@ def test_fail_if_data_paths_are_missing_in_paths_to_mapped_column_names(
         tt_targets=TTTargets.tree(tt_targets__tree),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     with pytest.raises(
         ValueError,
@@ -857,6 +861,7 @@ def test_fail_if_non_convertible_objects_in_results_tree_because_of_object_type(
             tt_targets=TTTargets.tree(tt_targets__tree),
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -893,6 +898,7 @@ def test_fail_if_non_convertible_objects_in_results_tree_because_of_object_lengt
             tt_targets=TTTargets.tree(tt_targets__tree),
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -922,6 +928,7 @@ def test_fail_if_non_convertible_objects_in_results_tree_passes_with_correct_len
         policy_date=datetime.date(2024, 1, 1),
         tt_targets=TTTargets.tree({}),
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     non_convertible_objects_in_results_tree(
         processed_data=processed_data,
@@ -946,6 +953,7 @@ def test_fail_if_non_convertible_objects_in_results_tree_passes_with_unsized_jax
         policy_date=datetime.date(2024, 1, 1),
         tt_targets=TTTargets.tree({}),
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     non_convertible_objects_in_results_tree(
         processed_data=processed_data,
@@ -1007,6 +1015,7 @@ def test_fail_if_p_id_is_missing_via_main(backend):
             evaluation_date=datetime.date(2025, 1, 1),
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1036,6 +1045,7 @@ def test_fail_if_p_id_is_not_unique_via_main(minimal_input_data, backend):
             policy_date=datetime.date(2025, 1, 1),
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1098,6 +1108,7 @@ def test_fail_if_input_data_has_different_lengths(backend):
             evaluation_date=datetime.date(2025, 1, 1),
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1109,8 +1120,8 @@ def test_fail_if_tt_root_nodes_are_missing_via_main(minimal_input_data, backend)
         return b
 
     policy_environment = {
-        "b": policy_function(leaf_name="b", unit=Unit.DIMENSIONLESS)(b),
-        "c": policy_function(leaf_name="c", unit=Unit.DIMENSIONLESS)(c),
+        "b": policy_function(leaf_name="b", unit=TTSIMUnit.DIMENSIONLESS)(b),
+        "c": policy_function(leaf_name="c", unit=TTSIMUnit.DIMENSIONLESS)(c),
     }
 
     with pytest.raises(
@@ -1126,17 +1137,18 @@ def test_fail_if_tt_root_nodes_are_missing_via_main(minimal_input_data, backend)
             tt_targets=TTTargets.tree({"c": None}),
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
 def test_fail_if_tt_root_nodes_are_missing_asks_for_individual_level_columns(
     minimal_input_data, backend
 ):
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def b(a_fam: int) -> int:
         return a_fam
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def a() -> int:
         pass
 
@@ -1161,6 +1173,7 @@ def test_fail_if_tt_root_nodes_are_missing_asks_for_individual_level_columns(
             include_fail_nodes=False,
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1215,6 +1228,7 @@ def test_fail_if_targets_are_not_in_specialized_environment_or_data_via_main(
             evaluation_date=datetime.date(2025, 1, 1),
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1357,6 +1371,7 @@ def test_fail_if_input_df_mapper_columns_missing_in_df_via_main(
             input_data=InputData.df_and_mapper(df=df, mapper=mapper),
             main_target=MainTarget.results.df_with_mapper,
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
             tt_targets=TTTargets.qname({"d": None}),
             policy_date_str="2025-01-01",
             backend=backend,
@@ -1421,6 +1436,7 @@ def test_fail_if_input_df_mapper_p_id_is_missing_via_main(
             evaluation_date=datetime.date(2025, 1, 1),
             rounding=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1481,6 +1497,7 @@ def test_invalid_tt_targets_tree(
                 }
             ),
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
             policy_date_str="2025-01-01",
             tt_targets=TTTargets.tree(tt_targets__tree),
         )
@@ -1516,6 +1533,7 @@ def test_invalid_input_data_tree_via_main(
             main_target=MainTarget.results.df_with_nested_columns,
             policy_date_str="2025-01-01",
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
             input_data=InputData.tree(tree=input_data_tree_with_p_id),
             tt_targets=TTTargets.tree({"p_id": None}),
             backend=backend,
@@ -1581,10 +1599,10 @@ def test_fail_if_policy_environment_is_invalid(policy_environment, match):
         # Valid environment with policy functions
         lambda _xnp: {
             "valid_func": policy_function(
-                leaf_name="valid_func", unit=Unit.DIMENSIONLESS
+                leaf_name="valid_func", unit=TTSIMUnit.DIMENSIONLESS
             )(identity),
             "another_func": policy_function(
-                leaf_name="another_func", unit=Unit.DIMENSIONLESS
+                leaf_name="another_func", unit=TTSIMUnit.DIMENSIONLESS
             )(return_one),
         },
         # Valid environment with param functions
@@ -1604,7 +1622,7 @@ def test_fail_if_policy_environment_is_invalid(policy_environment, match):
         lambda _xnp: {
             "nested": {
                 "nested_func": policy_function(
-                    leaf_name="nested_func", unit=Unit.DIMENSIONLESS
+                    leaf_name="nested_func", unit=TTSIMUnit.DIMENSIONLESS
                 )(identity),
                 "some_param_func_returning_array_of_length_2": some_param_func_returning_array_of_length_2,
             },
@@ -1612,7 +1630,7 @@ def test_fail_if_policy_environment_is_invalid(policy_environment, match):
         },
         # Valid environment with mixed types
         lambda _xnp: {
-            "func": policy_function(leaf_name="func", unit=Unit.DIMENSIONLESS)(
+            "func": policy_function(leaf_name="func", unit=TTSIMUnit.DIMENSIONLESS)(
                 identity
             ),
             "some_param_func_returning_array_of_length_2": some_param_func_returning_array_of_length_2,
@@ -1635,6 +1653,7 @@ def test_raises_error_if_p_id_is_passed_as_scalar(backend: Literal["jax", "numpy
             main_target=MainTarget.results.df_with_nested_columns,
             policy_date_str="2025-01-01",
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
             input_data=InputData.tree(tree={"p_id": 1}),
             tt_targets=TTTargets.tree({"p_id": None}),
             backend=backend,
@@ -1647,6 +1666,7 @@ def test_invalid_input_data_as_object_via_main(backend: Literal["jax", "numpy"])
             main_target=MainTarget.results.df_with_nested_columns,
             policy_date_str="2025-01-01",
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
             input_data=InputData.tree(object()),  # ty: ignore [invalid-argument-type]
             tt_targets=TTTargets.tree({"p_id": None}),
             backend=backend,
@@ -1656,7 +1676,11 @@ def test_invalid_input_data_as_object_via_main(backend: Literal["jax", "numpy"])
 @pytest.mark.parametrize(
     "policy_environment",
     [
-        {"foo": policy_function(leaf_name="bar", unit=Unit.DIMENSIONLESS)(return_one)},
+        {
+            "foo": policy_function(leaf_name="bar", unit=TTSIMUnit.DIMENSIONLESS)(
+                return_one
+            )
+        },
     ],
 )
 def test_fail_if_name_of_last_branch_element_is_not_the_functions_leaf_name(
@@ -1673,6 +1697,7 @@ def test_fail_if_name_of_last_branch_element_is_not_the_functions_leaf_name(
             policy_date=datetime.date(2025, 1, 1),
             tt_targets=TTTargets.tree({"p_id": None}),
             input_data=InputData.tree(tree={"p_id": xnp.array([0, 1, 2])}),
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1696,6 +1721,7 @@ def test_raise_tt_root_nodes_are_missing_without_input_data(
             policy_date_str="2025-01-01",
             backend=backend,
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1711,6 +1737,7 @@ def test_raise_some_error_without_input_data(
             main_target=MainTarget.results.df_with_mapper,
             backend=backend,
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1734,6 +1761,7 @@ def test_fail_if_tt_dag_includes_function_with_fail_msg_if_included_set(
             input_data=InputData.tree(tree=minimal_data_tree),
             include_warn_nodes=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1757,6 +1785,7 @@ def test_fail_if_tt_dag_includes_policy_input_with_fail_msg_if_included_set(
             input_data=InputData.tree(tree=minimal_data_tree),
             include_warn_nodes=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -1779,6 +1808,7 @@ def test_fail_if_tt_dag_includes_policy_input_with_fail_msg_if_included_set_does
         input_data=InputData.tree(tree=minimal_data_tree),
         include_warn_nodes=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
 
@@ -1789,6 +1819,7 @@ def test_backend_has_changed_from_jax_to_numpy_passes():
         main_target=MainTarget.policy_environment,
         policy_date_str="2000-01-01",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         backend="jax",
     )
     input_data = InputData.tree(
@@ -1806,6 +1837,7 @@ def test_backend_has_changed_from_jax_to_numpy_passes():
         policy_date_str="2000-01-01",
         tt_targets=TTTargets.tree({"property_tax": {"amount_y": None}}),
         backend="numpy",
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
 
@@ -1824,6 +1856,7 @@ def test_backend_has_changed_from_numpy_for_processed_data_to_jax_passes():
         backend="numpy",
         policy_date_str="2000-01-01",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         input_data=input_data,
         tt_targets=TTTargets.tree({"property_tax": {"amount_y": None}}),
     )
@@ -1831,6 +1864,7 @@ def test_backend_has_changed_from_numpy_for_processed_data_to_jax_passes():
         main_target=MainTarget.results.df_with_nested_columns,
         policy_date_str="2000-01-01",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         input_data=input_data,
         processed_data=processed_data,
         tt_targets=TTTargets.tree({"property_tax": {"amount_y": None}}),
@@ -1846,6 +1880,7 @@ def test_backend_has_changed_from_numpy_for_policy_environment_to_jax_raises(
         main_target=MainTarget.policy_environment,
         policy_date_str="2000-01-01",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         backend="numpy",
     )
     input_data = InputData.tree(
@@ -1864,28 +1899,29 @@ def test_backend_has_changed_from_numpy_for_policy_environment_to_jax_raises(
             policy_date_str="2000-01-01",
             tt_targets=TTTargets.tree({"property_tax": {"amount_y": None}}),
             backend="jax",
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
-@param_function(unit=Unit.DIMENSIONLESS)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS)
 def valid_param_function(x: int) -> int:
     """A valid param function that only depends on parameters."""
     return x * 2
 
 
-@param_function(unit=Unit.DIMENSIONLESS)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS)
 def invalid_param_function(some_policy_function: int) -> int:
     """An invalid param function that depends on a column object."""
     return some_policy_function * 2
 
 
-@policy_function(unit=Unit.DIMENSIONLESS)
+@policy_function(unit=TTSIMUnit.DIMENSIONLESS)
 def some_policy_function(x: int) -> int:
     """A policy function for testing."""
     return x + 1
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def some_policy_input() -> int:
     """A policy input for testing."""
 
@@ -1981,4 +2017,5 @@ def test_param_function_depends_on_column_objects_via_main(
                 "invalid_param_function": invalid_param_function,
                 "some_policy_function": some_policy_function,
             },
+            unit_system=middle_earth.UNIT_SYSTEM,
         )

--- a/tests/interface_dag_elements/test_input_units.py
+++ b/tests/interface_dag_elements/test_input_units.py
@@ -25,20 +25,31 @@ from ttsim.interface_dag_elements.unit_checks import (
     fail_if_input_units_are_inconsistent,
     fail_if_not_all_leaves_are_unit_annotated_columns,
 )
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.grouping_levels import register_grouping_levels
 from ttsim.tt.units import (
     CompositeUnit,
-    Unit,
+    TTSIMUnit,
     UnitAnnotatedColumn,
     output_unit_in_data_currency,
     resolve_compositional_column_unit,
     resolve_compositional_unit,
 )
 
+# A representative system whose registry these boundary tests resolve against.
+# They pass the agnostic ``CURRENCY`` as the data currency explicitly, so the
+# base currency is never exercised; the grouping level ``hh`` is.
+SYSTEM = UnitSystem(
+    base_currency="EUR",
+    statutory_currencies={"0001-01-01": "EUR"},
+    grouping_levels=["hh"],
+)
+REGISTRY = SYSTEM.registry
+
 
 def _resolved(unit: CompositeUnit) -> pint.Unit:
     """Resolve a CompositeUnit to its pint unit (no implied person leaf)."""
-    return resolve_compositional_unit(unit=unit)
+    return resolve_compositional_unit(unit=unit, registry=REGISTRY)
 
 
 def _column(
@@ -53,30 +64,38 @@ def _column(
         time_unit_id=time_unit_id,
         grouping_level=grouping_level,
         where="test",
+        registry=REGISTRY,
     )
 
 
 def test_output_unit_in_data_currency_leaves_non_currency_units_untouched():
-    for composite in (Unit.YEARS, Unit.HECTARE, Unit.DIMENSIONLESS):
+    for composite in (TTSIMUnit.YEARS, TTSIMUnit.HECTARE, TTSIMUnit.DIMENSIONLESS):
         unit = _resolved(composite)
         assert (
-            output_unit_in_data_currency(units=unit, data_currency="CURRENCY") == unit
+            output_unit_in_data_currency(
+                units=unit, data_currency="CURRENCY", registry=REGISTRY
+            )
+            == unit
         )
 
 
 def test_units_from_tree_with_unit_annotations_extracts_each_tag():
     tree = {
         "wage_m": UnitAnnotatedColumn(
-            values=numpy.array([1.0, 2.0]), unit=Unit.CURRENCY.PER_MONTH
+            values=numpy.array([1.0, 2.0]), unit=TTSIMUnit.CURRENCY.PER_MONTH
         ),
         "nested": {
-            "alter": UnitAnnotatedColumn(values=numpy.array([30, 40]), unit=Unit.YEARS)
+            "alter": UnitAnnotatedColumn(
+                values=numpy.array([30, 40]), unit=TTSIMUnit.YEARS
+            )
         },
         "p_id": UnitAnnotatedColumn(
-            values=numpy.array([0, 1]), unit=Unit.DIMENSIONLESS
+            values=numpy.array([0, 1]), unit=TTSIMUnit.DIMENSIONLESS
         ),
     }
-    units = units_from_tree_with_unit_annotations(tree_with_unit_annotations=tree)
+    units = units_from_tree_with_unit_annotations(
+        tree_with_unit_annotations=tree, unit_system=SYSTEM
+    )
     assert {k: str(v) for k, v in units.items()} == {
         "wage_m": "CURRENCY / month",
         "nested__alter": "delta_calendar_year",
@@ -87,7 +106,7 @@ def test_units_from_tree_with_unit_annotations_extracts_each_tag():
 def test_fail_if_not_all_leaves_are_unit_annotated_columns_rejects_bare_leaf():
     flat: dict[tuple[str, ...], object] = {
         ("wage_m",): UnitAnnotatedColumn(
-            values=numpy.array([1.0]), unit=Unit.CURRENCY.PER_MONTH
+            values=numpy.array([1.0]), unit=TTSIMUnit.CURRENCY.PER_MONTH
         ),
         ("alter",): numpy.array([30]),  # bare — not tagged
     }
@@ -98,14 +117,14 @@ def test_fail_if_not_all_leaves_are_unit_annotated_columns_rejects_bare_leaf():
 def test_flat_from_tree_with_unit_annotations_strips_to_bare_arrays():
     tree = {
         "wage_m": UnitAnnotatedColumn(
-            values=numpy.array([1.0, 2.0]), unit=Unit.CURRENCY.PER_MONTH
+            values=numpy.array([1.0, 2.0]), unit=TTSIMUnit.CURRENCY.PER_MONTH
         ),
         "p_id": UnitAnnotatedColumn(
-            values=numpy.array([0, 1]), unit=Unit.DIMENSIONLESS
+            values=numpy.array([0, 1]), unit=TTSIMUnit.DIMENSIONLESS
         ),
     }
     flat = flat_from_tree_with_unit_annotations(
-        tree_with_unit_annotations=tree, data_currency="CURRENCY"
+        tree_with_unit_annotations=tree, data_currency="CURRENCY", unit_system=SYSTEM
     )
     assert not isinstance(flat[("wage_m",)], pint.Quantity)
     assert not isinstance(flat[("p_id",)], pint.Quantity)
@@ -117,10 +136,10 @@ def test_flat_from_tree_with_unit_annotations_strips_to_bare_arrays():
 def test_fail_if_not_all_leaves_are_unit_annotated_columns_passes_when_all_tagged():
     flat: dict[tuple[str, ...], object] = {
         ("wage_m",): UnitAnnotatedColumn(
-            values=numpy.array([1.0]), unit=Unit.CURRENCY.PER_MONTH
+            values=numpy.array([1.0]), unit=TTSIMUnit.CURRENCY.PER_MONTH
         ),
         ("p_id",): UnitAnnotatedColumn(
-            values=numpy.array([0]), unit=Unit.DIMENSIONLESS
+            values=numpy.array([0]), unit=TTSIMUnit.DIMENSIONLESS
         ),
     }
     fail_if_not_all_leaves_are_unit_annotated_columns(flat=flat)
@@ -129,11 +148,15 @@ def test_fail_if_not_all_leaves_are_unit_annotated_columns_passes_when_all_tagge
 def test_flat_from_tree_with_unit_annotations_fails_on_period_mismatch():
     # A `_m` column tagged without a period (a stock tag) is a boundary error.
     tree = {
-        "wage_m": UnitAnnotatedColumn(values=numpy.array([1.0]), unit=Unit.CURRENCY)
+        "wage_m": UnitAnnotatedColumn(
+            values=numpy.array([1.0]), unit=TTSIMUnit.CURRENCY
+        )
     }
     with pytest.raises(UnitConsistencyError):
         flat_from_tree_with_unit_annotations(
-            tree_with_unit_annotations=tree, data_currency="CURRENCY"
+            tree_with_unit_annotations=tree,
+            data_currency="CURRENCY",
+            unit_system=SYSTEM,
         )
 
 
@@ -143,9 +166,11 @@ def test_input_currency_non_currency_columns_pass():
     # covered end-to-end in the mettsim suite (a base currency is registered there).
     input_currency_is_not_concrete(
         input_data__tree_with_unit_annotations={
-            "alter": UnitAnnotatedColumn(values=numpy.array([30]), unit=Unit.YEARS),
+            "alter": UnitAnnotatedColumn(
+                values=numpy.array([30]), unit=TTSIMUnit.YEARS
+            ),
             "p_id": UnitAnnotatedColumn(
-                values=numpy.array([0]), unit=Unit.DIMENSIONLESS
+                values=numpy.array([0]), unit=TTSIMUnit.DIMENSIONLESS
             ),
         }
     )
@@ -154,81 +179,88 @@ def test_input_currency_non_currency_columns_pass():
 def test_input_level_must_match_declared():
     # A `_hh` column declares the hh level; a person-leaf (level-less) tag contradicts
     # it. Compared against the declared resolved unit, not the name suffix directly.
-    register_grouping_levels(["hh"])
+    register_grouping_levels(["hh"], registry=REGISTRY)
     with pytest.raises(UnitConsistencyError, match="level"):
         fail_if_input_units_are_inconsistent(
             input_units={
-                "miete_m_hh": _column(Unit.CURRENCY.PER_MONTH, time_unit_id="m")
+                "miete_m_hh": _column(TTSIMUnit.CURRENCY.PER_MONTH, time_unit_id="m")
             },
             resolved_units={
                 "miete_m_hh": _column(
-                    Unit.CURRENCY.PER_MONTH.PER_HH,
+                    TTSIMUnit.CURRENCY.PER_MONTH.PER_HH,
                     time_unit_id="m",
                     grouping_level="hh",
                 )
             },
+            unit_system=SYSTEM,
         )
 
 
 def test_input_level_matching_declared_passes():
-    register_grouping_levels(["hh"])
+    register_grouping_levels(["hh"], registry=REGISTRY)
     miete = _column(
-        Unit.CURRENCY.PER_MONTH.PER_HH, time_unit_id="m", grouping_level="hh"
+        TTSIMUnit.CURRENCY.PER_MONTH.PER_HH, time_unit_id="m", grouping_level="hh"
     )
-    wage = _column(Unit.CURRENCY.PER_MONTH, time_unit_id="m")
+    wage = _column(TTSIMUnit.CURRENCY.PER_MONTH, time_unit_id="m")
     fail_if_input_units_are_inconsistent(
         input_units={"miete_m_hh": miete, "wage_m": wage},
         resolved_units={"miete_m_hh": miete, "wage_m": wage},
+        unit_system=SYSTEM,
     )
 
 
 def test_input_share_at_group_suffix_stays_level_less():
     # A group suffix must not force a level onto a level-less quantity.
-    register_grouping_levels(["hh"])
+    register_grouping_levels(["hh"], registry=REGISTRY)
     fail_if_input_units_are_inconsistent(
-        input_units={"rate_hh": _resolved(Unit.DIMENSIONLESS)},
-        resolved_units={"rate_hh": _resolved(Unit.DIMENSIONLESS)},
+        input_units={"rate_hh": _resolved(TTSIMUnit.DIMENSIONLESS)},
+        resolved_units={"rate_hh": _resolved(TTSIMUnit.DIMENSIONLESS)},
+        unit_system=SYSTEM,
     )
 
 
 def test_input_units_consistent_passes():
     resolved = {
-        "wage_m": _resolved(Unit.CURRENCY.PER_MONTH),
-        "alter": _resolved(Unit.YEARS),
+        "wage_m": _resolved(TTSIMUnit.CURRENCY.PER_MONTH),
+        "alter": _resolved(TTSIMUnit.YEARS),
     }
     fail_if_input_units_are_inconsistent(
-        input_units={"wage_m": _resolved(Unit.CURRENCY.PER_MONTH)},
+        input_units={"wage_m": _resolved(TTSIMUnit.CURRENCY.PER_MONTH)},
         resolved_units=resolved,
+        unit_system=SYSTEM,
     )
 
 
 def test_input_units_dimension_mismatch_raises():
-    resolved = {"alter": _resolved(Unit.YEARS)}
+    resolved = {"alter": _resolved(TTSIMUnit.YEARS)}
     with pytest.raises(UnitConsistencyError, match="inconsistent with the DAG"):
         fail_if_input_units_are_inconsistent(
-            input_units={"alter": _resolved(Unit.CURRENCY)},
+            input_units={"alter": _resolved(TTSIMUnit.CURRENCY)},
             resolved_units=resolved,
+            unit_system=SYSTEM,
         )
 
 
 def test_input_units_compatible_but_differently_scaled_area_raises():
     # A HECTARES column tagged in m² shares the area dimension but is a
     # 10,000-fold level error — rejected, not silently mis-stripped (S4, GEP 10).
-    resolved = {"land": _resolved(Unit.HECTARE)}
+    resolved = {"land": _resolved(TTSIMUnit.HECTARE)}
     with pytest.raises(UnitConsistencyError, match="not equivalent"):
         fail_if_input_units_are_inconsistent(
-            input_units={"land": _resolved(Unit.SQUARE_METER)},
+            input_units={"land": _resolved(TTSIMUnit.SQUARE_METER)},
             resolved_units=resolved,
+            unit_system=SYSTEM,
         )
 
 
 def test_input_units_compatible_but_differently_scaled_time_raises():
     # A YEARS age tagged in months is a 12-fold level error (S4, GEP 10).
-    resolved = {"alter": _resolved(Unit.YEARS)}
+    resolved = {"alter": _resolved(TTSIMUnit.YEARS)}
     with pytest.raises(UnitConsistencyError, match="not equivalent"):
         fail_if_input_units_are_inconsistent(
-            input_units={"alter": _resolved(Unit.MONTHS)},
+            input_units={"alter": _resolved(TTSIMUnit.MONTHS)},
             resolved_units=resolved,
+            unit_system=SYSTEM,
         )
 
 
@@ -237,10 +269,11 @@ def test_input_units_period_mismatch_is_left_to_the_suffix_guard():
     # guard, not here: once currency and period are factored out, a `_m` flow
     # tagged per year has an equivalent (bare) residual, so this check passes and
     # the period guard owns the mismatch (S4, GEP 10).
-    resolved = {"wage_m": _resolved(Unit.CURRENCY.PER_MONTH)}
+    resolved = {"wage_m": _resolved(TTSIMUnit.CURRENCY.PER_MONTH)}
     fail_if_input_units_are_inconsistent(
-        input_units={"wage_m": _resolved(Unit.CURRENCY.PER_YEAR)},
+        input_units={"wage_m": _resolved(TTSIMUnit.CURRENCY.PER_YEAR)},
         resolved_units=resolved,
+        unit_system=SYSTEM,
     )
 
 
@@ -249,33 +282,36 @@ def test_input_units_currency_tag_on_non_currency_column_raises():
     # out of both sides used to leave equal residuals and pass, while the boundary
     # would silently rescale the data by the currency factor on a non-base run.
     # The currency-presence mismatch is now rejected (defect #3, GEP 10).
-    resolved = {"flag": _resolved(Unit.DIMENSIONLESS)}
+    resolved = {"flag": _resolved(TTSIMUnit.DIMENSIONLESS)}
     with pytest.raises(UnitConsistencyError, match="one carries a currency"):
         fail_if_input_units_are_inconsistent(
-            input_units={"flag": _resolved(Unit.CURRENCY)},
+            input_units={"flag": _resolved(TTSIMUnit.CURRENCY)},
             resolved_units=resolved,
+            unit_system=SYSTEM,
         )
 
 
 def test_input_units_non_currency_tag_on_currency_column_raises():
     # The converse: a dimensionless tag on a declared-currency column would skip
     # the currency conversion the column needs (defect #3, GEP 10).
-    resolved = {"wage": _resolved(Unit.CURRENCY)}
+    resolved = {"wage": _resolved(TTSIMUnit.CURRENCY)}
     with pytest.raises(UnitConsistencyError, match="one carries a currency"):
         fail_if_input_units_are_inconsistent(
-            input_units={"wage": _resolved(Unit.DIMENSIONLESS)},
+            input_units={"wage": _resolved(TTSIMUnit.DIMENSIONLESS)},
             resolved_units=resolved,
+            unit_system=SYSTEM,
         )
 
 
 def test_input_units_skips_columns_without_a_scalar_declared_unit():
     # A dict-parameter style entry (nested dict, not a single pint.Unit) and an
     # unknown column are both skipped rather than raising.
-    resolved = {"some_dict_param": {"a": _resolved(Unit.CURRENCY)}}
+    resolved = {"some_dict_param": {"a": _resolved(TTSIMUnit.CURRENCY)}}
     fail_if_input_units_are_inconsistent(
         input_units={
-            "some_dict_param": _resolved(Unit.CURRENCY),
-            "not_in_env": _resolved(Unit.YEARS),
+            "some_dict_param": _resolved(TTSIMUnit.CURRENCY),
+            "not_in_env": _resolved(TTSIMUnit.YEARS),
         },
         resolved_units=resolved,
+        unit_system=SYSTEM,
     )

--- a/tests/interface_dag_elements/test_labels.py
+++ b/tests/interface_dag_elements/test_labels.py
@@ -17,14 +17,14 @@ from ttsim.interface_dag_elements.labels import (
     root_nodes,
     top_level_namespace,
 )
-from ttsim.tt import Unit, param_function, policy_function, policy_input
+from ttsim.tt import TTSIMUnit, param_function, policy_function, policy_input
 
 
 def identity(x: int) -> int:
     return x
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def fam_id() -> int:
     pass
 
@@ -37,16 +37,16 @@ def fam_id() -> int:
     [
         (
             {
-                "foo_m": policy_function(leaf_name="foo_m", unit=Unit.DIMENSIONLESS)(
-                    identity
-                ),
+                "foo_m": policy_function(
+                    leaf_name="foo_m", unit=TTSIMUnit.DIMENSIONLESS
+                )(identity),
                 "fam_id": fam_id,
             },
             {"foo_m", "foo_y", "foo_m_fam", "foo_y_fam"},
         ),
         (
             {
-                "foo": policy_function(leaf_name="foo", unit=Unit.DIMENSIONLESS)(
+                "foo": policy_function(leaf_name="foo", unit=TTSIMUnit.DIMENSIONLESS)(
                     identity
                 ),
                 "fam_id": fam_id,
@@ -67,15 +67,15 @@ def test_get_top_level_namespace(policy_environment, expected):
 # grouping_levels tests
 # =============================================================================
 def test_grouping_levels_extracts_id_columns():
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def p_id() -> int:
         pass
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def hh_id() -> int:
         pass
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def fam_id() -> int:
         pass
 
@@ -95,7 +95,7 @@ def test_grouping_levels_extracts_id_columns():
 
 
 def test_grouping_levels_excludes_p_id():
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def p_id() -> int:
         pass
 
@@ -153,11 +153,11 @@ def test_input_columns_is_empty_set_returns_empty():
 # all_qnames_in_policy_environment tests
 # =============================================================================
 def test_all_qnames_in_policy_environment_flat():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def col_a(x: int) -> int:
         return x
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def col_b() -> int:
         pass
 
@@ -169,7 +169,7 @@ def test_all_qnames_in_policy_environment_flat():
 
 
 def test_all_qnames_in_policy_environment_nested():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def nested_col(x: int) -> int:
         return x
 
@@ -183,15 +183,15 @@ def test_all_qnames_in_policy_environment_nested():
 # policy_inputs tests
 # =============================================================================
 def test_policy_inputs_returns_only_policy_input_qnames():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def col_func(x: int) -> int:
         return x
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def input_col() -> int:
         pass
 
-    @param_function(unit=Unit.DIMENSIONLESS)
+    @param_function(unit=TTSIMUnit.DIMENSIONLESS)
     def param_func() -> int:
         return 42
 
@@ -209,7 +209,7 @@ def test_policy_inputs_returns_only_policy_input_qnames():
 
 
 def test_policy_inputs_handles_nested():
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def nested_input() -> int:
         pass
 

--- a/tests/interface_dag_elements/test_nullable_dtypes.py
+++ b/tests/interface_dag_elements/test_nullable_dtypes.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 import pytest
+from mettsim import middle_earth
 
 from ttsim import InputData, MainTarget, TTTargets, main
 from ttsim.interface_dag_elements.processed_data import (
@@ -58,6 +59,7 @@ def test_float_nullable_input_with_na_round_trips_as_nan(
         policy_date=datetime.date(2025, 1, 1),
         evaluation_date=datetime.date(2025, 1, 1),
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     expected = pd.DataFrame(
@@ -146,6 +148,7 @@ def test_int_input_with_na_fails_with_actionable_message(
             policy_date=datetime.date(2025, 1, 1),
             evaluation_date=_DATE,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -169,6 +172,7 @@ def test_bool_input_with_na_fails_with_actionable_message(
             policy_date=datetime.date(2025, 1, 1),
             evaluation_date=_DATE,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -200,6 +204,7 @@ def test_multiple_int_or_bool_columns_with_na_all_reported(
             policy_date=datetime.date(2025, 1, 1),
             evaluation_date=_DATE,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -222,6 +227,7 @@ def test_pyarrow_int_input_round_trips_as_int(backend: Literal["numpy", "jax"]):
         policy_date=datetime.date(2025, 1, 1),
         evaluation_date=_DATE,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     assert result[("age",)].tolist() == [25, 35, 45]
 
@@ -249,6 +255,7 @@ def test_uint64_overflow_fails_with_actionable_message(
             policy_date=datetime.date(2025, 1, 1),
             evaluation_date=_DATE,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -276,4 +283,5 @@ def test_uint64_overflow_from_dataframe_fails_with_actionable_message(
             policy_date=datetime.date(2025, 1, 1),
             evaluation_date=_DATE,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )

--- a/tests/interface_dag_elements/test_policy_environment.py
+++ b/tests/interface_dag_elements/test_policy_environment.py
@@ -17,8 +17,7 @@ from ttsim.interface_dag_elements.policy_environment import (
     _active_column_objects_and_param_functions,
     _active_param_objects,
 )
-from ttsim.tt import ScalarParam, Unit, policy_function
-from ttsim.tt.currencies import statutory_currency_for_date
+from ttsim.tt import ScalarParam, TTSIMUnit, policy_function
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -38,7 +37,7 @@ def some_int_param():
         end_date=datetime.date(2025, 12, 31),
         name={"de": "Some int param", "en": "Some int param"},
         description={"de": "Some int param", "en": "Some int param"},
-        unit=Unit.DIMENSIONLESS,
+        unit=TTSIMUnit.DIMENSIONLESS,
         note=None,
         reference=None,
     )
@@ -82,6 +81,7 @@ def test_input_is_recognized_as_potential_group_id(backend):
     assert "kin" in main(
         main_target="labels__grouping_levels",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         policy_date=datetime.date(2020, 1, 1),
         backend=backend,
     )
@@ -91,6 +91,7 @@ def test_p_id_not_recognized_as_potential_group_id(backend):
     assert "p" not in main(
         main_target="labels__grouping_levels",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         policy_date=datetime.date(2020, 1, 1),
         backend=backend,
     )
@@ -103,7 +104,7 @@ def test_p_id_not_recognized_as_potential_group_id(backend):
     ],
 )
 def test_start_date_valid(date_string: str, expected: datetime.date):
-    @policy_function(start_date=date_string, unit=Unit.DIMENSIONLESS)
+    @policy_function(start_date=date_string, unit=TTSIMUnit.DIMENSIONLESS)
     def test_func() -> int:
         pass
 
@@ -124,13 +125,13 @@ def test_start_date_invalid(date_string: str):
         match=r"neither matches the format YYYY-MM-DD nor is a datetime.date",
     ):
 
-        @policy_function(start_date=date_string, unit=Unit.DIMENSIONLESS)
+        @policy_function(start_date=date_string, unit=TTSIMUnit.DIMENSIONLESS)
         def test_func() -> int:
             pass
 
 
 def test_start_date_missing():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def test_func() -> int:
         pass
 
@@ -144,7 +145,7 @@ def test_start_date_missing():
     ],
 )
 def test_end_date_valid(date_string: str, expected: datetime.date):
-    @policy_function(end_date=date_string, unit=Unit.DIMENSIONLESS)
+    @policy_function(end_date=date_string, unit=TTSIMUnit.DIMENSIONLESS)
     def test_func() -> int:
         pass
 
@@ -165,13 +166,13 @@ def test_end_date_invalid(date_string: str):
         match=r"neither matches the format YYYY-MM-DD nor is a datetime.date",
     ):
 
-        @policy_function(end_date=date_string, unit=Unit.DIMENSIONLESS)
+        @policy_function(end_date=date_string, unit=TTSIMUnit.DIMENSIONLESS)
         def test_func() -> int:
             pass
 
 
 def test_end_date_missing():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def test_func() -> int:
         pass
 
@@ -182,7 +183,7 @@ def test_active_period_is_empty():
     with pytest.raises(ValueError, match="must be before the end date"):
 
         @policy_function(
-            start_date="2023-01-20", end_date="2023-01-19", unit=Unit.DIMENSIONLESS
+            start_date="2023-01-20", end_date="2023-01-19", unit=TTSIMUnit.DIMENSIONLESS
         )
         def test_func() -> int:
             pass
@@ -210,12 +211,16 @@ def test_active_tree_with_column_objects_and_param_functions(
     functions_last_day = _active_column_objects_and_param_functions(
         orig=orig,
         policy_date=last_day,
-        computation_currency=statutory_currency_for_date(last_day),
+        computation_currency=middle_earth.UNIT_SYSTEM.statutory_currency_for_date(
+            last_day
+        ),
     )
     functions_next_day = _active_column_objects_and_param_functions(
         orig=orig,
         policy_date=next_day,
-        computation_currency=statutory_currency_for_date(next_day),
+        computation_currency=middle_earth.UNIT_SYSTEM.statutory_currency_for_date(
+            next_day
+        ),
     )
 
     accessor = optree.tree_accessors(tree, none_is_leaf=True)[0]  # ty: ignore[invalid-argument-type]

--- a/tests/interface_dag_elements/test_processed_data.py
+++ b/tests/interface_dag_elements/test_processed_data.py
@@ -4,6 +4,7 @@ import dags.tree as dt
 import numpy
 import pandas as pd
 import pytest
+from mettsim.middle_earth import UNIT_SYSTEM
 
 from ttsim.interface_dag_elements.input_data import sort_indices
 from ttsim.interface_dag_elements.processed_data import (
@@ -13,8 +14,7 @@ from ttsim.interface_dag_elements.processed_data import (
 from ttsim.interface_dag_elements.specialized_environment import (
     _add_derived_functions,
 )
-from ttsim.tt import Unit, policy_input
-from ttsim.tt.units import UNIT_REGISTRY
+from ttsim.tt import TTSIMUnit, policy_input
 
 
 def _spec_env(policy_environment, input_data__flat, grouping_levels=()):
@@ -53,6 +53,7 @@ def test_processed_data(input_data__flat, xnp):
                 specialized_environment__without_tree_logic_and_with_derived_functions={},
                 data_currency="CASTAR",
                 computation_currency="CASTAR",
+                unit_system=UNIT_SYSTEM,
             )
         ),
         pd.DataFrame(expected),
@@ -83,6 +84,7 @@ def test_processed_data_foreign_key_out_of_bounds(xnp):
                 specialized_environment__without_tree_logic_and_with_derived_functions={},
                 data_currency="CASTAR",
                 computation_currency="CASTAR",
+                unit_system=UNIT_SYSTEM,
             )
         ),
         pd.DataFrame(expected),
@@ -113,6 +115,7 @@ def test_processed_data_foreign_key_inside_bounds(xnp):
                 specialized_environment__without_tree_logic_and_with_derived_functions={},
                 data_currency="CASTAR",
                 computation_currency="CASTAR",
+                unit_system=UNIT_SYSTEM,
             )
         ),
         pd.DataFrame(expected),
@@ -139,6 +142,7 @@ def test_processed_data_single_column(xnp):
                 specialized_environment__without_tree_logic_and_with_derived_functions={},
                 data_currency="CASTAR",
                 computation_currency="CASTAR",
+                unit_system=UNIT_SYSTEM,
             )
         ),
         pd.DataFrame(expected),
@@ -206,6 +210,7 @@ def test_processed_data_coerces_uint_columns_to_signed(xnp):
         specialized_environment__without_tree_logic_and_with_derived_functions={},
         data_currency="CASTAR",
         computation_currency="CASTAR",
+        unit_system=UNIT_SYSTEM,
     )
     assert result["wage"].dtype.kind == "i"
     # Subtraction stays signed instead of underflowing into uint wraparound.
@@ -236,6 +241,7 @@ def test_processed_data_single_row(xnp):
                 specialized_environment__without_tree_logic_and_with_derived_functions={},
                 data_currency="CASTAR",
                 computation_currency="CASTAR",
+                unit_system=UNIT_SYSTEM,
             )
         ),
         pd.DataFrame(expected),
@@ -249,11 +255,11 @@ def test_processed_data_converts_pint_tagged_currency_input(xnp):
     handed in as silver pennies rides along castar data and is rescaled at the
     boundary (4 silver pennies = 1 castar).
     """
-    from mettsim import middle_earth  # noqa: F401, PLC0415 (registers the currencies)
-
     input_data__flat = {
         ("p_id",): numpy.array([0, 1]),
-        ("wealth",): UNIT_REGISTRY.Quantity(numpy.array([4.0, 8.0]), "SILVER_PENNY"),
+        ("wealth",): UNIT_SYSTEM.registry.Quantity(
+            numpy.array([4.0, 8.0]), "SILVER_PENNY"
+        ),
     }
     out = processed_data(
         input_data__flat=input_data__flat,
@@ -264,8 +270,9 @@ def test_processed_data_converts_pint_tagged_currency_input(xnp):
         specialized_environment__without_tree_logic_and_with_derived_functions={},
         data_currency="CASTAR",
         computation_currency="CASTAR",
+        unit_system=UNIT_SYSTEM,
     )
-    assert not isinstance(out["wealth"], UNIT_REGISTRY.Quantity)
+    assert not isinstance(out["wealth"], UNIT_SYSTEM.registry.Quantity)
     assert list(numpy.asarray(out["wealth"])) == pytest.approx([1.0, 2.0])
 
 
@@ -276,13 +283,12 @@ def test_processed_data_converts_untagged_currency_input_by_declared_unit(xnp):
     carries a currency component is converted to the computation currency.
     Non-currency columns are untouched.
     """
-    from mettsim import middle_earth  # noqa: F401, PLC0415 (registers the currencies)
 
-    @policy_input(unit=Unit.CURRENCY)
+    @policy_input(unit=TTSIMUnit.CURRENCY)
     def wealth() -> float:
         pass
 
-    @policy_input(unit=Unit.YEARS)
+    @policy_input(unit=TTSIMUnit.YEARS)
     def age() -> int:
         pass
 
@@ -306,6 +312,7 @@ def test_processed_data_converts_untagged_currency_input_by_declared_unit(xnp):
         ),
         data_currency="SILVER_PENNY",
         computation_currency="CASTAR",
+        unit_system=UNIT_SYSTEM,
     )
     assert list(numpy.asarray(out["wealth"])) == pytest.approx([1.0, 2.0])
     assert list(numpy.asarray(out["age"])) == [30, 40]
@@ -316,13 +323,12 @@ def test_derived_input_ignores_siblings_a_derivation_cannot_produce(xnp):
     flow `income_m` shares the base name but no derivation produces `income_hh`
     from it (a time suffix is only ever rebased, never dropped), so the column
     must not convert."""
-    from mettsim import middle_earth  # noqa: F401, PLC0415 (registers the currencies)
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def income_m() -> float:
         pass
 
-    @policy_input(unit=Unit.YEARS)
+    @policy_input(unit=TTSIMUnit.YEARS)
     def income() -> int:
         pass
 
@@ -345,6 +351,7 @@ def test_derived_input_ignores_siblings_a_derivation_cannot_produce(xnp):
         ),
         data_currency="SILVER_PENNY",
         computation_currency="CASTAR",
+        unit_system=UNIT_SYSTEM,
     )
     assert list(numpy.asarray(out["income_hh"])) == pytest.approx([4.0, 4.0])
 
@@ -356,9 +363,8 @@ def test_processed_data_converts_derived_input_via_its_stub(xnp):
     declared ``wage_m`` carries ``CURRENCY_PER_MONTH_PER_HH`` (aggregation
     never adds or removes the currency component), so the column converts.
     """
-    from mettsim import middle_earth  # noqa: F401, PLC0415 (registers the currencies)
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def wage_m() -> float:
         pass
 
@@ -381,6 +387,7 @@ def test_processed_data_converts_derived_input_via_its_stub(xnp):
         ),
         data_currency="SILVER_PENNY",
         computation_currency="CASTAR",
+        unit_system=UNIT_SYSTEM,
     )
     assert list(numpy.asarray(out["wage_m_hh"])) == pytest.approx([1.0, 1.0])
 
@@ -391,9 +398,8 @@ def test_processed_data_converts_time_variant_input_via_its_stub(xnp):
     ``wage_y`` has no declaration of its own; the stub minted from the
     declared ``wage_m`` carries ``CURRENCY_PER_YEAR``, so the column converts.
     """
-    from mettsim import middle_earth  # noqa: F401, PLC0415 (registers the currencies)
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def wage_m() -> float:
         pass
 
@@ -416,5 +422,6 @@ def test_processed_data_converts_time_variant_input_via_its_stub(xnp):
         ),
         data_currency="SILVER_PENNY",
         computation_currency="CASTAR",
+        unit_system=UNIT_SYSTEM,
     )
     assert list(numpy.asarray(out["wage_y"])) == pytest.approx([1.0, 1.0])

--- a/tests/interface_dag_elements/test_results.py
+++ b/tests/interface_dag_elements/test_results.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy
 import pytest
+from mettsim.middle_earth import UNIT_SYSTEM
 
 from ttsim.interface_dag_elements.results import tree
 
@@ -148,6 +149,7 @@ def test_restore_original_row_order(
         specialized_environment__without_tree_logic_and_with_derived_functions={},
         data_currency="CASTAR",
         computation_currency="CASTAR",
+        unit_system=UNIT_SYSTEM,
     )
 
     # Check the structure and values recursively

--- a/tests/interface_dag_elements/test_specialized_environment.py
+++ b/tests/interface_dag_elements/test_specialized_environment.py
@@ -8,6 +8,7 @@ import dags.tree as dt
 import numpy
 import pandas as pd
 import pytest
+from mettsim import middle_earth
 
 from ttsim import main, merge_trees
 from ttsim.interface_dag_elements.specialized_environment import (
@@ -23,7 +24,7 @@ from ttsim.tt import (
     PiecewisePolynomialParamValue,
     RawParam,
     ScalarParam,
-    Unit,
+    TTSIMUnit,
     agg_by_group_function,
     agg_by_p_id_function,
     param_function,
@@ -36,62 +37,62 @@ if TYPE_CHECKING:
     from ttsim.typing import IntColumn, RawParamValue
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def p_id() -> int:
     pass
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def p_id_someone_else() -> int:
     pass
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def fam_id() -> int:
     pass
 
 
-@policy_input(unit=Unit.CURRENCY.PER_MONTH)
+@policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
 def betrag_m() -> float:
     pass
 
 
-@policy_input(unit=Unit.CURRENCY.PER_MONTH)
+@policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
 def income_m() -> float:
     pass
 
 
-@policy_function(vectorization_strategy="vectorize", unit=Unit.CURRENCY.PER_MONTH)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.CURRENCY.PER_MONTH)
 def benefit_m(income_m: float) -> float:
     return income_m * 0.5
 
 
-@policy_function(vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS)
 def identity(x: int) -> int:
     return x
 
 
-@policy_function(vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS)
 def identity_plus_one(identity: int) -> int:
     return identity + 1
 
 
-@policy_function(vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS)
 def some_func(p_id: int) -> int:
     return p_id
 
 
-@policy_function(vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS)
 def another_func(some_func: int) -> int:
     return some_func
 
 
-@param_function(unit=Unit.DIMENSIONLESS)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS)
 def some_scalar_params_func(some_int_param: int) -> int:
     return some_int_param
 
 
-@policy_function(vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS)
 def some_policy_func_taking_scalar_params_func(
     some_scalar_params_func: int,
 ) -> int:
@@ -104,7 +105,7 @@ class ConvertedParam:
     some_bool_param: bool
 
 
-@param_function(unit=Unit.DIMENSIONLESS)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS)
 def some_converting_params_func(raw_param_spec: RawParamValue) -> ConvertedParam:
     return ConvertedParam(
         some_float_param=raw_param_spec["some_float_param"],
@@ -112,7 +113,7 @@ def some_converting_params_func(raw_param_spec: RawParamValue) -> ConvertedParam
     )
 
 
-@param_function(unit=Unit.DIMENSIONLESS)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS)
 def some_param_function_taking_scalar(
     some_int_scalar: int,
     some_float_scalar: float,
@@ -121,7 +122,7 @@ def some_param_function_taking_scalar(
     return some_int_scalar + some_float_scalar + int(some_bool_scalar)
 
 
-@policy_function(vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS)
 def some_policy_function_taking_int_param(some_int_param: int) -> float:
     return some_int_param
 
@@ -135,7 +136,7 @@ SOME_RAW_PARAM = RawParam(
     end_date=datetime.date(2025, 12, 31),
     name={"de": "Ein raw param spec", "en": "Some raw param spec"},
     description={"de": "Ein raw param spec", "en": "Some raw param spec"},
-    unit=Unit.DIMENSIONLESS,
+    unit=TTSIMUnit.DIMENSIONLESS,
     note=None,
     reference=None,
 )
@@ -147,7 +148,7 @@ SOME_INT_PARAM = ScalarParam(
     end_date=datetime.date(2025, 12, 31),
     name={"de": "Ein int param", "en": "Some int param"},
     description={"de": "Ein int param", "en": "Some int param"},
-    unit=Unit.DIMENSIONLESS,
+    unit=TTSIMUnit.DIMENSIONLESS,
     note=None,
     reference=None,
 )
@@ -159,7 +160,7 @@ SOME_DICT_PARAM = DictParam(
     end_date=datetime.date(2025, 12, 31),
     name={"de": "Ein dict param", "en": "Some dict param"},
     description={"de": "Ein dict param", "en": "Some dict param"},
-    unit=Unit.DIMENSIONLESS,
+    unit=TTSIMUnit.DIMENSIONLESS,
     note=None,
     reference=None,
 )
@@ -183,8 +184,8 @@ def some_piecewise_polynomial_param(xnp):
             "de": "Ein piecewise polynomial param",
             "en": "Some piecewise polynomial param",
         },
-        input_unit=Unit.DIMENSIONLESS,
-        output_unit=Unit.DIMENSIONLESS,
+        input_unit=TTSIMUnit.DIMENSIONLESS,
+        output_unit=TTSIMUnit.DIMENSIONLESS,
         note=None,
         reference=None,
     )
@@ -209,47 +210,49 @@ def minimal_input_data_shared_fam():
     }
 
 
-@agg_by_group_function(agg_type=AggType.SUM, unit=Unit.DIMENSIONLESS)
+@agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.DIMENSIONLESS)
 def foo_fam(foo: int, fam_id: int) -> int:
     pass
 
 
 # Create a function which is used by some tests below
-@policy_function(vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS)
 def func_before_partial(arg_1: int, some_param: int) -> int:
     return arg_1 + some_param
 
 
 @pytest.fixture
 @policy_function(
-    leaf_name="foo", vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS
+    leaf_name="foo", vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS
 )
 def function_with_bool_return(x: bool) -> bool:
     return x
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def x() -> int:
     pass
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def x_f() -> float:
     pass
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def x_b() -> bool:
     pass
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def kin_id() -> int:
     pass
 
 
 @agg_by_group_function(
-    leaf_name="y_kin", agg_type=AggType.SUM, unit=Unit.DIMENSIONLESS.PER_LEVEL("kin")
+    leaf_name="y_kin",
+    agg_type=AggType.SUM,
+    unit=TTSIMUnit.DIMENSIONLESS.PER_LEVEL("kin"),
 )
 def y_kin(kin_id: int, x: int) -> int:
     pass
@@ -258,7 +261,9 @@ def y_kin(kin_id: int, x: int) -> int:
 # A SUM is the group's whatever the source's base (GEP 10) — even a dimensionless
 # share acquires the target level, so the declared unit spells it.
 @agg_by_group_function(
-    leaf_name="y_kin", agg_type=AggType.SUM, unit=Unit.DIMENSIONLESS.PER_LEVEL("kin")
+    leaf_name="y_kin",
+    agg_type=AggType.SUM,
+    unit=TTSIMUnit.DIMENSIONLESS.PER_LEVEL("kin"),
 )
 def y_kin_namespaced_input(kin_id: int, inputs__x: int) -> int:
     pass
@@ -266,7 +271,7 @@ def y_kin_namespaced_input(kin_id: int, inputs__x: int) -> int:
 
 @pytest.fixture
 @policy_function(
-    leaf_name="bar", vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS
+    leaf_name="bar", vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS
 )
 def function_with_int_return(x: int) -> int:
     return x
@@ -274,7 +279,7 @@ def function_with_int_return(x: int) -> int:
 
 @pytest.fixture
 @policy_function(
-    leaf_name="baz", vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS
+    leaf_name="baz", vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS
 )
 def function_with_float_return(x: int) -> float:
     return x
@@ -310,7 +315,7 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "p_id": p_id,
                 "n1": {
                     "f": policy_function(
-                        leaf_name="f", unit=Unit.DIMENSIONLESS, verify_units=False
+                        leaf_name="f", unit=TTSIMUnit.DIMENSIONLESS, verify_units=False
                     )(return_n1__x_kin),
                     "x": x,
                 },
@@ -329,7 +334,7 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "p_id": p_id,
                 "n1": {
                     "f": policy_function(
-                        leaf_name="f", unit=Unit.DIMENSIONLESS, verify_units=False
+                        leaf_name="f", unit=TTSIMUnit.DIMENSIONLESS, verify_units=False
                     )(return_x_kin),
                     "x": x,
                 },
@@ -347,7 +352,7 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
-                    "f": policy_function(leaf_name="f", unit=Unit.DIMENSIONLESS)(
+                    "f": policy_function(leaf_name="f", unit=TTSIMUnit.DIMENSIONLESS)(
                         some_x
                     ),
                     "x": x,
@@ -366,7 +371,7 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
-                    "f": policy_function(leaf_name="f", unit=Unit.DIMENSIONLESS)(
+                    "f": policy_function(leaf_name="f", unit=TTSIMUnit.DIMENSIONLESS)(
                         some_x
                     ),
                     "x": x,
@@ -387,7 +392,7 @@ def return_n1__x_kin(n1__x_kin: int) -> int:
                 "p_id": p_id,
                 "n1": {
                     "f": policy_function(
-                        leaf_name="f", unit=Unit.DIMENSIONLESS, verify_units=False
+                        leaf_name="f", unit=TTSIMUnit.DIMENSIONLESS, verify_units=False
                     )(return_y_kin),
                     "y_kin": y_kin_namespaced_input,
                 },
@@ -417,6 +422,7 @@ def test_create_agg_by_group_functions(
         tt_targets=TTTargets.tree(tt_targets__tree),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
 
@@ -435,6 +441,7 @@ def test_output_is_tree(minimal_input_data, backend, xnp):
         tt_targets=TTTargets.tree({"module": {"some_func": None}}),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     assert isinstance(out, dict)
@@ -469,6 +476,7 @@ def test_params_target_is_allowed(minimal_input_data):
         tt_targets=TTTargets.tree({"some_param": None, "module": {"some_func": None}}),
         rounding=False,
         backend="numpy",
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     assert isinstance(out, dict)
@@ -484,13 +492,13 @@ def test_function_without_data_dependency_is_not_mistaken_for_data(
     @policy_function(
         leaf_name="a",
         vectorization_strategy="not_required",
-        unit=Unit.DIMENSIONLESS,
+        unit=TTSIMUnit.DIMENSIONLESS,
         verify_units=False,
     )
     def a() -> IntColumn:
         return xnp.array(minimal_input_data["p_id"])
 
-    @policy_function(leaf_name="b", unit=Unit.DIMENSIONLESS)
+    @policy_function(leaf_name="b", unit=TTSIMUnit.DIMENSIONLESS)
     def b(a: int) -> int:
         return a
 
@@ -507,6 +515,7 @@ def test_function_without_data_dependency_is_not_mistaken_for_data(
         tt_targets=TTTargets.tree({"b": None}),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     numpy.testing.assert_array_almost_equal(
         results__tree["b"],
@@ -579,6 +588,7 @@ def test_user_provided_aggregate_by_group_specs(backend):
         tt_targets=TTTargets.tree({"module_name": {"betrag_m_fam": None}}),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     pd.testing.assert_series_equal(
@@ -598,12 +608,14 @@ def test_user_provided_aggregation(backend):
     # Double up, then take max fam_id
     expected = pd.Series([400, 400, 200], index=pd.Index(data["p_id"], name="p_id"))
 
-    @policy_function(vectorization_strategy="vectorize", unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(
+        vectorization_strategy="vectorize", unit=TTSIMUnit.CURRENCY.PER_MONTH
+    )
     def betrag_double_m(betrag_m: float) -> float:
         return 2 * betrag_m
 
     @agg_by_group_function(
-        agg_type=AggType.MAX, unit=Unit.CURRENCY.PER_MONTH.PER_LEVEL("fam")
+        agg_type=AggType.MAX, unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_LEVEL("fam")
     )
     def betrag_double_m_fam(betrag_double_m: float, fam_id: int) -> float:
         pass
@@ -626,6 +638,7 @@ def test_user_provided_aggregation(backend):
         tt_targets=TTTargets.tree({"module_name": {"betrag_double_m_fam": None}}),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     pd.testing.assert_series_equal(
@@ -651,12 +664,14 @@ def test_user_provided_aggregation_with_time_conversion(backend):
         index=pd.Index(data["p_id"], name="p_id"),
     )
 
-    @policy_function(vectorization_strategy="vectorize", unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(
+        vectorization_strategy="vectorize", unit=TTSIMUnit.CURRENCY.PER_MONTH
+    )
     def betrag_double_m(betrag_m: float) -> float:
         return 2 * betrag_m
 
     @agg_by_group_function(
-        agg_type=AggType.MAX, unit=Unit.CURRENCY.PER_MONTH.PER_LEVEL("fam")
+        agg_type=AggType.MAX, unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_LEVEL("fam")
     )
     def max_betrag_double_m_fam(betrag_double_m: float, fam_id: int) -> float:
         pass
@@ -679,6 +694,7 @@ def test_user_provided_aggregation_with_time_conversion(backend):
         tt_targets=TTTargets.tree({"module_name": {"max_betrag_double_y_fam": None}}),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     pd.testing.assert_series_equal(
@@ -689,7 +705,7 @@ def test_user_provided_aggregation_with_time_conversion(backend):
     )
 
 
-@agg_by_p_id_function(agg_type=AggType.SUM, unit=Unit.DIMENSIONLESS)
+@agg_by_p_id_function(agg_type=AggType.SUM, unit=TTSIMUnit.DIMENSIONLESS)
 def sum_source_by_p_id_someone_else(
     source: int,
     p_id: int,
@@ -700,7 +716,7 @@ def sum_source_by_p_id_someone_else(
     pass
 
 
-@agg_by_p_id_function(agg_type=AggType.SUM, unit=Unit.CURRENCY.PER_MONTH)
+@agg_by_p_id_function(agg_type=AggType.SUM, unit=TTSIMUnit.CURRENCY.PER_MONTH)
 def sum_source_m_by_p_id_someone_else(
     source_m: int,
     p_id: int,
@@ -721,7 +737,7 @@ def sum_source_m_by_p_id_someone_else(
                 },
             },
             "source",
-            Unit.DIMENSIONLESS,
+            TTSIMUnit.DIMENSIONLESS,
             {"module": {"sum_source_by_p_id_someone_else": None}},
             pd.Series([200, 100, 0], index=pd.Index([0, 1, 2], name="p_id")),
         ),
@@ -733,7 +749,7 @@ def sum_source_m_by_p_id_someone_else(
             },
             "source_m",
             # The _m suffix denotes a flow, so a flow token is required.
-            Unit.CURRENCY.PER_MONTH,
+            TTSIMUnit.CURRENCY.PER_MONTH,
             {"module": {"sum_source_m_by_p_id_someone_else": None}},
             pd.Series([200, 100, 0], index=pd.Index([0, 1, 2], name="p_id")),
         ),
@@ -776,6 +792,7 @@ def test_user_provided_aggregate_by_p_id_specs(
         tt_targets=TTTargets.tree(target_tree),
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     pd.testing.assert_series_equal(
@@ -899,6 +916,7 @@ def test_can_override_ttsim_objects_with_data(
         include_fail_nodes=False,
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     flat_actual = dt.flatten_to_tree_paths(actual)
@@ -927,6 +945,7 @@ def test_scalars_in_input_data_become_part_of_specialized_environment(xnp, backe
         evaluation_date_str="2024-01-01",
         backend=backend,
         include_warn_nodes=False,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     assert root_nodes == set()
 
@@ -956,7 +975,15 @@ def test_derived_time_converted_scalar_drives_derived_consumer(xnp, backend):
         "include_warn_nodes": False,
         "include_fail_nodes": False,
     }
-    root_nodes = main(main_target=MainTarget.labels.root_nodes, **common_kwargs)  # ty: ignore[invalid-argument-type]
+    root_nodes = main(
+        main_target=MainTarget.labels.root_nodes,
+        **common_kwargs,  # ty: ignore[invalid-argument-type]
+        unit_system=middle_earth.UNIT_SYSTEM,
+    )
     assert root_nodes == set()
-    result = main(main_target=MainTarget.results.tree, **common_kwargs)  # ty: ignore[invalid-argument-type]
+    result = main(
+        main_target=MainTarget.results.tree,
+        **common_kwargs,  # ty: ignore[invalid-argument-type]
+        unit_system=middle_earth.UNIT_SYSTEM,
+    )
     numpy.testing.assert_allclose(result["benefit_m"], numpy.full(3, 500.0))

--- a/tests/interface_dag_elements/test_tt_targets.py
+++ b/tests/interface_dag_elements/test_tt_targets.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import ttsim.interface_dag_elements
 from ttsim.interface_dag_elements.interface_node_objects import InterfaceFunction
 from ttsim.interface_dag_elements.orig_policy_objects import load_module
-from ttsim.tt import Unit, param_function, policy_function, policy_input
+from ttsim.tt import TTSIMUnit, param_function, policy_function, policy_input
 
 # The package claw rewrites normally-imported `interface_dag_elements` modules,
 # binding each callable `InterfaceFunction` instance into a bound method. Re-load
@@ -31,7 +31,7 @@ def test_tree_is_interface_function():
 def test_tree_extracts_policy_functions_from_environment():
     """tree() extracts ColumnFunction instances (e.g., PolicyFunction)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def my_col(x: int) -> int:
         return x
 
@@ -47,11 +47,11 @@ def test_tree_extracts_policy_functions_from_environment():
 def test_tree_excludes_policy_inputs():
     """tree() only includes ColumnFunction instances, not PolicyInput."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def my_col(x: int) -> int:
         return x
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def my_input() -> int:
         pass
 
@@ -69,11 +69,11 @@ def test_tree_excludes_policy_inputs():
 
 
 def test_tree_excludes_param_functions():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def my_col(x: int) -> int:
         return x
 
-    @param_function(unit=Unit.DIMENSIONLESS)
+    @param_function(unit=TTSIMUnit.DIMENSIONLESS)
     def my_param() -> int:
         return 42
 
@@ -89,7 +89,7 @@ def test_tree_excludes_param_functions():
 
 
 def test_tree_handles_nested_policy_environment():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def nested_col(x: int) -> int:
         return x
 
@@ -106,7 +106,7 @@ def test_tree_handles_nested_policy_environment():
 
 
 def test_tree_returns_none_as_leaf_values():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def my_col(x: int) -> int:
         return x
 
@@ -122,7 +122,7 @@ def test_tree_empty_environment():
 
 
 def test_tree_environment_with_only_param_functions():
-    @param_function(unit=Unit.DIMENSIONLESS)
+    @param_function(unit=TTSIMUnit.DIMENSIONLESS)
     def my_param() -> int:
         return 42
 
@@ -133,7 +133,7 @@ def test_tree_environment_with_only_param_functions():
 
 
 def test_tree_environment_with_only_policy_inputs():
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def my_input() -> int:
         pass
 
@@ -234,19 +234,19 @@ def test_qname_handles_mixed_flat_and_nested():
 # tree + qname
 # =============================================================================
 def test_tree_then_qname_extracts_column_function_qnames():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def col_a(x: int) -> int:
         return x
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def col_b(x: int) -> int:
         return x
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def input_col() -> int:
         pass
 
-    @param_function(unit=Unit.DIMENSIONLESS)
+    @param_function(unit=TTSIMUnit.DIMENSIONLESS)
     def param_func() -> int:
         return 42
 
@@ -272,7 +272,7 @@ def test_tree_then_qname_extracts_column_function_qnames():
 
 
 def test_tree_then_qname_with_nested_policy_environment():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def nested_col(x: int) -> int:
         return x
 

--- a/tests/interface_dag_elements/test_unit_checks.py
+++ b/tests/interface_dag_elements/test_unit_checks.py
@@ -6,7 +6,7 @@ import datetime
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Any
 
-import mettsim.middle_earth  # noqa: F401
+import mettsim.middle_earth
 import numpy
 import pint
 import pytest
@@ -32,7 +32,7 @@ from ttsim.tt import (
     AggType,
     FKType,
     RoundingSpec,
-    Unit,
+    TTSIMUnit,
     agg_by_group_function,
     cast_unit,
     group_creation_function,
@@ -64,6 +64,9 @@ from ttsim.unit_converters import m_to_y, per_m_to_per_y, y_to_m
 if TYPE_CHECKING:
     from types import ModuleType
 
+UNIT_SYSTEM = mettsim.middle_earth.UNIT_SYSTEM
+REGISTRY = UNIT_SYSTEM.registry
+
 GROUPING_LEVELS = ("fam", "kin")
 
 _START = datetime.date(2020, 1, 1)
@@ -83,22 +86,22 @@ CASTAR = coerce_to_composite_unit(value="CASTAR", where="test setup")
 # ----------------------------------------------------------------------------
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def p_id() -> int:
     """Identifier; a dimensionless quantity (GEP 10)."""
 
 
-@policy_input(foreign_key_type=FKType.MAY_POINT_TO_SELF, unit=Unit.DIMENSIONLESS)
+@policy_input(foreign_key_type=FKType.MAY_POINT_TO_SELF, unit=TTSIMUnit.DIMENSIONLESS)
 def p_id_recipient() -> int:
     """Person pointer; a dimensionless quantity (GEP 10)."""
 
 
-@policy_input(unit=Unit.CURRENCY)
+@policy_input(unit=TTSIMUnit.CURRENCY)
 def wealth() -> float:
     """A stock of currency."""
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def is_exempt() -> bool:
     """Boolean input; a dimensionless quantity (GEP 10)."""
 
@@ -108,7 +111,7 @@ def unannotated_income_y() -> float:
     """Carries the UNSET sentinel; the missing-units check must report it."""
 
 
-@group_creation_function(unit=Unit.DIMENSIONLESS)
+@group_creation_function(unit=TTSIMUnit.DIMENSIONLESS)
 def fam_id(p_id: IntColumn, xnp: object) -> IntColumn:  # noqa: ARG001
     """Group creation (a dimensionless id)."""
     return p_id
@@ -131,7 +134,7 @@ def make_flow_rate() -> ScalarParam:
     # `tax_rate_y` name (the spelled period agrees with the suffix, GEP 10).
     return ScalarParam(
         value=0.01,
-        unit=Unit.DIMENSIONLESS.PER_YEAR,
+        unit=TTSIMUnit.DIMENSIONLESS.PER_YEAR,
         start_date=_START,
         end_date=_END,
     )
@@ -142,20 +145,20 @@ def make_dimensionless_rate() -> ScalarParam:
     # no period, so `wealth * rate` is a stock where a flow node expects a flow.
     return ScalarParam(
         value=0.01,
-        unit=Unit.DIMENSIONLESS,
+        unit=TTSIMUnit.DIMENSIONLESS,
         start_date=_START,
         end_date=_END,
     )
 
 
-@policy_input(unit=Unit.CURRENCY)
+@policy_input(unit=TTSIMUnit.CURRENCY)
 def wealth_threshold() -> float:
     """A wealth threshold; a stock of currency. Comparing a quantity against a
     bare inline literal is rejected (GEP 10), so the bound is a named producer
     rather than a magic number."""
 
 
-@policy_function(unit=Unit.CURRENCY.PER_YEAR)
+@policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
 def amount_y(wealth: float, tax_rate_y: float, is_exempt: bool) -> float:
     """The wealth-tax pattern: stock times a per-year rate, guarded by an
     exemption. ``tax_rate_y`` is a share per year, so the product is a flow."""
@@ -164,7 +167,7 @@ def amount_y(wealth: float, tax_rate_y: float, is_exempt: bool) -> float:
     return wealth * tax_rate_y
 
 
-@policy_function(unit=Unit.CURRENCY.PER_YEAR)
+@policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
 def amount_buggy_y(wealth: float, tax_rate: float, is_exempt: bool) -> float:
     """The bug: ``tax_rate`` is a plain dimensionless share, so ``wealth *
     tax_rate`` is a stock, not the declared yearly flow."""
@@ -173,37 +176,37 @@ def amount_buggy_y(wealth: float, tax_rate: float, is_exempt: bool) -> float:
     return wealth * tax_rate
 
 
-@policy_input(unit=Unit.CURRENCY.PER_MONTH)
+@policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
 def income_m() -> float:
     """A monthly flow of currency (CURRENCY / month)."""
 
 
-@policy_input(unit=Unit.CURRENCY.PER_MONTH)
+@policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
 def other_income_m() -> float:
     """A second monthly flow of currency (CURRENCY / month)."""
 
 
-@policy_input(unit=Unit.CURRENCY.PER_YEAR)
+@policy_input(unit=TTSIMUnit.CURRENCY.PER_YEAR)
 def bonus_y() -> float:
     """A yearly flow of currency (CURRENCY / year)."""
 
 
-@policy_input(unit=Unit.CALENDAR_YEAR)
+@policy_input(unit=TTSIMUnit.CALENDAR_YEAR)
 def geburtsjahr() -> int:
     """A birth year: a point on the calendar, not a duration (GEP 10)."""
 
 
-@policy_input(unit=Unit.YEARS)
+@policy_input(unit=TTSIMUnit.YEARS)
 def statutory_age() -> int:
     """A duration in years (an age threshold)."""
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def geburtsmonat() -> int:
     """A month-of-year (1-12): a cyclic ordinal, not a calendar point (GEP 10)."""
 
 
-@policy_input(unit=Unit.MONTHS)
+@policy_input(unit=TTSIMUnit.MONTHS)
 def months_paid() -> int:
     """A duration in months."""
 
@@ -271,7 +274,7 @@ def test_missing_check_reports_unannotated_identifier_and_boolean():
 
 
 def make_rounded_amount_y(rounding_spec: RoundingSpec):
-    @policy_function(rounding_spec=rounding_spec, unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(rounding_spec=rounding_spec, unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def rounded_amount_y(bonus_y: float) -> float:
         return bonus_y
 
@@ -307,7 +310,7 @@ def test_missing_check_passes_for_currency_rounding_spec_with_unit():
 
 def test_missing_check_passes_for_non_currency_rounding_spec_without_unit():
     @policy_function(
-        rounding_spec=RoundingSpec(base=1, direction="down"), unit=Unit.YEARS
+        rounding_spec=RoundingSpec(base=1, direction="down"), unit=TTSIMUnit.YEARS
     )
     def rounded_age(statutory_age: int) -> int:
         return statutory_age
@@ -327,6 +330,7 @@ def test_inconsistency_check_passes_for_matching_rounding_spec_unit():
             "bonus_y": bonus_y,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -340,6 +344,7 @@ def test_inconsistency_check_reports_rounding_spec_composite_mismatch():
                 "bonus_y": bonus_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -348,11 +353,14 @@ def test_inconsistency_check_reports_agnostic_rounding_spec_unit():
         fail_if_environment_units_are_inconsistent(
             env={
                 "rounded_amount_y": make_rounded_amount_y(
-                    RoundingSpec(base=1, direction="down", unit=Unit.CURRENCY.PER_YEAR)
+                    RoundingSpec(
+                        base=1, direction="down", unit=TTSIMUnit.CURRENCY.PER_YEAR
+                    )
                 ),
                 "bonus_y": bonus_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -361,18 +369,19 @@ def test_inconsistency_check_reports_non_currency_rounding_spec_unit():
         fail_if_environment_units_are_inconsistent(
             env={
                 "rounded_amount_y": make_rounded_amount_y(
-                    RoundingSpec(base=1, direction="down", unit=Unit.YEARS)
+                    RoundingSpec(base=1, direction="down", unit=TTSIMUnit.YEARS)
                 ),
                 "bonus_y": bonus_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_inconsistency_check_reports_rounding_spec_unit_on_non_currency_function():
     @policy_function(
         rounding_spec=RoundingSpec(base=1, direction="down", unit=CASTAR_PER_YEAR),
-        unit=Unit.YEARS,
+        unit=TTSIMUnit.YEARS,
     )
     def rounded_age(statutory_age: int) -> int:
         return statutory_age
@@ -381,6 +390,7 @@ def test_inconsistency_check_reports_rounding_spec_unit_on_non_currency_function
         fail_if_environment_units_are_inconsistent(
             env={"rounded_age": rounded_age, "statutory_age": statutory_age},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -397,21 +407,25 @@ def test_resolution_combines_token_and_name_suffix():
             "amount_y": amount_y,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     # `wealth` is a person-level currency stock, so it carries the individual
     # level as a denominator (GEP 10); `tax_rate_y` is dimensionless and stays
     # level-less.
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="wealth"),
-        right=parse_unit("CURRENCY / grouping_level_person"),
+        right=parse_unit("CURRENCY / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="tax_rate_y"),
-        right=parse_unit("1 / year"),
+        right=parse_unit("1 / year", registry=REGISTRY),
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="amount_y"),
-        right=parse_unit("CURRENCY / year / grouping_level_person"),
+        right=parse_unit("CURRENCY / year / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -424,8 +438,11 @@ def test_resolved_units_node_wraps_the_resolver():
     via_node = resolved_units(
         specialized_environment__without_tree_logic_and_with_derived_functions=env,
         labels__grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
-    direct = resolve_environment_units(env=env, grouping_levels=GROUPING_LEVELS)
+    direct = resolve_environment_units(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )
     assert via_node == direct
 
 
@@ -435,14 +452,18 @@ def test_resolution_includes_framework_date_nodes():
     env = {
         "policy_year": ScalarParam(value=2020, start_date=_START, end_date=_END),
     }
-    resolved = resolve_environment_units(env=env, grouping_levels=GROUPING_LEVELS)
+    resolved = resolve_environment_units(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="policy_year"),
-        right=parse_unit("calendar_year"),
+        right=parse_unit("calendar_year", registry=REGISTRY),
+        registry=REGISTRY,
     )
     assert not units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="policy_year"),
-        right=parse_unit("year"),
+        right=parse_unit("year", registry=REGISTRY),
+        registry=REGISTRY,
     )
     assert "policy_year" in FRAMEWORK_DATE_NODE_UNITS
 
@@ -455,14 +476,21 @@ def test_dict_param_with_per_leaf_units_resolves_to_unit_tree():
         end_date=_END,
     )
     resolved = resolve_environment_units(
-        env={"schedule": schedule}, grouping_levels=GROUPING_LEVELS
+        env={"schedule": schedule},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     unit_tree = _unit_tree(resolved=resolved, qname="schedule")
     assert units_are_equivalent(
         left=unit_tree["child_amount_y"],
-        right=parse_unit("CURRENCY / year / grouping_level_person"),
+        right=parse_unit("CURRENCY / year / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=unit_tree["max_age"], right=parse_unit("year"))
+    assert units_are_equivalent(
+        left=unit_tree["max_age"],
+        right=parse_unit("year", registry=REGISTRY),
+        registry=REGISTRY,
+    )
 
 
 def test_dict_param_leaf_key_suffix_must_agree_with_spelled_period():
@@ -476,7 +504,9 @@ def test_dict_param_leaf_key_suffix_must_agree_with_spelled_period():
     )
     with pytest.raises(UnitDefinitionError, match="must agree"):
         resolve_environment_units(
-            env={"schedule": schedule}, grouping_levels=GROUPING_LEVELS
+            env={"schedule": schedule},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -490,11 +520,14 @@ def test_dict_param_integer_keyed_flow_leaf_spells_its_period():
         end_date=_END,
     )
     resolved = resolve_environment_units(
-        env={"amount_by_rank": amount_by_rank}, grouping_levels=GROUPING_LEVELS
+        env={"amount_by_rank": amount_by_rank},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     assert units_are_equivalent(
         left=_unit_tree(resolved=resolved, qname="amount_by_rank")[1],
-        right=parse_unit("CURRENCY / month / grouping_level_person"),
+        right=parse_unit("CURRENCY / month / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -507,7 +540,9 @@ def test_dict_param_stock_token_on_suffixed_leaf_key_fails():
     )
     with pytest.raises(UnitDefinitionError, match="must agree"):
         resolve_environment_units(
-            env={"schedule": schedule}, grouping_levels=GROUPING_LEVELS
+            env={"schedule": schedule},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -520,16 +555,20 @@ def test_dict_param_mixed_periods_via_spelled_units_are_allowed():
         end_date=_END,
     )
     resolved = resolve_environment_units(
-        env={"schedule": schedule}, grouping_levels=GROUPING_LEVELS
+        env={"schedule": schedule},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     unit_tree = _unit_tree(resolved=resolved, qname="schedule")
     assert units_are_equivalent(
         left=unit_tree["base_amount_m"],
-        right=parse_unit("CURRENCY / month / grouping_level_person"),
+        right=parse_unit("CURRENCY / month / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
         left=unit_tree["annual_bonus_y"],
-        right=parse_unit("CURRENCY / year / grouping_level_person"),
+        right=parse_unit("CURRENCY / year / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -555,11 +594,14 @@ def test_scalar_flow_param_resolves_via_name_suffix():
         end_date=_END,
     )
     resolved = resolve_environment_units(
-        env={"lump_sum_deduction_y": lump_sum}, grouping_levels=GROUPING_LEVELS
+        env={"lump_sum_deduction_y": lump_sum},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="lump_sum_deduction_y"),
-        right=parse_unit("CURRENCY / year / grouping_level_person"),
+        right=parse_unit("CURRENCY / year / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -574,7 +616,9 @@ def test_scalar_param_spelled_period_must_agree_with_name_suffix():
     )
     with pytest.raises(UnitDefinitionError, match="must agree"):
         resolve_environment_units(
-            env={"some_amount_y": threshold}, grouping_levels=GROUPING_LEVELS
+            env={"some_amount_y": threshold},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -594,8 +638,7 @@ def _wealth_tax_env() -> dict:
 
 def test_stock_times_rate_with_time_component_passes():
     fail_if_environment_units_are_inconsistent(
-        env=_wealth_tax_env(),
-        grouping_levels=GROUPING_LEVELS,
+        env=_wealth_tax_env(), grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
     )
 
 
@@ -617,6 +660,7 @@ def test_stock_times_rate_without_time_component_is_caught():
                 "amount_buggy_y": amount_buggy_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -629,11 +673,11 @@ def test_multi_boolean_guard_bug_only_on_mixed_assignment_is_caught():
     correct flow branch). The path explorer walks every reachable combination.
     """
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def use_wealth() -> bool:
         """Boolean input selecting the stock branch."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def amount_mixed_guard_y(
         wealth: float,
         tax_rate_y: float,
@@ -656,17 +700,18 @@ def test_multi_boolean_guard_bug_only_on_mixed_assignment_is_caught():
                 "amount_mixed_guard_y": amount_mixed_guard_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_multi_boolean_guard_all_paths_consistent_passes():
     """The enumeration adds no false positive when every path is consistent."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def use_wealth() -> bool:
         """Boolean input selecting between two flow branches."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def amount_two_flow_branches_y(
         wealth: float,
         tax_rate_y: float,
@@ -688,6 +733,7 @@ def test_multi_boolean_guard_all_paths_consistent_passes():
             "amount_two_flow_branches_y": amount_two_flow_branches_y,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -701,7 +747,7 @@ def test_numeric_driven_branch_bug_is_caught():
     comparison itself is sound (equivalent units).
     """
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def amount_threshold_guard_y(
         wealth: float, tax_rate_y: float, wealth_threshold: float
     ) -> float:
@@ -718,6 +764,7 @@ def test_numeric_driven_branch_bug_is_caught():
                 "amount_threshold_guard_y": amount_threshold_guard_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -728,7 +775,7 @@ def test_numeric_driven_branch_with_dimensionless_arm_does_not_false_positive():
     fallback), so the ubiquitous ``if ...: return 0.0`` pattern is not flagged.
     """
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def amount_means_tested_y(
         wealth: float, tax_rate_y: float, wealth_threshold: float
     ) -> float:
@@ -744,6 +791,7 @@ def test_numeric_driven_branch_with_dimensionless_arm_does_not_false_positive():
             "amount_means_tested_y": amount_means_tested_y,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -768,7 +816,7 @@ def test_calendar_point_difference_is_a_duration_in_years():
     """The motivating S1 pattern: ``now - birth_year`` is a duration, declared
     ``YEARS``; the dry-run accepts it through pint's offset algebra."""
 
-    @policy_function(unit=Unit.YEARS)
+    @policy_function(unit=TTSIMUnit.YEARS)
     def age(policy_year: int, geburtsjahr: int) -> int:
         return policy_year - geburtsjahr
 
@@ -779,6 +827,7 @@ def test_calendar_point_difference_is_a_duration_in_years():
             "age": age,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -786,7 +835,7 @@ def test_duration_shifts_a_calendar_point_to_a_calendar_point():
     """A ``YEARS`` duration added to a calendar year yields a calendar year
     (``geburtsjahr + statutory_age``), declared ``CALENDAR_YEAR``."""
 
-    @policy_function(unit=Unit.CALENDAR_YEAR)
+    @policy_function(unit=TTSIMUnit.CALENDAR_YEAR)
     def retirement_year(geburtsjahr: int, statutory_age: int) -> int:
         return geburtsjahr + statutory_age
 
@@ -797,6 +846,7 @@ def test_duration_shifts_a_calendar_point_to_a_calendar_point():
             "retirement_year": retirement_year,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -804,7 +854,7 @@ def test_adding_two_calendar_points_is_caught():
     """``point + point`` has no affine meaning; pint refuses it and the dry-run
     reports a calendar misuse (GEP 10)."""
 
-    @policy_function(unit=Unit.CALENDAR_YEAR)
+    @policy_function(unit=TTSIMUnit.CALENDAR_YEAR)
     def nonsense(policy_year: int, geburtsjahr: int) -> int:
         return policy_year + geburtsjahr  # bug: two calendar points added
 
@@ -816,13 +866,14 @@ def test_adding_two_calendar_points_is_caught():
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_scaling_a_calendar_point_is_caught():
     """A calendar point cannot be scaled (it is affine, not multiplicative)."""
 
-    @policy_function(unit=Unit.CALENDAR_YEAR)
+    @policy_function(unit=TTSIMUnit.CALENDAR_YEAR)
     def doubled(geburtsjahr: int) -> int:
         return geburtsjahr * 2  # bug: scaling a calendar point
 
@@ -833,6 +884,7 @@ def test_scaling_a_calendar_point_is_caught():
                 "doubled": doubled,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -840,7 +892,7 @@ def test_calendar_point_difference_declared_as_a_calendar_year_is_caught():
     """The S1 failure mode: a year difference is a duration, so declaring the
     result ``CALENDAR_YEAR`` (a point) is inconsistent and is flagged."""
 
-    @policy_function(unit=Unit.CALENDAR_YEAR)
+    @policy_function(unit=TTSIMUnit.CALENDAR_YEAR)
     def age(policy_year: int, geburtsjahr: int) -> int:
         return policy_year - geburtsjahr  # a duration, not a calendar year
 
@@ -852,6 +904,7 @@ def test_calendar_point_difference_declared_as_a_calendar_year_is_caught():
                 "age": age,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -860,7 +913,7 @@ def test_ordering_a_calendar_point_against_another_unit_is_caught():
     delegate-to-pint dispensation there: ordered against anything but a
     same-axis point, it is a unit mix (GEP 10)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def nonsense(geburtsjahr: int, income_m: float) -> bool:
         return geburtsjahr >= income_m  # bug: a calendar point vs a flow
 
@@ -872,6 +925,7 @@ def test_ordering_a_calendar_point_against_another_unit_is_caught():
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -879,7 +933,7 @@ def test_ordering_a_calendar_point_against_a_duration_is_caught():
     """A point and a duration share ``[time]`` but not an algebra: equivalence
     decides points by identity, so ordering them is a unit mix (GEP 10)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def nonsense(geburtsjahr: int, statutory_age: int) -> bool:
         return geburtsjahr >= statutory_age  # bug: a point vs a duration
 
@@ -891,6 +945,7 @@ def test_ordering_a_calendar_point_against_a_duration_is_caught():
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -899,7 +954,7 @@ def test_ordering_two_same_axis_calendar_points_passes():
     (``geburtsjahr <= policy_year``): identical units, so the ordering screen
     passes without any calendar dispensation."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def born_by_policy_year(policy_year: int, geburtsjahr: int) -> bool:
         return geburtsjahr <= policy_year
 
@@ -910,6 +965,7 @@ def test_ordering_two_same_axis_calendar_points_passes():
             "born_by_policy_year": born_by_policy_year,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -919,11 +975,11 @@ def test_subtracting_calendar_points_of_different_axes_is_caught():
     run-time subtraction is raw and unconverted, so a cross-axis point - point is
     rejected rather than delegated to pint (defect #2, GEP 10)."""
 
-    @policy_input(unit=Unit.CALENDAR_MONTH)
+    @policy_input(unit=TTSIMUnit.CALENDAR_MONTH)
     def some_calendar_month() -> int:
         """A month point on the calendar."""
 
-    @policy_function(unit=Unit.MONTHS)
+    @policy_function(unit=TTSIMUnit.MONTHS)
     def nonsense(some_calendar_month: int, geburtsjahr: int) -> int:
         return some_calendar_month - geburtsjahr  # bug: subtract points across axes
 
@@ -935,6 +991,7 @@ def test_subtracting_calendar_points_of_different_axes_is_caught():
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -943,7 +1000,7 @@ def test_adding_a_currency_to_a_calendar_point_is_reported_as_a_calendar_misuse(
     it is a genuine calendar bug, so it reports as a calendar misuse rather than
     falling into the blanket ``verify_units=False`` advice (defect #7, GEP 10)."""
 
-    @policy_function(unit=Unit.CALENDAR_YEAR)
+    @policy_function(unit=TTSIMUnit.CALENDAR_YEAR)
     def nonsense(geburtsjahr: int, income_m: float) -> float:
         return geburtsjahr + income_m  # bug: a calendar point plus a currency
 
@@ -955,6 +1012,7 @@ def test_adding_a_currency_to_a_calendar_point_is_reported_as_a_calendar_misuse(
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -963,17 +1021,18 @@ def test_flow_time_converter_body_passes():
     the period rebase, so the body checks against its ``_y`` declaration with no
     opt-out (GEP 10, time converters)."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def betrag_m() -> float:
         """A monthly flow."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def betrag_y(betrag_m: float) -> float:
         return per_m_to_per_y(betrag_m)
 
     fail_if_environment_units_are_inconsistent(
         env={"betrag_m": betrag_m, "betrag_y": betrag_y},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -981,15 +1040,15 @@ def test_duration_time_converter_body_passes():
     """``m_to_y`` rebases a ``MONTHS`` duration to ``YEARS``; the classic
     ``m_to_y(months) >= grenze`` shape checks without an opt-out (GEP 10)."""
 
-    @policy_input(unit=Unit.MONTHS)
+    @policy_input(unit=TTSIMUnit.MONTHS)
     def wartezeit() -> int:
         """A waiting time in months (a duration)."""
 
-    @policy_input(unit=Unit.YEARS)
+    @policy_input(unit=TTSIMUnit.YEARS)
     def wartezeitgrenze() -> int:
         """A threshold in years."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def wartezeit_erfüllt(wartezeit: int, wartezeitgrenze: int) -> bool:
         return m_to_y(wartezeit) >= wartezeitgrenze
 
@@ -1000,6 +1059,7 @@ def test_duration_time_converter_body_passes():
             "wartezeit_erfüllt": wartezeit_erfüllt,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1007,11 +1067,11 @@ def test_wrong_direction_time_converter_is_caught():
     """A converter for the wrong period rebases to a unit that disagrees with the
     declaration, so the misuse is caught rather than silently passed (GEP 10)."""
 
-    @policy_input(unit=Unit.MONTHS)
+    @policy_input(unit=TTSIMUnit.MONTHS)
     def wartezeit() -> int:
         """A duration in months."""
 
-    @policy_function(unit=Unit.YEARS)
+    @policy_function(unit=TTSIMUnit.YEARS)
     def nonsense(wartezeit: int) -> float:
         return y_to_m(wartezeit)  # wrong: a MONTHS duration fed to a year->month rebase
 
@@ -1019,6 +1079,7 @@ def test_wrong_direction_time_converter_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"wartezeit": wartezeit, "nonsense": nonsense},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1027,7 +1088,7 @@ def test_month_date_nodes_are_cyclic_ordinals():
     ``DIMENSIONLESS`` (GEP 10), so comparing it to another ordinal is plain
     dimensionless arithmetic."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def had_birthday(policy_month: int, geburtsmonat: int) -> bool:
         return policy_month >= geburtsmonat
 
@@ -1038,6 +1099,7 @@ def test_month_date_nodes_are_cyclic_ordinals():
             "had_birthday": had_birthday,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1046,7 +1108,7 @@ def test_month_date_node_shifted_by_a_duration_is_caught():
     time — the silent fold the ordinal/point split exists to catch. As a
     dimensionless ordinal it does not add to a ``MONTHS`` duration (GEP 10)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def nonsense(policy_month: int, months_paid: int) -> int:
         return policy_month + months_paid  # bug: an ordinal shifted like a point
 
@@ -1058,6 +1120,7 @@ def test_month_date_node_shifted_by_a_duration_is_caught():
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1065,7 +1128,7 @@ def test_error_names_the_failing_branch():
     """A branch-confined failure names the branch in the body's own terms and
     reports the other combinations clean (GEP 10)."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def betrag_m(bonus_y: float, is_exempt: bool) -> float:
         if is_exempt:
             return 0.0
@@ -1085,6 +1148,7 @@ def test_error_names_the_failing_branch():
                 "betrag_m": betrag_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1092,7 +1156,7 @@ def test_error_names_a_comparison_driven_branch():
     """A branch decided by a comparison is named by that comparison's operands
     (GEP 10)."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def gated_m(income_m: float, other_income_m: float, bonus_y: float) -> float:
         if income_m < other_income_m:
             return income_m
@@ -1110,6 +1174,7 @@ def test_error_names_a_comparison_driven_branch():
                 "gated_m": gated_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1122,7 +1187,7 @@ def test_boolean_body_bad_comparison_is_caught():
     made the whole body skip the check and this slipped through silently.
     """
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def wealthy(wealth: float, bonus_y: float) -> bool:
         return wealth >= bonus_y  # bug: a stock compared with a yearly flow
 
@@ -1134,6 +1199,7 @@ def test_boolean_body_bad_comparison_is_caught():
                 "wealthy": wealthy,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1141,7 +1207,7 @@ def test_boolean_body_with_logical_ops_passes():
     """A boolean body combining clean truth values with ``&``/``|``/``~`` is not
     a false positive: every operand is a dimensionless truth value."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def eligible(income_m: float, other_income_m: float, is_exempt: bool) -> bool:
         return ((income_m >= other_income_m) | is_exempt) & (~is_exempt)
 
@@ -1153,6 +1219,7 @@ def test_boolean_body_with_logical_ops_passes():
             "eligible": eligible,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1164,11 +1231,11 @@ def test_logical_op_on_unit_carrying_operand_is_caught():
     a logical combination — caught on either side via the reflected dunders.
     """
 
-    @policy_input(unit=Unit.YEARS)
+    @policy_input(unit=TTSIMUnit.YEARS)
     def age() -> int:
         """An age in years (a ``YEARS`` quantity)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def nonsense(age: int, is_exempt: bool) -> bool:
         return age & is_exempt  # bug: '&' on a YEARS quantity
 
@@ -1180,6 +1247,7 @@ def test_logical_op_on_unit_carrying_operand_is_caught():
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1189,15 +1257,15 @@ def test_not_of_a_leveled_boolean_keeps_its_level():
     the fam-level declaration — no spurious level error. Before the fix, ``not``
     dropped the stand-in to a plain bool and the combine mislevelled the result."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS.PER_FAM)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
     def flag_fam() -> bool:
         """A fam-level indicator."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS.PER_FAM)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
     def other_flag_fam() -> bool:
         """Another fam-level indicator."""
 
-    @policy_function(leaf_name="combined_fam", unit=Unit.DIMENSIONLESS.PER_FAM)
+    @policy_function(leaf_name="combined_fam", unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
     def combined_fam(flag_fam: bool, other_flag_fam: bool) -> bool:
         return flag_fam and not other_flag_fam
 
@@ -1208,6 +1276,7 @@ def test_not_of_a_leveled_boolean_keeps_its_level():
             "combined_fam": combined_fam,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1216,7 +1285,7 @@ def test_not_of_a_non_boolean_quantity_is_caught():
     spelling must too — the dry-run models ``not`` as ``logical_not`` (defect #5,
     GEP 10)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def flag(income_m: float) -> bool:
         return not income_m  # bug: `not` on a currency
 
@@ -1224,6 +1293,7 @@ def test_not_of_a_non_boolean_quantity_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "flag": flag},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1231,16 +1301,16 @@ def test_boolean_body_at_correct_group_level_passes():
     """A fam-level predicate comparing fam-level quantities infers ``1 / [fam]``,
     matching its ``_fam`` name (GEP 10)."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def income_m_fam() -> float:
         """Family income."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def threshold_m_fam() -> float:
         """Family subsistence threshold."""
 
     @policy_function(
-        leaf_name="requirement_fulfilled_fam", unit=Unit.DIMENSIONLESS.PER_FAM
+        leaf_name="requirement_fulfilled_fam", unit=TTSIMUnit.DIMENSIONLESS.PER_FAM
     )
     def requirement_fulfilled_fam(income_m_fam: float, threshold_m_fam: float) -> bool:
         return income_m_fam < threshold_m_fam
@@ -1252,6 +1322,7 @@ def test_boolean_body_at_correct_group_level_passes():
             "requirement_fulfilled_fam": requirement_fulfilled_fam,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1264,7 +1335,7 @@ def test_boolean_body_at_wrong_group_level_is_caught():
     """
 
     @policy_function(
-        leaf_name="requirement_fulfilled_fam", unit=Unit.DIMENSIONLESS.PER_FAM
+        leaf_name="requirement_fulfilled_fam", unit=TTSIMUnit.DIMENSIONLESS.PER_FAM
     )
     def requirement_fulfilled_fam(income_m: float, other_income_m: float) -> bool:
         return income_m < other_income_m  # person-level operands, but a _fam name
@@ -1277,6 +1348,7 @@ def test_boolean_body_at_wrong_group_level_is_caught():
                 "requirement_fulfilled_fam": requirement_fulfilled_fam,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1284,15 +1356,15 @@ def test_logical_combine_of_mixed_levels_downcasts_to_person():
     """``|`` of a fam-level and a person-level indicator is a person-level boolean
     (the combine rule), matching an unsuffixed name (GEP 10)."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def income_m_fam() -> float:
         """Family income."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def threshold_m_fam() -> float:
         """Family subsistence threshold."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def eligible(
         income_m: float,
         other_income_m: float,
@@ -1310,6 +1382,7 @@ def test_logical_combine_of_mixed_levels_downcasts_to_person():
             "eligible": eligible,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1323,15 +1396,15 @@ def test_python_or_of_mixed_levels_is_rewritten_and_downcasts_to_person():
     the ``wealth_tax.exempt_from_wealth_tax`` shape.
     """
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def income_m_fam() -> float:
         """Family income."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def threshold_m_fam() -> float:
         """Family subsistence threshold."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def eligible(
         income_m: float,
         other_income_m: float,
@@ -1349,6 +1422,7 @@ def test_python_or_of_mixed_levels_is_rewritten_and_downcasts_to_person():
             "eligible": eligible,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1360,11 +1434,11 @@ def test_python_and_on_unit_carrying_operand_is_still_caught():
     ``age & is_exempt`` — the rewrite must not let it slip through.
     """
 
-    @policy_input(unit=Unit.YEARS)
+    @policy_input(unit=TTSIMUnit.YEARS)
     def age() -> int:
         """An age in years (a ``YEARS`` quantity)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def nonsense(age: int, is_exempt: bool) -> bool:
         return age and is_exempt  # bug: 'and' on a YEARS quantity
 
@@ -1376,6 +1450,7 @@ def test_python_and_on_unit_carrying_operand_is_still_caught():
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1390,15 +1465,15 @@ def test_terminal_cross_level_division_is_caught():
     content cancels. A grouping level cannot outlive its base, so returning that
     residue as a *result* is caught on the level axis (GEP 10)."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def betrag_m_fam() -> float:
         """A monthly family amount."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_KIN)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_KIN)
     def betrag_m_kin() -> float:
         """A monthly kin amount."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def anteil(betrag_m_fam: float, betrag_m_kin: float) -> float:
         return betrag_m_fam / betrag_m_kin
 
@@ -1410,6 +1485,7 @@ def test_terminal_cross_level_division_is_caught():
                 "anteil": anteil,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1418,15 +1494,15 @@ def test_terminal_cross_level_division_passes_with_an_explicit_opt_out():
     it takes a local ``verify_units=False`` rather than a blanket exemption
     (GEP 10)."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def betrag_m_fam() -> float:
         """A monthly family amount."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_KIN)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_KIN)
     def betrag_m_kin() -> float:
         """A monthly kin amount."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS, verify_units=False)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS, verify_units=False)
     def anteil(betrag_m_fam: float, betrag_m_kin: float) -> float:
         return betrag_m_kin / betrag_m_fam
 
@@ -1437,6 +1513,7 @@ def test_terminal_cross_level_division_passes_with_an_explicit_opt_out():
             "anteil": anteil,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1447,19 +1524,19 @@ def test_bedarfsanteilsmethode_cross_level_share_consumed_by_multiplication_pass
     that matches the declaration — no exemption needed, and unchanged by the
     cross-level rule (GEP 10)."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def bedarf_m() -> float:
         """A person's monthly need."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def bedarf_m_fam() -> float:
         """The family's pooled monthly need."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def anspruch_m_fam() -> float:
         """The family's monthly claim."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def betrag_m(bedarf_m: float, bedarf_m_fam: float, anspruch_m_fam: float) -> float:
         return (bedarf_m / bedarf_m_fam) * anspruch_m_fam
 
@@ -1471,6 +1548,7 @@ def test_bedarfsanteilsmethode_cross_level_share_consumed_by_multiplication_pass
             "betrag_m": betrag_m,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1480,15 +1558,15 @@ def test_cross_level_share_declared_with_concrete_content_is_caught():
     ``DIMENSIONLESS``) is caught on the physical axis, before the level axis is
     even reached (GEP 10)."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def betrag_m_fam() -> float:
         """A monthly family amount."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_KIN)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_KIN)
     def betrag_m_kin() -> float:
         """A monthly kin amount."""
 
-    @policy_function(leaf_name="anteil_m", unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(leaf_name="anteil_m", unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def anteil_m(betrag_m_fam: float, betrag_m_kin: float) -> float:
         return betrag_m_fam / betrag_m_kin  # [kin]/[fam] cross-level result, not money
 
@@ -1500,6 +1578,7 @@ def test_cross_level_share_declared_with_concrete_content_is_caught():
                 "anteil_m": anteil_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1508,11 +1587,13 @@ def test_head_count_at_wrong_group_level_is_still_caught():
     level-checked unit. A ``[person]/[fam]`` count declared at the kin level is
     caught (GEP 10) — it is not mistaken for a cross-level share."""
 
-    @policy_input(unit=Unit.PERSON_COUNT.PER_FAM)
+    @policy_input(unit=TTSIMUnit.PERSON_COUNT.PER_FAM)
     def anzahl_personen_fam() -> int:
         """A head count per family — ``[person]/[fam]``."""
 
-    @policy_function(leaf_name="anzahl_personen_kin", unit=Unit.PERSON_COUNT.PER_KIN)
+    @policy_function(
+        leaf_name="anzahl_personen_kin", unit=TTSIMUnit.PERSON_COUNT.PER_KIN
+    )
     def anzahl_personen_kin(anzahl_personen_fam: int) -> int:
         return anzahl_personen_fam  # a [person]/[fam] count under a _kin name
 
@@ -1523,6 +1604,7 @@ def test_head_count_at_wrong_group_level_is_still_caught():
                 "anzahl_personen_kin": anzahl_personen_kin,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1536,15 +1618,15 @@ def test_cross_level_comparison_without_cast_is_caught():
     (``month/[fam]`` against ``month``), so the ordering screen rejects it —
     even where the law mandates exactly this test (GEP 10)."""
 
-    @policy_input(unit=Unit.MONTHS.PER_FAM)
+    @policy_input(unit=TTSIMUnit.MONTHS.PER_FAM)
     def age_youngest_months_fam() -> float:
         """The family's youngest member's age — a property of the family."""
 
-    @policy_input(unit=Unit.MONTHS)
+    @policy_input(unit=TTSIMUnit.MONTHS)
     def age_limit_months() -> float:
         """An age threshold; a level-less duration."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def eligible(age_youngest_months_fam: float, age_limit_months: float) -> bool:
         return age_youngest_months_fam <= age_limit_months
 
@@ -1556,6 +1638,7 @@ def test_cross_level_comparison_without_cast_is_caught():
                 "eligible": eligible,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1564,18 +1647,18 @@ def test_cross_level_comparison_with_cast_passes():
     extreme — is stated at the site with ``cast_unit``; the rest of the body
     stays checked (GEP 10)."""
 
-    @policy_input(unit=Unit.MONTHS.PER_FAM)
+    @policy_input(unit=TTSIMUnit.MONTHS.PER_FAM)
     def age_youngest_months_fam() -> float:
         """The family's youngest member's age — a property of the family."""
 
-    @policy_input(unit=Unit.MONTHS)
+    @policy_input(unit=TTSIMUnit.MONTHS)
     def age_limit_months() -> float:
         """An age threshold; a level-less duration."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def eligible(age_youngest_months_fam: float, age_limit_months: float) -> bool:
         return (
-            cast_unit(value=age_youngest_months_fam, unit=Unit.MONTHS)
+            cast_unit(value=age_youngest_months_fam, unit=TTSIMUnit.MONTHS)
             <= age_limit_months
         )
 
@@ -1586,6 +1669,7 @@ def test_cross_level_comparison_with_cast_passes():
             "eligible": eligible,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1594,11 +1678,11 @@ def test_level_less_inference_under_a_declared_group_level_is_caught():
     yields no level cannot silently claim the declared group level; the error
     points at ``cast_unit`` (GEP 10)."""
 
-    @policy_input(unit=Unit.MONTHS)
+    @policy_input(unit=TTSIMUnit.MONTHS)
     def age_limit_months() -> float:
         """An age threshold; a level-less duration."""
 
-    @policy_function(unit=Unit.MONTHS.PER_FAM)
+    @policy_function(unit=TTSIMUnit.MONTHS.PER_FAM)
     def doubled_limit_months_fam(age_limit_months: float) -> float:
         return age_limit_months * 2.0
 
@@ -1609,6 +1693,7 @@ def test_level_less_inference_under_a_declared_group_level_is_caught():
                 "doubled_limit_months_fam": doubled_limit_months_fam,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1616,13 +1701,13 @@ def test_cast_at_the_return_states_the_declared_group_level():
     """An intensive group property computed from level-less material states its
     level with ``cast_unit`` at the return (GEP 10)."""
 
-    @policy_input(unit=Unit.MONTHS)
+    @policy_input(unit=TTSIMUnit.MONTHS)
     def age_limit_months() -> float:
         """An age threshold; a level-less duration."""
 
-    @policy_function(unit=Unit.MONTHS.PER_FAM)
+    @policy_function(unit=TTSIMUnit.MONTHS.PER_FAM)
     def doubled_limit_months_fam(age_limit_months: float) -> float:
-        return cast_unit(value=age_limit_months * 2.0, unit=Unit.MONTHS.PER_FAM)
+        return cast_unit(value=age_limit_months * 2.0, unit=TTSIMUnit.MONTHS.PER_FAM)
 
     fail_if_environment_units_are_inconsistent(
         env={
@@ -1630,6 +1715,7 @@ def test_cast_at_the_return_states_the_declared_group_level():
             "doubled_limit_months_fam": doubled_limit_months_fam,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1639,15 +1725,15 @@ def test_group_share_times_group_total_squares_the_level_and_is_caught():
     is compared with exponents, so the product cannot silently claim the
     declared single level (GEP 10)."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS.PER_FAM)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
     def parents_share_fam() -> float:
         """The parents' share of the family's need — the family's property."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def need_m_fam() -> float:
         """The family's monthly need."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def parents_need_m_fam(parents_share_fam: float, need_m_fam: float) -> float:
         return parents_share_fam * need_m_fam
 
@@ -1659,6 +1745,7 @@ def test_group_share_times_group_total_squares_the_level_and_is_caught():
                 "parents_need_m_fam": parents_need_m_fam,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1666,18 +1753,19 @@ def test_group_share_times_group_total_passes_with_cast():
     """Where the law mandates the group-share product, the cast states the
     intended result at the site (GEP 10)."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS.PER_FAM)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
     def parents_share_fam() -> float:
         """The parents' share of the family's need — the family's property."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def need_m_fam() -> float:
         """The family's monthly need."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def parents_need_m_fam(parents_share_fam: float, need_m_fam: float) -> float:
         return cast_unit(
-            value=parents_share_fam * need_m_fam, unit=Unit.CURRENCY.PER_MONTH.PER_FAM
+            value=parents_share_fam * need_m_fam,
+            unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM,
         )
 
     fail_if_environment_units_are_inconsistent(
@@ -1687,6 +1775,7 @@ def test_group_share_times_group_total_passes_with_cast():
             "parents_need_m_fam": parents_need_m_fam,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1695,25 +1784,27 @@ def test_cast_tags_a_dimensioned_literal_in_an_ordering_comparison():
     the tagged literal is still screened, so a wrong-period tag is caught
     (GEP 10)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def poor(income_m: float) -> bool:
-        return income_m < cast_unit(value=1000.0, unit=Unit.CURRENCY.PER_MONTH)
+        return income_m < cast_unit(value=1000.0, unit=TTSIMUnit.CURRENCY.PER_MONTH)
 
     fail_if_environment_units_are_inconsistent(
         env={"income_m": income_m, "poor": poor},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def poor_buggy(income_m: float) -> bool:
         return income_m < cast_unit(
-            value=1000.0, unit=Unit.CURRENCY.PER_YEAR
+            value=1000.0, unit=TTSIMUnit.CURRENCY.PER_YEAR
         )  # wrong period
 
     with pytest.raises(UnitConsistencyError, match="poor_buggy"):
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "poor_buggy": poor_buggy},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1723,16 +1814,17 @@ def test_cast_in_a_vectorized_body_is_screened_identically():
     rejected (GEP 10)."""
 
     @policy_function(
-        unit=Unit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
     )
     def capped_income_m(income_m: FloatColumn, xnp: ModuleType) -> FloatColumn:
         return xnp.minimum(
-            income_m, cast_unit(value=2000.0, unit=Unit.CURRENCY.PER_MONTH)
+            income_m, cast_unit(value=2000.0, unit=TTSIMUnit.CURRENCY.PER_MONTH)
         )
 
     fail_if_environment_units_are_inconsistent(
         env={"income_m": income_m, "capped_income_m": capped_income_m},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1741,7 +1833,7 @@ def test_cast_to_a_concrete_currency_is_rejected():
     cast pinning one is a definition error — reported as such, not as an
     un-evaluable body (GEP 10)."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def pinned_m(income_m: float) -> float:
         return cast_unit(value=income_m, unit="CASTAR_PER_MONTH")
 
@@ -1749,6 +1841,7 @@ def test_cast_to_a_concrete_currency_is_rejected():
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "pinned_m": pinned_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1758,15 +1851,15 @@ def test_dimensionless_inference_cannot_claim_a_group_owned_declaration():
     states its level with ``cast_unit``; the person grain stays lenient
     (GEP 10)."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def share_of_need() -> float:
         """A level-less share."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def threshold_share() -> float:
         """A level-less share."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS.PER_FAM)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
     def requirement_fulfilled_fam(share_of_need: float, threshold_share: float) -> bool:
         return share_of_need < threshold_share
 
@@ -1778,14 +1871,15 @@ def test_dimensionless_inference_cannot_claim_a_group_owned_declaration():
                 "requirement_fulfilled_fam": requirement_fulfilled_fam,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
-    @policy_function(unit=Unit.DIMENSIONLESS.PER_FAM)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
     def requirement_fulfilled_cast_fam(
         share_of_need: float, threshold_share: float
     ) -> bool:
         return cast_unit(
-            value=share_of_need < threshold_share, unit=Unit.DIMENSIONLESS.PER_FAM
+            value=share_of_need < threshold_share, unit=TTSIMUnit.DIMENSIONLESS.PER_FAM
         )
 
     fail_if_environment_units_are_inconsistent(
@@ -1795,6 +1889,7 @@ def test_dimensionless_inference_cannot_claim_a_group_owned_declaration():
             "requirement_fulfilled_fam": requirement_fulfilled_cast_fam,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1803,7 +1898,7 @@ def test_adding_a_nonzero_bare_literal_to_a_quantity_is_caught():
     screen literals exactly as the ordering comparisons do — promote to a
     parameter, tag with ``cast_unit``, or use 0 (GEP 10)."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def bumped_income_m(income_m: float) -> float:
         return income_m + 100.0
 
@@ -1811,15 +1906,17 @@ def test_adding_a_nonzero_bare_literal_to_a_quantity_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "bumped_income_m": bumped_income_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def bumped_income_cast_m(income_m: float) -> float:
-        return income_m + cast_unit(value=100.0, unit=Unit.CURRENCY.PER_MONTH)
+        return income_m + cast_unit(value=100.0, unit=TTSIMUnit.CURRENCY.PER_MONTH)
 
     fail_if_environment_units_are_inconsistent(
         env={"income_m": income_m, "bumped_income_m": bumped_income_cast_m},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1828,7 +1925,7 @@ def test_nonzero_literal_return_under_a_dimensioned_declaration_is_caught():
     constant: only ``0`` falls through (the eligibility guard); anything else
     is promoted to a parameter or tagged with ``cast_unit`` (GEP 10)."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def lump_m(is_exempt: bool, income_m: float) -> float:
         if is_exempt:
             return 25.0
@@ -1838,17 +1935,19 @@ def test_nonzero_literal_return_under_a_dimensioned_declaration_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"is_exempt": is_exempt, "income_m": income_m, "lump_m": lump_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def lump_cast_m(is_exempt: bool, income_m: float) -> float:
         if is_exempt:
-            return cast_unit(value=25.0, unit=Unit.CURRENCY.PER_MONTH)
+            return cast_unit(value=25.0, unit=TTSIMUnit.CURRENCY.PER_MONTH)
         return income_m
 
     fail_if_environment_units_are_inconsistent(
         env={"is_exempt": is_exempt, "income_m": income_m, "lump_m": lump_cast_m},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1861,19 +1960,19 @@ def test_path_cap_truncation_demands_opt_out(monkeypatch):
     """
     monkeypatch.setattr("ttsim.interface_dag_elements.unit_checks._MAX_PATHS", 4)
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def flag_a() -> bool:
         """A boolean gate."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def flag_b() -> bool:
         """A boolean gate."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def flag_c() -> bool:
         """A boolean gate."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def many_branches_y(
         wealth: float,
         tax_rate_y: float,
@@ -1901,6 +2000,7 @@ def test_path_cap_truncation_demands_opt_out(monkeypatch):
                 "many_branches_y": many_branches_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1908,7 +2008,7 @@ def test_bare_nonzero_literal_in_ordering_is_caught():
     """A bare non-zero literal in an ordering comparison carries the other
     operand's unit, so it is rejected — promote it to a parameter (GEP 10)."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def rich(wealth: float) -> bool:
         return wealth > 1_000_000.0  # bug: the bound silently becomes CURRENCY
 
@@ -1916,6 +2016,7 @@ def test_bare_nonzero_literal_in_ordering_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"wealth": wealth, "rich": rich},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1923,15 +2024,15 @@ def test_zero_literal_and_dimensionless_self_in_ordering_pass():
     """The two allowed cases: a literal ``0`` (sign test) against any quantity,
     and any bare literal when the quantity itself is dimensionless (GEP 10)."""
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def some_rate() -> float:
         """A dimensionless share."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def has_wealth(wealth: float) -> bool:
         return wealth > 0.0  # 0 is the allowed inline literal
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def high_rate(some_rate: float) -> bool:
         return some_rate > 0.5  # self is dimensionless, so a bare literal is fine
 
@@ -1943,6 +2044,7 @@ def test_zero_literal_and_dimensionless_self_in_ordering_pass():
             "high_rate": high_rate,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -1950,7 +2052,7 @@ def test_opaque_return_demands_opt_out():
     """A body returning an opaque value (a tuple, a dataclass) is neither a
     checkable quantity nor a plain scalar, so it must opt out (GEP 10)."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def packaged_y(wealth: float, tax_rate_y: float) -> tuple[float, float]:
         return (wealth * tax_rate_y, wealth)  # opaque: a tuple, not a scalar
 
@@ -1962,6 +2064,7 @@ def test_opaque_return_demands_opt_out():
                 "packaged_y": packaged_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1974,7 +2077,7 @@ def test_adding_different_period_flows_is_caught():
     before pint sees them (GEP 10).
     """
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def total_m(income_m: float, bonus_y: float) -> float:
         return income_m + bonus_y  # bug: adds a monthly and a yearly flow
 
@@ -1982,6 +2085,7 @@ def test_adding_different_period_flows_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "bonus_y": bonus_y, "total_m": total_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -1989,7 +2093,7 @@ def test_adding_stock_and_flow_is_caught():
     """A cross-dimension addition (stock + flow) raises a ``DimensionalityError``
     in pint, which the dry-run otherwise swallows; the additive check flags it."""
 
-    @policy_function(unit=Unit.CURRENCY)
+    @policy_function(unit=TTSIMUnit.CURRENCY)
     def stock_plus_flow(wealth: float, income_m: float) -> float:
         return wealth + income_m  # bug: a stock plus a monthly flow
 
@@ -2001,6 +2105,7 @@ def test_adding_stock_and_flow_is_caught():
                 "stock_plus_flow": stock_plus_flow,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2008,7 +2113,7 @@ def test_comparing_different_period_flows_is_caught():
     """Ordering comparisons are unit-blind at run time too: comparing a monthly
     flow to a yearly one is flagged even when both return arms are consistent."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def gated_income_m(income_m: float, bonus_y: float) -> float:
         if income_m > bonus_y:  # bug: compares a monthly flow to a yearly one
             return income_m * 2.0
@@ -2022,13 +2127,14 @@ def test_comparing_different_period_flows_is_caught():
                 "gated_income_m": gated_income_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_adding_same_period_flows_does_not_false_positive():
     """Two operands in equivalent units add cleanly — no false positive."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def total_two_monthly_m(income_m: float, other_income_m: float) -> float:
         return income_m + other_income_m
 
@@ -2039,37 +2145,40 @@ def test_adding_same_period_flows_does_not_false_positive():
             "total_two_monthly_m": total_two_monthly_m,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_adding_bare_literal_does_not_false_positive():
     """Only ``0`` is allowed inline, so the ``x + 0.0`` guard stays lenient."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def income_floor_m(income_m: float) -> float:
         return income_m + 0.0
 
     fail_if_environment_units_are_inconsistent(
         env={"income_m": income_m, "income_floor_m": income_floor_m},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_dimensionless_inference_falls_back_to_declaration():
-    @policy_function(unit=Unit.CURRENCY)
+    @policy_function(unit=TTSIMUnit.CURRENCY)
     def early_return(wealth: float) -> float:  # noqa: ARG001
         return 0.0
 
     fail_if_environment_units_are_inconsistent(
         env={"wealth": wealth, "early_return": early_return},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_undryrunnable_body_without_opt_out_is_rejected():
     # A body the dry-run cannot evaluate is not waved through silently (GEP 10):
     # the author must opt out explicitly with verify_units=False.
-    @policy_function(unit=Unit.CURRENCY)
+    @policy_function(unit=TTSIMUnit.CURRENCY)
     def not_dry_runnable(wealth: float) -> float:
         return wealth.this_attribute_does_not_exist()  # ty: ignore[unresolved-attribute]
 
@@ -2077,18 +2186,20 @@ def test_undryrunnable_body_without_opt_out_is_rejected():
         fail_if_environment_units_are_inconsistent(
             env={"wealth": wealth, "not_dry_runnable": not_dry_runnable},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_undryrunnable_body_with_opt_out_passes():
     # The same body, explicitly opted out, is accepted: its declared unit stands.
-    @policy_function(unit=Unit.CURRENCY, verify_units=False)
+    @policy_function(unit=TTSIMUnit.CURRENCY, verify_units=False)
     def not_dry_runnable(wealth: float) -> float:
         return wealth.this_attribute_does_not_exist()  # ty: ignore[unresolved-attribute]
 
     fail_if_environment_units_are_inconsistent(
         env={"wealth": wealth, "not_dry_runnable": not_dry_runnable},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -2122,7 +2233,7 @@ def test_where_arms_are_screened_for_equivalence():
     are pinned here."""
 
     @policy_function(
-        unit=Unit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
     )
     def gated_m(
         is_exempt: BoolColumn,
@@ -2140,10 +2251,11 @@ def test_where_arms_are_screened_for_equivalence():
             "gated_m": gated_m,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
     @policy_function(
-        unit=Unit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
     )
     def gated_buggy_m(
         is_exempt: BoolColumn,
@@ -2162,6 +2274,7 @@ def test_where_arms_are_screened_for_equivalence():
                 "gated_buggy_m": gated_buggy_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2170,7 +2283,9 @@ def test_where_mixing_a_calendar_point_and_a_duration_is_caught():
     delegate-to-pint dispensation: an arm mix of a point and a duration is
     flagged (GEP 10)."""
 
-    @policy_function(unit=Unit.CALENDAR_YEAR, vectorization_strategy="not_required")
+    @policy_function(
+        unit=TTSIMUnit.CALENDAR_YEAR, vectorization_strategy="not_required"
+    )
     def year_or_age(
         is_exempt: BoolColumn,
         geburtsjahr: IntColumn,
@@ -2188,6 +2303,7 @@ def test_where_mixing_a_calendar_point_and_a_duration_is_caught():
                 "year_or_age": year_or_age,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2197,7 +2313,7 @@ def test_vectorized_minimum_with_a_bare_literal_bound_is_caught():
     carries the other operand's unit, so promote it to a parameter (GEP 10)."""
 
     @policy_function(
-        unit=Unit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
     )
     def capped_m(income_m: FloatColumn, xnp: ModuleType) -> FloatColumn:
         return xnp.minimum(income_m, 1_000.0)  # bug: a bare literal cap
@@ -2206,6 +2322,7 @@ def test_vectorized_minimum_with_a_bare_literal_bound_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "capped_m": capped_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2214,7 +2331,7 @@ def test_clip_with_a_bare_nonzero_literal_bound_is_caught():
     the allowed sign test, a bare non-zero bound is rejected (GEP 10)."""
 
     @policy_function(
-        unit=Unit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
     )
     def clipped_m(income_m: FloatColumn, xnp: ModuleType) -> FloatColumn:
         return xnp.clip(income_m, 0.0, 5_000.0)  # bug: a bare literal ceiling
@@ -2223,6 +2340,55 @@ def test_clip_with_a_bare_nonzero_literal_bound_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "clipped_m": clipped_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_scalar_max_zero_floor_preserves_unit_when_result_is_continued():
+    """Scalar ``max(x, 0.0)`` carries ``x``'s unit on every branch, exactly as
+    the vectorized ``xnp.maximum`` does, so the clamped value stays usable: the
+    net/gross ratio ``max(income_m, 0.0) / income_m`` is dimensionless without a
+    ``cast_unit`` on the zero floor (GEP 10)."""
+
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
+    def ratio(income_m: float) -> float:
+        return max(income_m, 0.0) / income_m
+
+    fail_if_environment_units_are_inconsistent(
+        env={"income_m": income_m, "ratio": ratio},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_scalar_min_zero_floor_preserves_unit_when_result_is_continued():
+    """Scalar ``min(x, 0.0)`` likewise keeps ``x``'s unit on both branches."""
+
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
+    def ratio(income_m: float) -> float:
+        return min(income_m, 0.0) / income_m
+
+    fail_if_environment_units_are_inconsistent(
+        env={"income_m": income_m, "ratio": ratio},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_scalar_max_with_a_bare_nonzero_literal_bound_is_caught():
+    """Scalar ``max``/``min`` screen their bounds like the vectorized ops: a bare
+    non-zero literal silently carries the operand's unit and is rejected — only
+    the zero floor falls through (GEP 10)."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def capped_m(income_m: float) -> float:
+        return max(income_m, 1_000.0)  # bug: a bare literal floor
+
+    with pytest.raises(UnitConsistencyError, match="capped_m"):
+        fail_if_environment_units_are_inconsistent(
+            env={"income_m": income_m, "capped_m": capped_m},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2231,7 +2397,7 @@ def test_unmodelled_xnp_op_demands_opt_out():
     reported as needing ``verify_units=False`` — never silently passed (GEP 10)."""
 
     @policy_function(
-        unit=Unit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
     )
     def cumulative_m(income_m: FloatColumn, xnp: ModuleType) -> FloatColumn:
         return xnp.cumsum(income_m)
@@ -2240,6 +2406,7 @@ def test_unmodelled_xnp_op_demands_opt_out():
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "cumulative_m": cumulative_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2248,7 +2415,7 @@ def test_schedule_call_with_wrong_domain_unit_is_caught():
     argument must match the schedule's declared ``input_unit``."""
     schedule = _make_schedule_param(input_unit=CASTAR, output_unit=CASTAR_PER_YEAR)
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def levy_y(
         income_m: float, schedule: PiecewisePolynomialParamValue, xnp: ModuleType
     ) -> float:
@@ -2259,6 +2426,7 @@ def test_schedule_call_with_wrong_domain_unit_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "schedule": schedule, "levy_y": levy_y},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2269,7 +2437,7 @@ def test_schedule_output_disagreeing_with_the_declaration_is_caught():
     in every happy-path run."""
     schedule = _make_schedule_param(input_unit=CASTAR, output_unit=CASTAR_PER_YEAR)
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def levy_m(
         wealth: float, schedule: PiecewisePolynomialParamValue, xnp: ModuleType
     ) -> float:
@@ -2280,15 +2448,16 @@ def test_schedule_output_disagreeing_with_the_declaration_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"wealth": wealth, "schedule": schedule, "levy_m": levy_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_lookup_call_with_wrong_domain_unit_is_caught():
     by_year = _make_lookup_param(
-        input_unit=Unit.CALENDAR_YEAR, output_unit=CASTAR_PER_MONTH
+        input_unit=TTSIMUnit.CALENDAR_YEAR, output_unit=CASTAR_PER_MONTH
     )
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def max_amount_m(
         statutory_age: int, by_year: ConsecutiveIntLookupTableParamValue
     ) -> float:
@@ -2303,6 +2472,7 @@ def test_lookup_call_with_wrong_domain_unit_is_caught():
                 "max_amount_m": max_amount_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2312,11 +2482,11 @@ def test_join_target_level_disagreeing_with_the_declaration_is_caught():
     unit, this level mismatch could not be detected. (mettsim's checked join
     body gathers a dimensionless target, so it cannot pin this.)"""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def income_m_fam() -> float: ...
 
     @policy_function(
-        unit=Unit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
     )
     def recipient_family_income_m(
         p_id: IntColumn,
@@ -2343,6 +2513,7 @@ def test_join_target_level_disagreeing_with_the_declaration_is_caught():
                 "recipient_family_income_m": recipient_family_income_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2350,22 +2521,23 @@ def test_body_consuming_identifier_infers_dimensionless_and_passes():
     # An identifier is a dimensionless quantity (GEP 10); a body multiplying it
     # infers dimensionless, which falls back to the declaration (no false
     # positive) rather than being skipped as a previously-exempt input.
-    @policy_function(unit=Unit.CURRENCY)
+    @policy_function(unit=TTSIMUnit.CURRENCY)
     def depends_on_identifier(p_id: int) -> float:
         return p_id * 2.0
 
     fail_if_environment_units_are_inconsistent(
         env={"p_id": p_id, "depends_on_identifier": depends_on_identifier},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_concrete_mismatch_is_caught():
-    @policy_function(unit=Unit.CURRENCY)
+    @policy_function(unit=TTSIMUnit.CURRENCY)
     def mislabelled(age_in_years: float) -> float:
         return age_in_years * 2.0
 
-    @policy_input(unit=Unit.YEARS)
+    @policy_input(unit=TTSIMUnit.YEARS)
     def age_in_years() -> float:
         """An age."""
 
@@ -2373,6 +2545,7 @@ def test_concrete_mismatch_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"age_in_years": age_in_years, "mislabelled": mislabelled},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2385,7 +2558,7 @@ def test_dict_param_subscripting_is_verifiable():
         end_date=_END,
     )
 
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def claim_of_child_y(is_exempt: bool, schedule: dict) -> float:
         if is_exempt:
             return 0.0
@@ -2398,9 +2571,10 @@ def test_dict_param_subscripting_is_verifiable():
             "claim_of_child_y": claim_of_child_y,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def claim_of_child_m(is_exempt: bool, schedule: dict) -> float:
         if is_exempt:
             return 0.0
@@ -2414,6 +2588,7 @@ def test_dict_param_subscripting_is_verifiable():
                 "claim_of_child_m": claim_of_child_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2425,11 +2600,11 @@ def test_uniform_dict_param_is_subscriptable_in_dry_run():
         end_date=_END,
     )
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def number_of_adults() -> int:
         """A head count — dimensionless (GEP 10)."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def subsistence_income_m(subsistence: dict, number_of_adults: int) -> float:
         return subsistence["per_spouse"] * number_of_adults
 
@@ -2440,6 +2615,7 @@ def test_uniform_dict_param_is_subscriptable_in_dry_run():
             "subsistence_income_m": subsistence_income_m,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -2484,7 +2660,7 @@ def child_rate(raw_child_rate: RawParamValue) -> _ChildRate:
     )
 
 
-@policy_input(unit=Unit.YEARS)
+@policy_input(unit=TTSIMUnit.YEARS)
 def age() -> int:
     """A duration in years (a person's age)."""
 
@@ -2515,10 +2691,12 @@ def test_missing_check_reports_uncovered_require_converter_leaf():
 def test_structured_plucks_with_casts_are_verifiable():
     """Casting each pluck keeps the rest of the body checked (GEP 10)."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def child_benefit_m(age: int, child_rate: _ChildRate) -> float:
-        amount_m = cast_unit(value=child_rate.amount_m, unit=Unit.CURRENCY.PER_MONTH)
-        max_age = cast_unit(value=child_rate.bounds.max_age, unit=Unit.YEARS)
+        amount_m = cast_unit(
+            value=child_rate.amount_m, unit=TTSIMUnit.CURRENCY.PER_MONTH
+        )
+        max_age = cast_unit(value=child_rate.bounds.max_age, unit=TTSIMUnit.YEARS)
         if age <= max_age:
             return amount_m
         return 0.0
@@ -2531,14 +2709,17 @@ def test_structured_plucks_with_casts_are_verifiable():
             "child_benefit_m": child_benefit_m,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_structured_pluck_used_without_cast_is_caught():
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def child_benefit_m(age: int, child_rate: _ChildRate) -> float:
         if age <= child_rate.bounds.max_age:  # bug: pluck used as a quantity
-            return cast_unit(value=child_rate.amount_m, unit=Unit.CURRENCY.PER_MONTH)
+            return cast_unit(
+                value=child_rate.amount_m, unit=TTSIMUnit.CURRENCY.PER_MONTH
+            )
         return 0.0
 
     with pytest.raises(UnitConsistencyError, match="cast_unit"):
@@ -2549,11 +2730,12 @@ def test_structured_pluck_used_without_cast_is_caught():
                 "child_benefit_m": child_benefit_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_structured_pluck_returned_without_cast_is_caught():
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def child_benefit_m(child_rate: _ChildRate) -> float:
         return child_rate.amount_m  # bug: returned without stating its unit
 
@@ -2561,6 +2743,7 @@ def test_structured_pluck_returned_without_cast_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"child_rate": child_rate, "child_benefit_m": child_benefit_m},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2568,11 +2751,13 @@ def test_structured_cast_too_coarse_fails_on_the_deeper_pluck():
     """A cast on a sub-structure yields a plain quantity, so the next deeper
     pluck fails loudly — a too-coarse cast can never silently mis-tag."""
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def child_benefit_m(age: int, child_rate: _ChildRate) -> float:
-        bounds = cast_unit(value=child_rate.bounds, unit=Unit.YEARS)  # too coarse
+        bounds = cast_unit(value=child_rate.bounds, unit=TTSIMUnit.YEARS)  # too coarse
         if age <= bounds.max_age:
-            return cast_unit(value=child_rate.amount_m, unit=Unit.CURRENCY.PER_MONTH)
+            return cast_unit(
+                value=child_rate.amount_m, unit=TTSIMUnit.CURRENCY.PER_MONTH
+            )
         return 0.0
 
     with pytest.raises(UnitConsistencyError, match="verify_units=False"):
@@ -2583,6 +2768,7 @@ def test_structured_cast_too_coarse_fails_on_the_deeper_pluck():
                 "child_benefit_m": child_benefit_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2594,13 +2780,13 @@ def test_structured_cast_too_coarse_fails_on_the_deeper_pluck():
 
 @dataclass(frozen=True)
 class _AnnotatedAgeBounds:
-    min_age: Annotated[int, Unit.YEARS]
-    max_age: Annotated[int, Unit.YEARS]
+    min_age: Annotated[int, TTSIMUnit.YEARS]
+    max_age: Annotated[int, TTSIMUnit.YEARS]
 
 
 @dataclass(frozen=True)
 class _AnnotatedChildRate:
-    amount_m: Annotated[float, Unit.CURRENCY.PER_MONTH]
+    amount_m: Annotated[float, TTSIMUnit.CURRENCY.PER_MONTH]
     bounds: _AnnotatedAgeBounds
 
 
@@ -2617,7 +2803,7 @@ def annotated_child_rate(raw_child_rate: RawParamValue) -> _AnnotatedChildRate:
 
 
 def test_annotated_fields_resolve_plucks_without_casts():
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def child_benefit_m(age: int, annotated_child_rate: _AnnotatedChildRate) -> float:
         if age <= annotated_child_rate.bounds.max_age:
             return annotated_child_rate.amount_m
@@ -2631,11 +2817,12 @@ def test_annotated_fields_resolve_plucks_without_casts():
             "child_benefit_m": child_benefit_m,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_annotated_pluck_misuse_is_caught():
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def child_benefit_m(age: int, annotated_child_rate: _AnnotatedChildRate) -> float:
         return annotated_child_rate.amount_m + age  # bug: money plus a duration
 
@@ -2648,12 +2835,13 @@ def test_annotated_pluck_misuse_is_caught():
                 "child_benefit_m": child_benefit_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 @dataclass(frozen=True)
 class _PartiallyAnnotatedRate:
-    amount_m: Annotated[float, Unit.CURRENCY.PER_MONTH]
+    amount_m: Annotated[float, TTSIMUnit.CURRENCY.PER_MONTH]
     max_age: int
 
 
@@ -2666,7 +2854,7 @@ def partially_annotated_rate(raw_child_rate: RawParamValue) -> _PartiallyAnnotat
 
 
 def test_unannotated_field_keeps_the_cast_requirement():
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def benefit_m(age: int, partially_annotated_rate: _PartiallyAnnotatedRate) -> float:
         if age <= partially_annotated_rate.max_age:  # bug: opaque pluck, no cast
             return partially_annotated_rate.amount_m
@@ -2681,12 +2869,13 @@ def test_unannotated_field_keeps_the_cast_requirement():
                 "benefit_m": benefit_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 @dataclass(frozen=True)
 class _DriftingChildRate:
-    amount_m: Annotated[float, Unit.YEARS]
+    amount_m: Annotated[float, TTSIMUnit.YEARS]
 
 
 @param_function(unit=UNSET_UNIT)
@@ -2705,6 +2894,7 @@ def test_field_annotation_drifting_from_the_unit_mapping_is_rejected():
                 "drifting_child_rate": drifting_child_rate,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2726,12 +2916,13 @@ def test_concrete_currency_field_annotation_is_rejected():
                 "concrete_currency_rate": concrete_currency_rate,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 @dataclass(frozen=True)
 class _ContainerRate:
-    amounts_m: Annotated[dict[str, float], Unit.CURRENCY.PER_MONTH]
+    amounts_m: Annotated[dict[str, float], TTSIMUnit.CURRENCY.PER_MONTH]
 
 
 @param_function(unit=UNSET_UNIT)
@@ -2749,6 +2940,7 @@ def test_container_field_annotation_is_rejected():
                 "container_rate": container_rate,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2765,7 +2957,7 @@ def built_schedule(
 
 
 def test_piecewise_call_on_converter_built_schedule_is_cast_at_the_call():
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def levy_y(
         bonus_y: float,
         built_schedule: PiecewisePolynomialParamValue,
@@ -2773,17 +2965,18 @@ def test_piecewise_call_on_converter_built_schedule_is_cast_at_the_call():
     ) -> float:
         return cast_unit(
             value=piecewise_polynomial(x=bonus_y, parameters=built_schedule, xnp=xnp),
-            unit=Unit.CURRENCY.PER_YEAR,
+            unit=TTSIMUnit.CURRENCY.PER_YEAR,
         )
 
     fail_if_environment_units_are_inconsistent(
         env={"bonus_y": bonus_y, "built_schedule": built_schedule, "levy_y": levy_y},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_piecewise_call_on_converter_built_schedule_without_cast_is_caught():
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def levy_y(
         bonus_y: float,
         built_schedule: PiecewisePolynomialParamValue,
@@ -2799,6 +2992,7 @@ def test_piecewise_call_on_converter_built_schedule_without_cast_is_caught():
                 "levy_y": levy_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2831,7 +3025,7 @@ def levy_schedule(
 
 
 def test_axes_declared_schedule_screens_consumer_without_cast():
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def levy_y(
         wealth: float,
         levy_schedule: PiecewisePolynomialParamValue,
@@ -2847,11 +3041,12 @@ def test_axes_declared_schedule_screens_consumer_without_cast():
             "levy_y": levy_y,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_axes_declared_schedule_rejects_wrong_domain_argument():
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def levy_y(
         age: int,
         levy_schedule: PiecewisePolynomialParamValue,
@@ -2868,11 +3063,12 @@ def test_axes_declared_schedule_rejects_wrong_domain_argument():
                 "levy_y": levy_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_axes_declared_schedule_output_reaches_the_consumer_declaration():
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def levy_m(
         wealth: float,
         levy_schedule: PiecewisePolynomialParamValue,
@@ -2889,6 +3085,7 @@ def test_axes_declared_schedule_output_reaches_the_consumer_declaration():
                 "levy_m": levy_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2904,11 +3101,12 @@ def test_axes_consumer_without_schedule_return_annotation_is_rejected():
                 "levy_params": levy_params,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_axes_consumer_with_quantity_unit_is_rejected():
-    @param_function(unit=Unit.CURRENCY.PER_YEAR)
+    @param_function(unit=TTSIMUnit.CURRENCY.PER_YEAR)
     def levy_ceiling_y(raw_levy_schedule: RawParamValue) -> float:
         return raw_levy_schedule["ceiling"]
 
@@ -2919,6 +3117,69 @@ def test_axes_consumer_with_quantity_unit_is_rejected():
                 "levy_ceiling_y": levy_ceiling_y,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_schedule_param_function_declared_unit_flows_into_look_up_without_cast():
+    """A schedule-returning ``@param_function`` may declare its **own** output
+    unit (rather than deriving it from a require_converter's axes): ``look_up``
+    then yields that unit at the consumer with no ``cast_unit``. Used where the
+    raw keeps honest per-key units that cannot collapse to a single axis (GEP
+    10)."""
+
+    @param_function(unit=TTSIMUnit.SQUARE_METER.PER_FAM)
+    def eligible_area(xnp: ModuleType) -> ConsecutiveIntLookupTableParamValue:
+        return ConsecutiveIntLookupTableParamValue(
+            xnp=xnp,
+            values_to_look_up=xnp.array([45.0, 60.0]),
+            bases_to_subtract=xnp.array([1]),
+        )
+
+    @policy_function(unit=TTSIMUnit.SQUARE_METER.PER_FAM)
+    def area_fam(
+        statutory_age: int, eligible_area: ConsecutiveIntLookupTableParamValue
+    ) -> float:
+        return eligible_area.look_up(statutory_age)
+
+    fail_if_environment_units_are_inconsistent(
+        env={
+            "statutory_age": statutory_age,
+            "eligible_area": eligible_area,
+            "area_fam": area_fam,
+        },
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_schedule_param_function_declared_unit_screens_a_mismatched_consumer():
+    """The declared output unit is a real contract: a ``look_up`` result fed into
+    a disagreeing consumer declaration is caught (GEP 10)."""
+
+    @param_function(unit=TTSIMUnit.SQUARE_METER.PER_FAM)
+    def eligible_area(xnp: ModuleType) -> ConsecutiveIntLookupTableParamValue:
+        return ConsecutiveIntLookupTableParamValue(
+            xnp=xnp,
+            values_to_look_up=xnp.array([45.0, 60.0]),
+            bases_to_subtract=xnp.array([1]),
+        )
+
+    @policy_function(unit=TTSIMUnit.SQUARE_METER)
+    def area_per_person(
+        statutory_age: int, eligible_area: ConsecutiveIntLookupTableParamValue
+    ) -> float:
+        return eligible_area.look_up(statutory_age)
+
+    with pytest.raises(UnitConsistencyError, match="area_per_person"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "statutory_age": statutory_age,
+                "eligible_area": eligible_area,
+                "area_per_person": area_per_person,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2943,6 +3204,7 @@ def test_converter_of_two_input_output_unit_params_is_rejected():
                 "merged_schedule": merged_schedule,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2955,7 +3217,7 @@ def test_verify_units_false_skips_body_inference():
     # A body whose dry-run would otherwise flag a mismatch (stock * share is a
     # stock, not the declared yearly flow) is not dry-run when it opts out; the
     # declared unit still stands (GEP 10).
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR, verify_units=False)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR, verify_units=False)
     def amount_optout_y(wealth: float, tax_rate: float, is_exempt: bool) -> float:
         if is_exempt:
             return 0.0
@@ -2969,17 +3231,18 @@ def test_verify_units_false_skips_body_inference():
             "amount_optout_y": amount_optout_y,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_verify_units_false_still_checks_consumers_against_declared_unit():
     # The opt-out is local to the body: the declared unit is still the edge
     # contract, so a consumer that misuses the producer is still caught.
-    @policy_function(unit=Unit.CURRENCY.PER_YEAR, verify_units=False)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_YEAR, verify_units=False)
     def producer_y(wealth: float) -> float:
         return wealth.this_does_not_exist()  # ty: ignore[unresolved-attribute]
 
-    @policy_function(unit=Unit.YEARS)
+    @policy_function(unit=TTSIMUnit.YEARS)
     def consumer(producer_y: float) -> float:
         return producer_y
 
@@ -2987,6 +3250,7 @@ def test_verify_units_false_still_checks_consumers_against_declared_unit():
         fail_if_environment_units_are_inconsistent(
             env={"wealth": wealth, "producer_y": producer_y, "consumer": consumer},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -2995,51 +3259,50 @@ def test_verify_units_false_still_checks_consumers_against_declared_unit():
 # ----------------------------------------------------------------------------
 
 
-def test_count_aggregation_auto_assigns_person_per_group():
-    @agg_by_group_function(agg_type=AggType.COUNT)
+def test_count_aggregation_declares_person_per_group():
+    """A COUNT declares its head-count unit explicitly — ``PERSON_COUNT_PER_<group>``,
+    the person leaf implied (GEP 10)."""
+
+    @agg_by_group_function(agg_type=AggType.COUNT, unit=TTSIMUnit.PERSON_COUNT.PER_FAM)
     def number_of_individuals_fam(fam_id: int) -> int:
-        """A head count per family — PERSON_COUNT_PER_FAM (GEP 10)."""
+        """A head count per family."""
 
-    assert number_of_individuals_fam.unit == Unit.PERSON_COUNT.PER_FAM
+    assert number_of_individuals_fam.unit == TTSIMUnit.PERSON_COUNT.PER_FAM
 
 
-def test_any_aggregation_auto_assigns_dimensionless_at_target_level():
-    # ANY/ALL yield a boolean at the target level (GEP 10): a group aggregation
-    # auto-assigns DIMENSIONLESS_PER_<target>, the person leaf being implied.
-    @agg_by_group_function(agg_type=AggType.ANY)
+def test_any_aggregation_declares_dimensionless_at_target_level():
+    """A group ANY declares ``DIMENSIONLESS_PER_<group>`` — a boolean at the target
+    level, the person leaf implied (GEP 10)."""
+
+    @agg_by_group_function(agg_type=AggType.ANY, unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
     def any_exempt_fam(is_exempt: bool, fam_id: int) -> bool:
         """Any member exempt."""
 
-    assert any_exempt_fam.unit == Unit.DIMENSIONLESS.PER_FAM
+    assert any_exempt_fam.unit == TTSIMUnit.DIMENSIONLESS.PER_FAM
 
 
 def test_sum_aggregation_requires_explicit_unit():
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.CURRENCY)
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.CURRENCY)
     def wealth_fam(wealth: float, fam_id: int) -> float:
         """Family wealth."""
 
-    assert wealth_fam.unit is Unit.CURRENCY
+    assert wealth_fam.unit is TTSIMUnit.CURRENCY
 
-    @agg_by_group_function(agg_type=AggType.SUM)
-    def unannotated_fam(wealth: float, fam_id: int) -> float:
-        """Missing its unit."""
+    with pytest.raises(AggregationDefinitionError, match="must declare a `unit"):
 
-    assert unannotated_fam.unit is UNSET_UNIT
-    with pytest.raises(UnitDefinitionError, match="unannotated_fam"):
-        fail_if_environment_units_are_missing(
-            env={"unannotated_fam": unannotated_fam},
-            grouping_levels=GROUPING_LEVELS,
-        )
+        @agg_by_group_function(agg_type=AggType.SUM)
+        def unannotated_fam(wealth: float, fam_id: int) -> float:
+            """Missing its unit."""
 
 
 def test_sum_aggregation_over_booleans_declares_dimensionless():
     # A sum over a boolean column is a plain head count — declared
-    # dimensionless via an explicit `unit=Unit.DIMENSIONLESS` (GEP 10).
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.DIMENSIONLESS)
+    # dimensionless via an explicit `unit=TTSIMUnit.DIMENSIONLESS` (GEP 10).
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.DIMENSIONLESS)
     def number_of_exempt_fam(is_exempt: bool, fam_id: int) -> int:
         """The number of exempt members per family."""
 
-    assert number_of_exempt_fam.unit is Unit.DIMENSIONLESS
+    assert number_of_exempt_fam.unit is TTSIMUnit.DIMENSIONLESS
     fail_if_environment_units_are_missing(
         env={"number_of_exempt_fam": number_of_exempt_fam},
         grouping_levels=GROUPING_LEVELS,
@@ -3051,7 +3314,7 @@ def test_aggregation_must_spell_the_derived_grouping_level():
     declaring a bare ``CURRENCY`` (omitting the derived ``[fam]`` level) is rejected
     — there is no implicit matching of group levels, the author spells it (GEP 10)."""
 
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.CURRENCY)
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.CURRENCY)
     def wealth_fam(wealth: float, fam_id: int) -> float:
         """A family sum that fails to spell its [fam] level."""
 
@@ -3059,6 +3322,7 @@ def test_aggregation_must_spell_the_derived_grouping_level():
         fail_if_environment_units_are_inconsistent(
             env={"wealth": wealth, "wealth_fam": wealth_fam},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3066,13 +3330,14 @@ def test_aggregation_with_the_precise_derived_unit_passes():
     """The full, precise declaration — kind, period, *and* level — matches the
     derived unit and passes (GEP 10)."""
 
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.CURRENCY.PER_FAM)
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.CURRENCY.PER_FAM)
     def wealth_fam(wealth: float, fam_id: int) -> float:
         """Family wealth, level spelled."""
 
     fail_if_environment_units_are_inconsistent(
         env={"wealth": wealth, "wealth_fam": wealth_fam},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -3080,7 +3345,7 @@ def test_aggregation_with_spelled_wrong_grouping_level_is_caught():
     """A spelled grouping level that contradicts the derivation is rejected: a
     ``_fam`` sum declaring ``CURRENCY_PER_KIN`` derives ``[fam]`` (GEP 10)."""
 
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.CURRENCY.PER_KIN)
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.CURRENCY.PER_KIN)
     def wealth_fam(wealth: float, fam_id: int) -> float:
         """A family sum mis-declared at the kin level."""
 
@@ -3088,12 +3353,13 @@ def test_aggregation_with_spelled_wrong_grouping_level_is_caught():
         fail_if_environment_units_are_inconsistent(
             env={"wealth": wealth, "wealth_fam": wealth_fam},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_aggregation_decorator_rejects_invalid_unit():
     # Strings are not tokens: the decorator's type contract only admits
-    # `Unit` members (or None), enforced by the beartype claw.
+    # `TTSIMUnit` members (or None), enforced by the beartype claw.
     with pytest.raises(AggregationDefinitionError, match="unit"):
 
         @agg_by_group_function(agg_type=AggType.SUM, unit="kelvin")  # ty: ignore[invalid-argument-type]
@@ -3107,18 +3373,20 @@ def test_aggregation_decorator_rejects_invalid_unit():
 
 
 def test_param_function_unit_resolves_via_leaf_name_suffix():
-    @param_function(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @param_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def max_amount_m_fam(policy_year: int) -> float:
         return float(policy_year)
 
     resolved = resolve_environment_units(
         env={"max_amount_m_fam": max_amount_m_fam},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     # The `_fam` suffix puts this flow at the family level (GEP 10).
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="max_amount_m_fam"),
-        right=parse_unit("CURRENCY / month / grouping_level_fam"),
+        right=parse_unit("CURRENCY / month / grouping_level_fam", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -3130,13 +3398,15 @@ def test_param_function_unit_resolves_via_leaf_name_suffix():
 def test_scalar_param_with_agnostic_currency_token_fails():
     threshold = ScalarParam(
         value=100.0,
-        unit=Unit.CURRENCY,
+        unit=TTSIMUnit.CURRENCY,
         start_date=_START,
         end_date=_END,
     )
     with pytest.raises(UnitDefinitionError, match="pin down the concrete currency"):
         resolve_environment_units(
-            env={"threshold": threshold}, grouping_levels=GROUPING_LEVELS
+            env={"threshold": threshold},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3149,7 +3419,9 @@ def test_dict_param_leaf_with_agnostic_currency_token_fails():
     )
     with pytest.raises(UnitDefinitionError, match="pin down the concrete currency"):
         resolve_environment_units(
-            env={"schedule": schedule}, grouping_levels=GROUPING_LEVELS
+            env={"schedule": schedule},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3163,11 +3435,14 @@ def test_concrete_currency_token_resolves_like_agnostic_counterpart():
         end_date=_END,
     )
     resolved = resolve_environment_units(
-        env={"threshold": threshold}, grouping_levels=GROUPING_LEVELS
+        env={"threshold": threshold},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="threshold"),
-        right=parse_unit("CURRENCY / grouping_level_person"),
+        right=parse_unit("CURRENCY / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -3201,26 +3476,32 @@ def test_param_mapping_object_resolves_output_axis():
         output_unit=CASTAR_PER_YEAR,
     )
     resolved = resolve_environment_units(
-        env={"schedule": schedule}, grouping_levels=GROUPING_LEVELS
+        env={"schedule": schedule},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="schedule"),
-        right=parse_unit("CURRENCY / year / grouping_level_person"),
+        right=parse_unit("CURRENCY / year / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_param_mapping_object_complete_input_axis_with_flow_output():
     # The property-tax shape: hectares in, a yearly currency flow out.
     schedule = _make_schedule_param(
-        input_unit=Unit.HECTARE,
+        input_unit=TTSIMUnit.HECTARE,
         output_unit=CASTAR_PER_YEAR,
     )
     resolved = resolve_environment_units(
-        env={"schedule": schedule}, grouping_levels=GROUPING_LEVELS
+        env={"schedule": schedule},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="schedule"),
-        right=parse_unit("CURRENCY / year / grouping_level_person"),
+        right=parse_unit("CURRENCY / year / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -3229,11 +3510,12 @@ def test_param_mapping_object_rejects_agnostic_currency_axis():
         resolve_environment_units(
             env={
                 "schedule": _make_schedule_param(
-                    input_unit=Unit.CURRENCY.PER_YEAR,
+                    input_unit=TTSIMUnit.CURRENCY.PER_YEAR,
                     output_unit=CASTAR_PER_YEAR,
                 )
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3254,7 +3536,7 @@ def test_auto_generated_boolean_group_aggregate_passes_the_build():
     DIMENSIONLESS_PER_FAM while the resolver derived [person]/[fam], so the build
     rejected its own auto-assignment. It must now pass unchanged (GEP 10)."""
 
-    @policy_function(leaf_name="is_adult", unit=Unit.DIMENSIONLESS)
+    @policy_function(leaf_name="is_adult", unit=TTSIMUnit.DIMENSIONLESS)
     def is_adult() -> bool:
         return True
 
@@ -3269,6 +3551,7 @@ def test_auto_generated_boolean_group_aggregate_passes_the_build():
     fail_if_environment_units_are_inconsistent(
         env={"is_adult": is_adult, "is_adult_fam": aggs["is_adult_fam"]},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -3277,38 +3560,44 @@ def test_opted_out_aggregation_declares_its_own_level():
     and resolves the *declared* unit, so a MEAN can be stated ``PER_KIN`` (a kin
     property) even though the algebra derives it as the person's (GEP 10)."""
 
-    @policy_input(unit=Unit.CURRENCY)
+    @policy_input(unit=TTSIMUnit.CURRENCY)
     def wealth() -> float: ...
 
     @agg_by_group_function(
-        agg_type=AggType.MEAN, unit=Unit.CURRENCY.PER_KIN, verify_units=False
+        agg_type=AggType.MEAN, unit=TTSIMUnit.CURRENCY.PER_KIN, verify_units=False
     )
     def average_wealth_kin(kin_id: int, wealth: float) -> float: ...
 
     env = {"wealth": wealth, "average_wealth_kin": average_wealth_kin}
-    resolved = resolve_environment_units(env=env, grouping_levels=GROUPING_LEVELS)
+    resolved = resolve_environment_units(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="average_wealth_kin"),
-        right=parse_unit("CURRENCY / grouping_level_kin"),
+        right=parse_unit("CURRENCY / grouping_level_kin", registry=REGISTRY),
+        registry=REGISTRY,
     )
     # No declared-vs-derived rejection despite the MEAN deriving the person level.
-    fail_if_environment_units_are_inconsistent(env=env, grouping_levels=GROUPING_LEVELS)
+    fail_if_environment_units_are_inconsistent(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )
 
 
 def test_aggregation_without_opt_out_still_rejects_a_wrong_level():
     """Without the opt-out, the same ``PER_KIN`` declaration on a MEAN is rejected —
     the opt-out is the only way to override the derivation (GEP 10)."""
 
-    @policy_input(unit=Unit.CURRENCY)
+    @policy_input(unit=TTSIMUnit.CURRENCY)
     def wealth() -> float: ...
 
-    @agg_by_group_function(agg_type=AggType.MEAN, unit=Unit.CURRENCY.PER_KIN)
+    @agg_by_group_function(agg_type=AggType.MEAN, unit=TTSIMUnit.CURRENCY.PER_KIN)
     def average_wealth_kin(kin_id: int, wealth: float) -> float: ...
 
     with pytest.raises(UnitConsistencyError, match="average_wealth_kin"):
         fail_if_environment_units_are_inconsistent(
             env={"wealth": wealth, "average_wealth_kin": average_wealth_kin},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3316,13 +3605,13 @@ def test_count_and_sum_of_boolean_both_mint_head_counts():
     """A COUNT and a SUM over a boolean are both head counts (GEP 10): each
     resolves to [person]/[target], not DIMENSIONLESS."""
 
-    @agg_by_group_function(agg_type=AggType.COUNT)
+    @agg_by_group_function(agg_type=AggType.COUNT, unit=TTSIMUnit.PERSON_COUNT.PER_FAM)
     def number_of_individuals_fam(fam_id: int) -> int: ...
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def is_adult() -> bool: ...
 
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.DIMENSIONLESS)
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.DIMENSIONLESS)
     def number_of_adults_fam(fam_id: int, is_adult: bool) -> int: ...
 
     resolved = resolve_environment_units(
@@ -3332,15 +3621,20 @@ def test_count_and_sum_of_boolean_both_mint_head_counts():
             "number_of_adults_fam": number_of_adults_fam,
         },
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
-    head_count = parse_unit("grouping_level_person / grouping_level_fam")
+    head_count = parse_unit(
+        "grouping_level_person / grouping_level_fam", registry=REGISTRY
+    )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="number_of_individuals_fam"),
         right=head_count,
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="number_of_adults_fam"),
         right=head_count,
+        registry=REGISTRY,
     )
 
 
@@ -3348,13 +3642,13 @@ def test_per_capita_division_bridges_via_head_count():
     """A group total divided by a head count type-checks to a per-person amount:
     (CURRENCY/[fam]) / ([person]/[fam]) = CURRENCY/[person] (GEP 10)."""
 
-    @agg_by_group_function(agg_type=AggType.COUNT)
+    @agg_by_group_function(agg_type=AggType.COUNT, unit=TTSIMUnit.PERSON_COUNT.PER_FAM)
     def number_of_individuals_fam(fam_id: int) -> int: ...
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def rent_m_fam() -> float: ...
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def rent_per_head_m(rent_m_fam: float, number_of_individuals_fam: int) -> float:
         return rent_m_fam / number_of_individuals_fam
 
@@ -3363,13 +3657,80 @@ def test_per_capita_division_bridges_via_head_count():
         "rent_m_fam": rent_m_fam,
         "rent_per_head_m": rent_per_head_m,
     }
-    resolved = resolve_environment_units(env=env, grouping_levels=GROUPING_LEVELS)
+    resolved = resolve_environment_units(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )
     assert units_are_equivalent(
         left=_scalar_unit(resolved=resolved, qname="rent_per_head_m"),
-        right=parse_unit("CURRENCY / month / grouping_level_person"),
+        right=parse_unit("CURRENCY / month / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )
     # The [fam] cancels against the count's [person]/[fam] — no level mismatch.
-    fail_if_environment_units_are_inconsistent(env=env, grouping_levels=GROUPING_LEVELS)
+    fail_if_environment_units_are_inconsistent(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )
+
+
+def test_cast_unit_literal_clamp_floor_inside_max_is_checkable():
+    """A ``cast_unit(0, …)`` clamp floor inside ``max()`` is dry-run-checkable: the
+    tagged literal participates in the ordering screen like any quantity, so the
+    body infers its declared unit rather than reporting as un-evaluable (GEP 10)."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def wage_m() -> float: ...
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def clamped_wage_m(wage_m: float) -> float:
+        return max(wage_m, cast_unit(0, TTSIMUnit.CURRENCY.PER_MONTH))
+
+    fail_if_environment_units_are_inconsistent(
+        env={"wage_m": wage_m, "clamped_wage_m": clamped_wage_m},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_cast_unit_literal_participates_in_every_screened_op():
+    """A cast literal is a first-class dry-run operand across the screened ops, not
+    only ``max``/``min``: arithmetic (``*``/``+``), an ordering comparison, and a
+    ``where`` (ternary) all check with a cast literal on one side (GEP 10)."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def wage_m() -> float: ...
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def floored_m(wage_m: float) -> float:
+        floor = cast_unit(0, TTSIMUnit.CURRENCY.PER_MONTH)
+        bonus = cast_unit(100, TTSIMUnit.CURRENCY.PER_MONTH) * cast_unit(
+            1, TTSIMUnit.DIMENSIONLESS
+        )
+        return (wage_m + bonus) if wage_m > floor else floor
+
+    fail_if_environment_units_are_inconsistent(
+        env={"wage_m": wage_m, "floored_m": floored_m},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_cast_unit_literal_with_wrong_unit_is_still_screened():
+    """The cast literal is checked, not waved through: currency ordered against a
+    ``YEARS``-tagged literal is rejected as a unit mismatch, not reported as an
+    un-evaluable body (GEP 10)."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def wage_m() -> float: ...
+
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
+    def wage_is_positive(wage_m: float) -> bool:
+        return wage_m > cast_unit(0, TTSIMUnit.YEARS)
+
+    with pytest.raises(UnitConsistencyError, match="wage_is_positive"):
+        fail_if_environment_units_are_inconsistent(
+            env={"wage_m": wage_m, "wage_is_positive": wage_is_positive},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
 
 
 def test_cross_group_level_subtraction_in_a_body_is_caught():
@@ -3381,13 +3742,13 @@ def test_cross_group_level_subtraction_in_a_body_is_caught():
     headline cross-level bug the dry-run must reject.
     """
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def income_m_fam() -> float: ...
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_KIN)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_KIN)
     def income_m_kin() -> float: ...
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def difference_m_fam(income_m_fam: float, income_m_kin: float) -> float:
         return income_m_fam - income_m_kin
 
@@ -3399,6 +3760,7 @@ def test_cross_group_level_subtraction_in_a_body_is_caught():
                 "difference_m_fam": difference_m_fam,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3410,13 +3772,13 @@ def test_person_versus_group_level_subtraction_in_a_body_is_caught():
     explicit per-capita reconciliation, so the bare subtraction is rejected.
     """
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def income_m() -> float: ...
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def freibetrag_m_fam() -> float: ...
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def difference_m(income_m: float, freibetrag_m_fam: float) -> float:
         return income_m - freibetrag_m_fam
 
@@ -3428,6 +3790,7 @@ def test_person_versus_group_level_subtraction_in_a_body_is_caught():
                 "difference_m": difference_m,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3439,13 +3802,13 @@ def test_person_versus_group_level_ordering_comparison_is_caught():
     non-equivalent quantities is rejected — a distinct dry-run path from `<`.
     """
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def income_m() -> float: ...
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def schwelle_m_fam() -> float: ...
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def below_threshold(income_m: float, schwelle_m_fam: float) -> bool:
         return income_m < schwelle_m_fam
 
@@ -3457,6 +3820,7 @@ def test_person_versus_group_level_ordering_comparison_is_caught():
                 "below_threshold": below_threshold,
             },
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3467,19 +3831,20 @@ def test_same_group_level_addition_in_a_body_passes():
     merely seeing a group suffix — ``a_m_fam + b_m_fam`` is ``[fam] + [fam]``.
     """
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def a_m_fam() -> float: ...
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def b_m_fam() -> float: ...
 
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def total_m_fam(a_m_fam: float, b_m_fam: float) -> float:
         return a_m_fam + b_m_fam
 
     fail_if_environment_units_are_inconsistent(
         env={"a_m_fam": a_m_fam, "b_m_fam": b_m_fam, "total_m_fam": total_m_fam},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
@@ -3495,45 +3860,48 @@ def test_sum_over_boolean_declared_dimensionless_is_caught():
     declaration must be PERSON_COUNT_PER_FAM, not DIMENSIONLESS (GEP 10).
     """
 
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def adult() -> bool: ...
 
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.DIMENSIONLESS)
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.DIMENSIONLESS)
     def number_of_adults_fam(adult: bool, fam_id: int) -> int: ...
 
     with pytest.raises(UnitConsistencyError, match="number_of_adults_fam"):
         fail_if_environment_units_are_inconsistent(
             env={"adult": adult, "number_of_adults_fam": number_of_adults_fam},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
 def test_sum_over_boolean_declared_person_per_group_passes():
-    @policy_input(unit=Unit.DIMENSIONLESS)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def adult() -> bool: ...
 
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.PERSON_COUNT.PER_FAM)
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.PERSON_COUNT.PER_FAM)
     def number_of_adults_fam(adult: bool, fam_id: int) -> int: ...
 
     fail_if_environment_units_are_inconsistent(
         env={"adult": adult, "number_of_adults_fam": number_of_adults_fam},
         grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
     )
 
 
 def test_sum_of_currency_declared_with_wrong_kind_is_caught():
     """A SUM of a currency flow derives currency; declaring YEARS is rejected."""
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def income_m() -> float: ...
 
-    @agg_by_group_function(agg_type=AggType.SUM, unit=Unit.YEARS)
+    @agg_by_group_function(agg_type=AggType.SUM, unit=TTSIMUnit.YEARS)
     def income_m_fam(income_m: float, fam_id: int) -> float: ...
 
     with pytest.raises(UnitConsistencyError, match="income_m_fam"):
         fail_if_environment_units_are_inconsistent(
             env={"income_m": income_m, "income_m_fam": income_m_fam},
             grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
         )
 
 
@@ -3543,27 +3911,39 @@ def test_max_over_level_carrying_source_carries_the_target_group_level():
     CURRENCY/month/[fam], not the source [person], and is declared `..._PER_FAM`.
     """
 
-    @policy_input(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def income_m() -> float: ...
 
-    @agg_by_group_function(agg_type=AggType.MAX, unit=Unit.CURRENCY.PER_MONTH.PER_FAM)
+    @agg_by_group_function(
+        agg_type=AggType.MAX, unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM
+    )
     def income_max_m_fam(income_m: float, fam_id: int) -> float: ...
 
     env = {"income_m": income_m, "income_max_m_fam": income_max_m_fam}
-    resolved = resolve_environment_units(env=env, grouping_levels=GROUPING_LEVELS)
+    resolved = resolve_environment_units(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )
     max_unit = _scalar_unit(resolved=resolved, qname="income_max_m_fam")
     # The MAX carries the target [fam] level, not the source [person] level.
     assert units_are_equivalent(
         left=max_unit,
         right=divide_by_grouping_level(
-            unit=parse_unit("CURRENCY / month"), level="fam"
+            unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+            level="fam",
+            registry=REGISTRY,
         ),
+        registry=REGISTRY,
     )
     assert not units_are_equivalent(
         left=max_unit,
         right=divide_by_grouping_level(
-            unit=parse_unit("CURRENCY / month"), level=PERSON_LEVEL
+            unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+            level=PERSON_LEVEL,
+            registry=REGISTRY,
         ),
+        registry=REGISTRY,
     )
     # The `_PER_FAM` declaration is consistent with what it derives.
-    fail_if_environment_units_are_inconsistent(env=env, grouping_levels=GROUPING_LEVELS)
+    fail_if_environment_units_are_inconsistent(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )

--- a/tests/interface_dag_elements/test_warnings.py
+++ b/tests/interface_dag_elements/test_warnings.py
@@ -10,7 +10,7 @@ import pytest
 from mettsim import middle_earth
 
 from ttsim import InputData, MainTarget, OrigPolicyObjects, TTTargets, main
-from ttsim.tt import ScalarParam, Unit, group_creation_function, policy_function
+from ttsim.tt import ScalarParam, TTSIMUnit, group_creation_function, policy_function
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -27,12 +27,12 @@ def minimal_data_tree():
     }
 
 
-@policy_function(unit=Unit.DIMENSIONLESS)
+@policy_function(unit=TTSIMUnit.DIMENSIONLESS)
 def some_func(p_id: int) -> int:
     return p_id
 
 
-@policy_function(unit=Unit.DIMENSIONLESS)
+@policy_function(unit=TTSIMUnit.DIMENSIONLESS)
 def another_func(some_func: int) -> int:
     return some_func
 
@@ -41,6 +41,7 @@ def mettsim_environment(backend) -> PolicyEnvironment:
     return main(
         main_target="policy_environment",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         policy_date=datetime.date(2025, 1, 1),
         backend=backend,
     )
@@ -49,7 +50,7 @@ def mettsim_environment(backend) -> PolicyEnvironment:
 @group_creation_function(
     leaf_name="sp_id",
     warn_msg_if_included="""You should pass `sp_id` as an input.""",
-    unit=Unit.DIMENSIONLESS,
+    unit=TTSIMUnit.DIMENSIONLESS,
 )
 def should_warn_sp_id(
     p_id: IntColumn, p_id_spouse: IntColumn, xnp: ModuleType
@@ -62,7 +63,7 @@ def should_warn_sp_id(
     return xnp.maximum(p_id, p_id_spouse) + xnp.minimum(p_id, p_id_spouse) * n
 
 
-@group_creation_function(leaf_name="fam_id", unit=Unit.DIMENSIONLESS)
+@group_creation_function(leaf_name="fam_id", unit=TTSIMUnit.DIMENSIONLESS)
 def dummy_fam_id(sp_id: IntColumn, xnp: ModuleType) -> IntColumn:  # noqa: ARG001
     """
     Just want to use this as a drop-in replacement for `fam_id` from METTSIM with
@@ -91,6 +92,7 @@ def test_warn_if_functions_and_data_columns_overlap(backend):
             rounding=False,
             include_fail_nodes=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -111,6 +113,7 @@ def test_warn_if_functions_and_columns_overlap_no_warning_if_no_overlap(backend)
             rounding=False,
             include_fail_nodes=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
         assert not w, f"Expected no warning, but got at least: {w[0].message}"
 
@@ -134,6 +137,7 @@ def test_warn_if_evaluation_date_set_in_multiple_places(backend):
             processed_data={},
             tt_targets=TTTargets.tree({}),
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -157,6 +161,7 @@ def test_warn_if_evaluation_date_set_in_multiple_places_implicitly_added(backend
             input_data=InputData.tree(tree={"p_id": xnp.array([0])}),
             tt_targets=TTTargets.tree({"p_id": None}),
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -178,6 +183,7 @@ def test_do_not_need_to_warn_if_evaluation_date_is_set_only_once(backend, xnp):
             input_data=InputData.tree(tree={"p_id": xnp.array([0])}),
             tt_targets=TTTargets.tree({"p_id": None}),
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
         assert not w, f"Expected no warning, but got at least: {w[0].message}"
 
@@ -198,6 +204,7 @@ def test_warn_if_tt_dag_includes_functions_with_warn_msg_if_included_set(
             tt_targets=TTTargets.tree({"fam_id": None}),
             input_data=InputData.tree(tree=minimal_data_tree),
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -214,4 +221,5 @@ def test_warn_if_tt_function_type_annotations_turned_off(
             input_data=InputData.tree(tree=minimal_data_tree),
             tt_function_set_annotations=False,
             backend=backend,
+            unit_system=middle_earth.UNIT_SYSTEM,
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,7 +44,7 @@ from ttsim.interface_dag_elements.specialized_environment_for_plotting_and_templ
     dummy_callable,
 )
 from ttsim.main_target import MainTarget
-from ttsim.tt import Unit
+from ttsim.tt import TTSIMUnit
 from ttsim.tt.column_objects_param_function import policy_function
 
 if TYPE_CHECKING:
@@ -108,7 +108,7 @@ def a() -> int:
     return 1
 
 
-@policy_function(unit=Unit.DIMENSIONLESS)
+@policy_function(unit=TTSIMUnit.DIMENSIONLESS)
 def e(c: int, d: float) -> float:
     return c + d
 
@@ -567,7 +567,10 @@ def test_harmonize_main_target(main_target, expected):
     ],
 )
 def test_fail_if_input_structure_is_invalid(dict_inputs):
-    with pytest.raises(ValueError, match=r"Invalid inputs for main()"):
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid inputs for main",
+    ):
         _fail_if_input_structure_is_invalid(
             user_treedef=optree.tree_flatten(dict_inputs)[1],
             expected_treedef=optree.tree_flatten(MainTarget.to_dict())[1],  # ty: ignore[invalid-argument-type]
@@ -632,6 +635,7 @@ def test_fail_if_data_is_provided_but_no_tt_targets(backend, xnp):
                 }
             ),
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
             backend=backend,
         )
 

--- a/tests/test_run_currency.py
+++ b/tests/test_run_currency.py
@@ -26,17 +26,9 @@ from ttsim.interface_dag_elements.results import tree_with_unit_annotations
 from ttsim.interface_dag_elements.warn_if import (
     statutory_currency_and_base_currency_differ,
 )
-from ttsim.tt.currencies import (
-    _statutory_currencies,
-    base_currency,
-    currency_conversion_factor,
-    isolated_currency_registration,
-    register_currency,
-    register_statutory_currencies,
-    statutory_currency_for_date,
-)
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.param_objects import RawParam
-from ttsim.tt.units import UNIT_REGISTRY, UNSET_UNIT
+from ttsim.tt.units import UNSET_UNIT
 from ttsim.warnings import PotentialCurrencyMismatchWarning
 
 POLICY_DATE = datetime.date(2020, 1, 1)
@@ -51,6 +43,7 @@ def _policy_environment(backend, policy_date=POLICY_DATE):
     return main(
         main_target=MainTarget.policy_environment,
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
         policy_date=policy_date,
         backend=backend,
     )
@@ -61,6 +54,7 @@ def test_data_currency_defaults_to_registered_base(backend):
         main(
             main_target=MainTarget.data_currency,
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
             policy_date=POLICY_DATE,
             backend=backend,
         )
@@ -82,6 +76,7 @@ def test_computation_currency_is_the_statutory_currency_at_the_policy_date(
         main(
             main_target=MainTarget.computation_currency,
             orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+            unit_system=middle_earth.UNIT_SYSTEM,
             policy_date=policy_date,
             backend=backend,
         )
@@ -510,31 +505,44 @@ def test_unknown_annotation_is_rejected_at_load():
 
 
 # --------------------------------------------------------------------------
-# A single interconvertible currency system plus the statutory mapping
-# (GEP 10). Registration rules are exercised inside
-# `isolated_currency_registration`, so nothing leaks.
+# A policy system's interconvertible currencies plus its statutory mapping
+# (GEP 10). Middle Earth's system is `middle_earth.UNIT_SYSTEM`; the rule tests
+# construct throwaway systems.
 # --------------------------------------------------------------------------
 
 
-def test_base_currency_is_the_registered_base():
-    assert base_currency() == "CASTAR"
+def _fresh_system(**overrides: Any) -> UnitSystem:
+    """A Middle-Earth-shaped system, with fields overridable per test."""
+    kwargs: dict[str, Any] = {
+        "base_currency": "CASTAR",
+        "other_currencies": {"SILVER_PENNY": "CASTAR / 4"},
+        "statutory_currencies": {"0001-01-01": "SILVER_PENNY", "2020-01-01": "CASTAR"},
+    }
+    kwargs.update(overrides)
+    return UnitSystem(**kwargs)
 
 
-def test_registered_currencies_are_interconvertible():
+def test_base_currency_is_the_declared_base():
+    assert middle_earth.UNIT_SYSTEM.base_currency == "CASTAR"
+
+
+def test_system_currencies_are_interconvertible():
     # silver_penny = castar / 4, so the factors are reciprocal.
-    assert currency_conversion_factor(
+    assert middle_earth.UNIT_SYSTEM.currency_conversion_factor(
         source_currency="SILVER_PENNY", target_currency="CASTAR"
     ) == pytest.approx(0.25)
-    assert currency_conversion_factor(
+    assert middle_earth.UNIT_SYSTEM.currency_conversion_factor(
         source_currency="CASTAR", target_currency="SILVER_PENNY"
     ) == pytest.approx(4.0)
 
 
 def test_currency_conversion_rejects_the_abstract_currency_token():
-    # The agnostic CURRENCY token is a pint unit but not a registered currency;
-    # conversion (and hence `data_currency=`) requires a concrete registered one.
+    # The agnostic CURRENCY token is a pint unit but not one of the system's
+    # currencies; conversion (and hence `data_currency=`) requires a concrete one.
     with pytest.raises(UnitDefinitionError, match="not a registered currency"):
-        currency_conversion_factor(source_currency="CURRENCY", target_currency="CASTAR")
+        middle_earth.UNIT_SYSTEM.currency_conversion_factor(
+            source_currency="CURRENCY", target_currency="CASTAR"
+        )
 
 
 def test_annotated_results_label_a_parameter_in_the_statutory_currency():
@@ -544,93 +552,55 @@ def test_annotated_results_label_a_parameter_in_the_statutory_currency():
     parameter and a column both resolve to the agnostic CURRENCY, so the label
     must follow the result category, not the resolved unit: the parameter's value
     is never converted, the column's is (GEP 10)."""
-    with isolated_currency_registration():
-        register_currency(name="CASTAR", base=True)
-        register_currency(name="SILVER_PENNY", definition="CASTAR / 4")
-        agnostic = UNIT_REGISTRY.parse_units("CURRENCY / month")
-        annotated = tree_with_unit_annotations(
-            tree={"a_param_m": 25.0, "a_column_m": np.array([1.0, 2.0])},
-            raw_results__from_input_data={},
-            raw_results__params={"a_param_m": 25.0},
-            unit_checks__resolved_units={"a_param_m": agnostic, "a_column_m": agnostic},
-            data_currency="CASTAR",
-            computation_currency="SILVER_PENNY",
-        )
-        labels = {qname: leaf.unit.base for qname, leaf in annotated.items()}
-        assert labels == {"a_param_m": "SILVER_PENNY", "a_column_m": "CASTAR"}
+    system = _fresh_system()
+    agnostic = system.registry.parse_units("CURRENCY / month")
+    annotated = tree_with_unit_annotations(
+        tree={"a_param_m": 25.0, "a_column_m": np.array([1.0, 2.0])},
+        raw_results__from_input_data={},
+        raw_results__params={"a_param_m": 25.0},
+        unit_checks__resolved_units={"a_param_m": agnostic, "a_column_m": agnostic},
+        data_currency="CASTAR",
+        computation_currency="SILVER_PENNY",
+        unit_system=system,
+    )
+    labels = {qname: leaf.unit.base for qname, leaf in annotated.items()}
+    assert labels == {"a_param_m": "SILVER_PENNY", "a_column_m": "CASTAR"}
 
 
-def test_a_second_base_currency_is_rejected():
-    # CASTAR is already the base; the process has a single base currency.
-    with (
-        isolated_currency_registration(),
-        pytest.raises(UnitDefinitionError, match="already the base"),
-    ):
-        register_currency(name="GOLD_DRAGON", base=True)
-
-
-def test_definition_referencing_no_registered_currency_is_rejected():
-    # A currency must be defined relative to an already-registered one; a
+def test_definition_referencing_no_system_currency_is_rejected():
+    # A currency must be defined relative to one the system already defines; a
     # definition against the abstract CURRENCY reference alone would start a
     # second, unconnected base.
-    with (
-        isolated_currency_registration(),
-        pytest.raises(UnitDefinitionError, match="no registered currency"),
-    ):
-        register_currency(name="FLOATING", definition="CURRENCY / 2")
+    with pytest.raises(UnitDefinitionError, match="no currency of this policy system"):
+        _fresh_system(other_currencies={"FLOATING": "CURRENCY / 2"})
 
 
 def test_statutory_currency_follows_the_dated_mapping():
-    assert statutory_currency_for_date(datetime.date(2019, 12, 31)) == "SILVER_PENNY"
-    assert statutory_currency_for_date(datetime.date(2020, 1, 1)) == "CASTAR"
-    assert statutory_currency_for_date(datetime.date(2025, 6, 1)) == "CASTAR"
+    system = middle_earth.UNIT_SYSTEM
+    assert (
+        system.statutory_currency_for_date(datetime.date(2019, 12, 31))
+        == "SILVER_PENNY"
+    )
+    assert system.statutory_currency_for_date(datetime.date(2020, 1, 1)) == "CASTAR"
+    assert system.statutory_currency_for_date(datetime.date(2025, 6, 1)) == "CASTAR"
 
 
 def test_statutory_currency_is_undefined_before_the_first_entry():
-    with isolated_currency_registration():
-        _statutory_currencies[:] = [(datetime.date(1900, 1, 1), "SILVER_PENNY")]
-        with pytest.raises(UnitDefinitionError, match="Extend the mapping"):
-            statutory_currency_for_date(datetime.date(1899, 12, 31))
+    system = _fresh_system(statutory_currencies={"1900-01-01": "SILVER_PENNY"})
+    with pytest.raises(UnitDefinitionError, match="Extend the mapping"):
+        system.statutory_currency_for_date(datetime.date(1899, 12, 31))
 
 
-def test_statutory_currency_requires_a_registered_mapping():
-    with isolated_currency_registration():
-        _statutory_currencies.clear()
-        with pytest.raises(UnitDefinitionError, match="No statutory-currency mapping"):
-            statutory_currency_for_date(datetime.date(2020, 1, 1))
+def test_empty_statutory_mapping_is_rejected():
+    with pytest.raises(UnitDefinitionError, match="at least one entry"):
+        _fresh_system(statutory_currencies={})
 
 
-def test_registering_an_empty_statutory_mapping_is_rejected():
-    with (
-        isolated_currency_registration(),
-        pytest.raises(UnitDefinitionError, match="at least one entry"),
+def test_statutory_mapping_must_reference_system_currencies():
+    with pytest.raises(
+        UnitDefinitionError, match="not a currency of this policy system"
     ):
-        register_statutory_currencies({})
-
-
-def test_statutory_mapping_must_reference_registered_currencies():
-    with (
-        isolated_currency_registration(),
-        pytest.raises(UnitDefinitionError, match="not registered"),
-    ):
-        register_statutory_currencies({"1900-01-01": "GOLD_DRAGON"})
-
-
-def test_a_different_statutory_mapping_is_rejected():
-    # mettsim's mapping is registered; a conflicting one must not replace it.
-    with (
-        isolated_currency_registration(),
-        pytest.raises(UnitDefinitionError, match="already registered"),
-    ):
-        register_statutory_currencies({"1900-01-01": "CASTAR"})
-
-
-def test_re_registering_the_identical_statutory_mapping_is_tolerated():
-    # A re-imported module registers the same mapping again — a no-op.
-    with isolated_currency_registration():
-        register_statutory_currencies(
-            {"0001-01-01": "SILVER_PENNY", "2020-01-01": "CASTAR"}
-        )
+        _fresh_system(statutory_currencies={"1900-01-01": "GOLD_DRAGON"})
 
 
 def test_warns_when_statutory_currency_differs_from_default_data_currency():
@@ -642,6 +612,7 @@ def test_warns_when_statutory_currency_differs_from_default_data_currency():
             computation_currency="SILVER_PENNY",
             data_currency="CASTAR",
             policy_date=datetime.date(2019, 1, 1),
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -652,6 +623,7 @@ def test_no_warning_when_statutory_currency_is_the_base():
             computation_currency="CASTAR",
             data_currency="CASTAR",
             policy_date=datetime.date(2025, 1, 1),
+            unit_system=middle_earth.UNIT_SYSTEM,
         )
 
 
@@ -663,4 +635,5 @@ def test_no_warning_when_the_data_currency_is_set_off_the_base():
             computation_currency="SILVER_PENNY",
             data_currency="SILVER_PENNY",
             policy_date=datetime.date(2019, 1, 1),
+            unit_system=middle_earth.UNIT_SYSTEM,
         )

--- a/tests/tt/test_grouping_levels.py
+++ b/tests/tt/test_grouping_levels.py
@@ -15,17 +15,13 @@ import pytest
 from ttsim.exceptions import UnitDefinitionError
 from ttsim.tt import (
     AggType,
-    Unit,
+    TTSIMUnit,
 )
-from ttsim.tt.currencies import (
-    isolated_currency_registration,
-    register_currency,
-)
+from ttsim.tt.currencies import UnitSystem
 from ttsim.tt.grouping_levels import register_grouping_levels
 from ttsim.tt.units import (
     CURRENCY_TOKEN,
     PERSON_LEVEL,
-    UNIT_REGISTRY,
     base_is_level_carrying,
     divide_by_grouping_level,
     grouping_level_count_unit,
@@ -37,6 +33,17 @@ from ttsim.tt.units import (
     unit_for_aggregation,
     units_are_equivalent,
 )
+
+# A representative policy system for the level-aware tests: its registry holds
+# the grouping levels the level mechanics resolve against.
+SYSTEM = UnitSystem(
+    base_currency="CASTAR",
+    other_currencies={"SILVER_PENNY": "CASTAR / 4"},
+    statutory_currencies={"0001-01-01": "CASTAR"},
+    grouping_levels=["hh", "bg", "sn"],
+)
+REGISTRY = SYSTEM.registry
+
 
 # ----------------------------------------------------------------------------
 # #118: grouping levels as base dimensions + the [person] count dimension
@@ -51,38 +58,58 @@ def _register_middle_earth_levels():
     them. ``person`` is always present. Registration is idempotent, so the
     autouse fixture is safe across tests.
     """
-    register_grouping_levels(["hh", "bg", "sn"])
+    register_grouping_levels(names=["hh", "bg", "sn"], registry=REGISTRY)
 
 
 def test_register_grouping_levels_always_registers_person():
-    register_grouping_levels([])
+    register_grouping_levels([], registry=REGISTRY)
     # `person` resolves to its own base dimension (the [person] count dimension).
     assert (
-        divide_by_grouping_level(unit=parse_unit("CURRENCY"), level=PERSON_LEVEL)
+        divide_by_grouping_level(
+            unit=parse_unit("CURRENCY", registry=REGISTRY),
+            level=PERSON_LEVEL,
+            registry=REGISTRY,
+        )
         is not None
     )
 
 
 def test_register_grouping_levels_is_idempotent():
     # Re-registering an already-known level is a tolerated no-op.
-    register_grouping_levels(["hh"])
-    register_grouping_levels(["hh", "bg"])
-    first = divide_by_grouping_level(unit=parse_unit("CURRENCY"), level="hh")
-    second = divide_by_grouping_level(unit=parse_unit("CURRENCY"), level="hh")
-    assert units_are_equivalent(left=first, right=second)
+    register_grouping_levels(["hh"], registry=REGISTRY)
+    register_grouping_levels(["hh", "bg"], registry=REGISTRY)
+    first = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY", registry=REGISTRY), level="hh", registry=REGISTRY
+    )
+    second = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY", registry=REGISTRY), level="hh", registry=REGISTRY
+    )
+    assert units_are_equivalent(left=first, right=second, registry=REGISTRY)
 
 
 def test_each_level_is_its_own_base_dimension():
     # No conversion between levels: hh and bg denominators are distinct dimensions.
-    at_hh = divide_by_grouping_level(unit=parse_unit("CURRENCY / month"), level="hh")
-    at_bg = divide_by_grouping_level(unit=parse_unit("CURRENCY / month"), level="bg")
+    at_hh = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
+    )
+    at_bg = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level="bg",
+        registry=REGISTRY,
+    )
     assert at_hh.dimensionality != at_bg.dimensionality
-    assert not units_are_equivalent(left=at_hh, right=at_bg)
+    assert not units_are_equivalent(left=at_hh, right=at_bg, registry=REGISTRY)
 
 
 def test_unregistered_grouping_level_is_rejected():
     with pytest.raises(UnitDefinitionError, match="Unknown grouping level"):
-        divide_by_grouping_level(unit=parse_unit("CURRENCY"), level="eg_not_registered")
+        divide_by_grouping_level(
+            unit=parse_unit("CURRENCY", registry=REGISTRY),
+            level="eg_not_registered",
+            registry=REGISTRY,
+        )
 
 
 # ----------------------------------------------------------------------------
@@ -112,11 +139,13 @@ def test_base_is_level_carrying_defaults(base, level_carrying):
 
 
 def test_concrete_currency_base_is_level_carrying():
-    # Defined relative to CASTAR, the base currency the mettsim import registers;
-    # the registration is isolated so it does not leak to other tests.
-    with isolated_currency_registration():
-        register_currency(name="LEVEL_TEST_COIN", definition="CASTAR / 2")
-        assert base_is_level_carrying("LEVEL_TEST_COIN")
+    # A concrete currency a policy system defines is a level-carrying base.
+    UnitSystem(
+        base_currency="CASTAR",
+        other_currencies={"LEVEL_TEST_COIN": "CASTAR / 2"},
+        statutory_currencies={"0001-01-01": "CASTAR"},
+    )
+    assert base_is_level_carrying("LEVEL_TEST_COIN")
 
 
 # ----------------------------------------------------------------------------
@@ -125,43 +154,57 @@ def test_concrete_currency_base_is_level_carrying():
 
 
 def test_currency_flow_resolves_with_hh_denominator_at_level_hh():
-    base = resolve_compositional_unit(Unit.CURRENCY.PER_MONTH)
-    at_hh = divide_by_grouping_level(unit=base, level="hh")
+    base = resolve_compositional_unit(TTSIMUnit.CURRENCY.PER_MONTH, registry=REGISTRY)
+    at_hh = divide_by_grouping_level(unit=base, level="hh", registry=REGISTRY)
     assert units_are_equivalent(
         left=at_hh,
-        right=divide_by_grouping_level(unit=parse_unit("CURRENCY / month"), level="hh"),
+        right=divide_by_grouping_level(
+            unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+            level="hh",
+            registry=REGISTRY,
+        ),
+        registry=REGISTRY,
     )
 
 
 def test_currency_flow_resolves_with_person_denominator_at_individual_level():
-    base = resolve_compositional_unit(Unit.CURRENCY.PER_MONTH)
-    at_person = divide_by_grouping_level(unit=base, level=PERSON_LEVEL)
+    base = resolve_compositional_unit(TTSIMUnit.CURRENCY.PER_MONTH, registry=REGISTRY)
+    at_person = divide_by_grouping_level(
+        unit=base, level=PERSON_LEVEL, registry=REGISTRY
+    )
     assert units_are_equivalent(
         left=at_person,
         right=divide_by_grouping_level(
-            unit=parse_unit("CURRENCY / month"), level=PERSON_LEVEL
+            unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+            level=PERSON_LEVEL,
+            registry=REGISTRY,
         ),
+        registry=REGISTRY,
     )
     # Person and hh denominators are different dimensions.
     assert not units_are_equivalent(
-        left=at_person, right=divide_by_grouping_level(unit=base, level="hh")
+        left=at_person,
+        right=divide_by_grouping_level(unit=base, level="hh", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 @pytest.mark.parametrize(
     "token",
     [
-        Unit.YEARS,
-        Unit.HOURS.PER_WEEK,
-        Unit.DIMENSIONLESS,
+        TTSIMUnit.YEARS,
+        TTSIMUnit.HOURS.PER_WEEK,
+        TTSIMUnit.DIMENSIONLESS,
     ],
 )
 def test_level_less_tokens_resolve_without_a_level(token):
     # A level-less unit carries no grouping denominator: the resolved unit is
     # the plain physical unit, unchanged by any level.
-    resolved = resolve_compositional_unit(token)
+    resolved = resolve_compositional_unit(token, registry=REGISTRY)
     person_division = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
     # It has no [person] denominator: dividing CURRENCY by person is a different
     # dimension, and the level-less unit shares no level dimension with it.
@@ -176,40 +219,60 @@ def test_level_less_tokens_resolve_without_a_level(token):
 def test_count_bridges_hh_to_person_via_division():
     # (CURRENCY/month/[hh]) / ([person]/[hh]) == CURRENCY/month/[person].
     rent_at_hh = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / month"), level="hh"
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
     )
-    count_to_hh = grouping_level_count_unit(target_level="hh")  # [person]/[hh]
+    count_to_hh = grouping_level_count_unit(
+        target_level="hh", registry=REGISTRY
+    )  # [person]/[hh]
     bridged = (
-        UNIT_REGISTRY.Quantity(1.0, rent_at_hh)
-        / UNIT_REGISTRY.Quantity(1.0, count_to_hh)
+        REGISTRY.Quantity(1.0, rent_at_hh) / REGISTRY.Quantity(1.0, count_to_hh)
     ).units
     expected = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / month"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=bridged, right=expected)
+    assert units_are_equivalent(left=bridged, right=expected, registry=REGISTRY)
 
 
 def test_count_bridges_person_to_sn_via_multiplication():
     # ([person]/[sn]) * (CURRENCY/year/[person]) == CURRENCY/year/[sn]: a
     # per-person allowance times a head count is a per-group amount.
-    count_to_sn = grouping_level_count_unit(target_level="sn")  # [person]/[sn]
+    count_to_sn = grouping_level_count_unit(
+        target_level="sn", registry=REGISTRY
+    )  # [person]/[sn]
     per_person = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / year"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY / year", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
     product = (
-        UNIT_REGISTRY.Quantity(1.0, count_to_sn)
-        * UNIT_REGISTRY.Quantity(1.0, per_person)
+        REGISTRY.Quantity(1.0, count_to_sn) * REGISTRY.Quantity(1.0, per_person)
     ).units
-    expected = divide_by_grouping_level(unit=parse_unit("CURRENCY / year"), level="sn")
-    assert units_are_equivalent(left=product, right=expected)
+    expected = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY / year", registry=REGISTRY),
+        level="sn",
+        registry=REGISTRY,
+    )
+    assert units_are_equivalent(left=product, right=expected, registry=REGISTRY)
 
 
 def test_cross_level_addition_is_not_equivalent():
     # A unit at [hh] and one at [bg] are different dimensions: adding them across
     # levels is a mismatch the equivalence check catches.
-    at_hh = divide_by_grouping_level(unit=parse_unit("CURRENCY / month"), level="hh")
-    at_bg = divide_by_grouping_level(unit=parse_unit("CURRENCY / month"), level="bg")
-    assert not units_are_equivalent(left=at_hh, right=at_bg)
+    at_hh = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
+    )
+    at_bg = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level="bg",
+        registry=REGISTRY,
+    )
+    assert not units_are_equivalent(left=at_hh, right=at_bg, registry=REGISTRY)
 
 
 # ----------------------------------------------------------------------------
@@ -221,32 +284,40 @@ def test_spelled_person_level_is_rejected():
     # The person leaf is implied, never spelled (GEP 10): _PER_PERSON is rejected
     # so there is exactly one canonical spelling for a per-person quantity.
     with pytest.raises(UnitDefinitionError, match="implied, never spelled"):
-        _ = Unit.CURRENCY.PER_YEAR.PER_PERSON
+        _ = TTSIMUnit.CURRENCY.PER_YEAR.PER_PERSON
 
 
 def test_absent_level_yields_person_leaf():
     # sparerfreibetrag: a per-person yearly amount — the person leaf is implied,
     # so the bare CURRENCY_PER_YEAR resolves to CURRENCY / year / [person].
     resolved = resolve_compositional_param_unit(
-        unit=Unit.CURRENCY.PER_YEAR, where="test"
+        unit=TTSIMUnit.CURRENCY.PER_YEAR, where="test", registry=REGISTRY
     )
     per_person = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / year"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY / year", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=resolved, right=per_person)
+    assert units_are_equivalent(left=resolved, right=per_person, registry=REGISTRY)
 
 
 def test_spelled_level_on_stock_param():
     # A non-flow per-group amount: CURRENCY at level hh.
-    resolved = resolve_compositional_param_unit(unit=Unit.CURRENCY.PER_HH, where="test")
-    expected = divide_by_grouping_level(unit=parse_unit("CURRENCY"), level="hh")
-    assert units_are_equivalent(left=resolved, right=expected)
+    resolved = resolve_compositional_param_unit(
+        unit=TTSIMUnit.CURRENCY.PER_HH, where="test", registry=REGISTRY
+    )
+    expected = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY", registry=REGISTRY), level="hh", registry=REGISTRY
+    )
+    assert units_are_equivalent(left=resolved, right=expected, registry=REGISTRY)
 
 
 def test_unknown_level_is_rejected():
     with pytest.raises(UnitDefinitionError, match="Unknown grouping level"):
         resolve_compositional_param_unit(
-            unit=Unit.CURRENCY.PER_YEAR.PER_LEVEL("not_a_level"), where="test"
+            unit=TTSIMUnit.CURRENCY.PER_YEAR.PER_LEVEL("not_a_level"),
+            where="test",
+            registry=REGISTRY,
         )
 
 
@@ -254,12 +325,17 @@ def test_person_implied_on_scalar_param_with_name_suffix():
     # A per-person scalar param: the person leaf is implied (not spelled) and the
     # spelled period agrees with the name's time suffix.
     resolved = resolve_compositional_param_unit(
-        unit=Unit.CURRENCY.PER_YEAR, time_unit_id="y", where="test"
+        unit=TTSIMUnit.CURRENCY.PER_YEAR,
+        time_unit_id="y",
+        where="test",
+        registry=REGISTRY,
     )
     expected = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / year"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY / year", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=resolved, right=expected)
+    assert units_are_equivalent(left=resolved, right=expected, registry=REGISTRY)
 
 
 # ----------------------------------------------------------------------------
@@ -272,61 +348,77 @@ def test_column_omitting_the_group_level_is_a_person_property():
     # ``regelbedarf_pro_person_m_bg``): omitting the level at a group suffix
     # leaves the implied person leaf, no ``[bg]``.
     resolved = resolve_compositional_column_unit(
-        unit=Unit.CURRENCY.PER_MONTH,
+        unit=TTSIMUnit.CURRENCY.PER_MONTH,
         time_unit_id="m",
         grouping_level="bg",
         where="test",
+        registry=REGISTRY,
     )
     expected = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / month"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=resolved, right=expected)
+    assert units_are_equivalent(left=resolved, right=expected, registry=REGISTRY)
 
 
 def test_intensive_column_omitting_the_level_stays_bare_at_a_group_suffix():
     resolved = resolve_compositional_column_unit(
-        unit=Unit.MONTHS, time_unit_id=None, grouping_level="bg", where="test"
+        unit=TTSIMUnit.MONTHS,
+        time_unit_id=None,
+        grouping_level="bg",
+        where="test",
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=resolved, right=parse_unit("delta_calendar_month"))
+    assert units_are_equivalent(
+        left=resolved,
+        right=parse_unit("delta_calendar_month", registry=REGISTRY),
+        registry=REGISTRY,
+    )
 
 
 def test_intensive_column_with_a_spelled_group_level_resolves():
     # GEP 10's ``alter_monate_jüngstes_mitglied_fg``: the family's property, so
     # the duration carries the group level — declared, not read off the base.
     resolved = resolve_compositional_column_unit(
-        unit=Unit.MONTHS.PER_LEVEL("hh"),
+        unit=TTSIMUnit.MONTHS.PER_LEVEL("hh"),
         time_unit_id=None,
         grouping_level="hh",
         where="test",
+        registry=REGISTRY,
     )
     expected = divide_by_grouping_level(
-        unit=parse_unit("delta_calendar_month"), level="hh"
+        unit=parse_unit("delta_calendar_month", registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=resolved, right=expected)
+    assert units_are_equivalent(left=resolved, right=expected, registry=REGISTRY)
 
 
 def test_spelled_group_level_contradicting_the_suffix_is_rejected():
     with pytest.raises(UnitDefinitionError, match="must not contradict"):
         resolve_compositional_column_unit(
-            unit=Unit.CURRENCY.PER_MONTH.PER_LEVEL("bg"),
+            unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_LEVEL("bg"),
             time_unit_id="m",
             grouping_level="hh",
             where="test",
+            registry=REGISTRY,
         )
 
 
 def test_boolean_omitting_the_level_at_a_group_suffix_is_a_person_indicator():
     resolved = resolve_compositional_column_unit(
-        unit=Unit.DIMENSIONLESS,
+        unit=TTSIMUnit.DIMENSIONLESS,
         time_unit_id=None,
         grouping_level="hh",
         where="test",
         is_boolean=True,
+        registry=REGISTRY,
     )
     expected = divide_by_grouping_level(
-        unit=UNIT_REGISTRY.dimensionless, level=PERSON_LEVEL
+        unit=REGISTRY.dimensionless, level=PERSON_LEVEL, registry=REGISTRY
     )
-    assert units_are_equivalent(left=resolved, right=expected)
+    assert units_are_equivalent(left=resolved, right=expected, registry=REGISTRY)
 
 
 def test_calendar_point_carries_a_level():
@@ -334,14 +426,23 @@ def test_calendar_point_carries_a_level():
     # household's property — a leveled calendar point. Attaching and comparing
     # the level must stay clear of pint's offset-arithmetic rules.
     resolved = resolve_compositional_column_unit(
-        unit=Unit.CALENDAR_YEAR.PER_LEVEL("hh"),
+        unit=TTSIMUnit.CALENDAR_YEAR.PER_LEVEL("hh"),
         time_unit_id=None,
         grouping_level="hh",
         where="test",
+        registry=REGISTRY,
     )
-    expected = divide_by_grouping_level(unit=parse_unit("calendar_year"), level="hh")
-    assert units_are_equivalent(left=resolved, right=expected)
-    assert not units_are_equivalent(left=resolved, right=parse_unit("calendar_year"))
+    expected = divide_by_grouping_level(
+        unit=parse_unit("calendar_year", registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
+    )
+    assert units_are_equivalent(left=resolved, right=expected, registry=REGISTRY)
+    assert not units_are_equivalent(
+        left=resolved,
+        right=parse_unit("calendar_year", registry=REGISTRY),
+        registry=REGISTRY,
+    )
 
 
 # ----------------------------------------------------------------------------
@@ -352,143 +453,194 @@ def test_calendar_point_carries_a_level():
 def test_resolved_aggregation_sum_swaps_person_to_hh():
     # SUM person -> hh swaps the denominator [person] -> [hh].
     source = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / month"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.SUM,
         target_level="hh",
         source_level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
-    expected = divide_by_grouping_level(unit=parse_unit("CURRENCY / month"), level="hh")
-    assert units_are_equivalent(left=result, right=expected)
+    expected = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
+    )
+    assert units_are_equivalent(left=result, right=expected, registry=REGISTRY)
 
 
 def test_resolved_aggregation_count_mints_person_over_target():
     # COUNT to hh yields [person]/[hh], independent of the source.
     source = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / month"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.COUNT,
         target_level="hh",
         source_level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
-        left=result, right=grouping_level_count_unit(target_level="hh")
+        left=result,
+        right=grouping_level_count_unit(target_level="hh", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_resolved_aggregation_min_over_level_less_source_acquires_target_level():
     # An extreme is a property of the target group whatever the source's base
     # (GEP 10): an ``_hh`` min of a bare month-duration age carries ``[hh]``.
-    source = parse_unit("delta_calendar_month")
+    source = parse_unit("delta_calendar_month", registry=REGISTRY)
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.MIN,
         target_level="hh",
         source_level=None,
+        registry=REGISTRY,
     )
-    expected = divide_by_grouping_level(unit=source, level="hh")
-    assert units_are_equivalent(left=result, right=expected)
+    expected = divide_by_grouping_level(unit=source, level="hh", registry=REGISTRY)
+    assert units_are_equivalent(left=result, right=expected, registry=REGISTRY)
 
 
 def test_resolved_aggregation_min_over_level_carrying_source_carries_target_level():
-    source = divide_by_grouping_level(unit=parse_unit("CURRENCY"), level=PERSON_LEVEL)
+    source = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
+    )
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.MIN,
         target_level="hh",
         source_level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
-    expected = divide_by_grouping_level(unit=parse_unit("CURRENCY"), level="hh")
-    assert units_are_equivalent(left=result, right=expected)
+    expected = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY", registry=REGISTRY), level="hh", registry=REGISTRY
+    )
+    assert units_are_equivalent(left=result, right=expected, registry=REGISTRY)
 
 
 @pytest.mark.parametrize("agg_type", [AggType.ANY, AggType.ALL])
 def test_resolved_aggregation_any_all_are_boolean_at_target_level(agg_type):
     # A boolean aggregation mints a boolean at its *target* level (GEP 10):
     # `1 / [hh]`, not a level-less dimensionless.
-    source = divide_by_grouping_level(unit=parse_unit("CURRENCY"), level=PERSON_LEVEL)
+    source = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
+    )
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=agg_type,
         target_level="hh",
         source_level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
         left=result,
-        right=divide_by_grouping_level(unit=UNIT_REGISTRY.dimensionless, level="hh"),
+        right=divide_by_grouping_level(
+            unit=REGISTRY.dimensionless, level="hh", registry=REGISTRY
+        ),
+        registry=REGISTRY,
     )
 
 
 def test_resolved_aggregation_sum_over_level_less_source_acquires_target_level():
-    source = parse_unit("working_hour / week")
+    source = parse_unit("working_hour / week", registry=REGISTRY)
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.SUM,
         target_level="hh",
         source_level=None,
+        registry=REGISTRY,
     )
-    expected = divide_by_grouping_level(unit=source, level="hh")
-    assert units_are_equivalent(left=result, right=expected)
+    expected = divide_by_grouping_level(unit=source, level="hh", registry=REGISTRY)
+    assert units_are_equivalent(left=result, right=expected, registry=REGISTRY)
 
 
 def test_resolved_aggregation_mean_resolves_to_the_individual_level():
     # A per-head average belongs to the person, whatever the target (GEP 10):
     # leveling it to the target would break ``mean · count = sum``.
-    source = divide_by_grouping_level(unit=parse_unit(CURRENCY_TOKEN), level="hh")
+    source = divide_by_grouping_level(
+        unit=parse_unit(CURRENCY_TOKEN, registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
+    )
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.MEAN,
         target_level="sn",
         source_level="hh",
+        registry=REGISTRY,
     )
     expected = divide_by_grouping_level(
-        unit=parse_unit(CURRENCY_TOKEN), level=PERSON_LEVEL
+        unit=parse_unit(CURRENCY_TOKEN, registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=result, right=expected)
+    assert units_are_equivalent(left=result, right=expected, registry=REGISTRY)
 
 
 def test_resolved_aggregation_mean_over_level_less_source_stays_bare():
     # The person-level reading of an intensive base is bare, so an age's mean
     # stays comparable to level-less thresholds.
-    source = parse_unit("delta_calendar_month")
+    source = parse_unit("delta_calendar_month", registry=REGISTRY)
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.MEAN,
         target_level="hh",
         source_level=None,
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=result, right=source)
+    assert units_are_equivalent(left=result, right=source, registry=REGISTRY)
 
 
 def test_resolved_aggregation_mean_over_boolean_source_is_a_bare_share():
     # The mean of an indicator is a share: stripping the boolean's level leaves
     # no base to put at the person leaf.
-    source = divide_by_grouping_level(unit=UNIT_REGISTRY.dimensionless, level="hh")
+    source = divide_by_grouping_level(
+        unit=REGISTRY.dimensionless, level="hh", registry=REGISTRY
+    )
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.MEAN,
         target_level="hh",
         source_level="hh",
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=result, right=UNIT_REGISTRY.dimensionless)
+    assert units_are_equivalent(
+        left=result, right=REGISTRY.dimensionless, registry=REGISTRY
+    )
 
 
 def test_resolved_aggregation_min_over_leveled_calendar_point_swaps_level():
     # Re-leveling a calendar point must not trip pint's offset-arithmetic rules:
     # levels attach and strip via *unit* arithmetic (GEP 10).
-    source = divide_by_grouping_level(unit=parse_unit("calendar_year"), level="hh")
+    source = divide_by_grouping_level(
+        unit=parse_unit("calendar_year", registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
+    )
     result = resolved_unit_for_aggregation(
         source_unit=source,
         agg_type=AggType.MIN,
         target_level="sn",
         source_level="hh",
+        registry=REGISTRY,
     )
-    expected = divide_by_grouping_level(unit=parse_unit("calendar_year"), level="sn")
-    assert units_are_equivalent(left=result, right=expected)
+    expected = divide_by_grouping_level(
+        unit=parse_unit("calendar_year", registry=REGISTRY),
+        level="sn",
+        registry=REGISTRY,
+    )
+    assert units_are_equivalent(left=result, right=expected, registry=REGISTRY)
 
 
 # ----------------------------------------------------------------------------
@@ -501,71 +653,84 @@ def test_person_column_at_group_level_matches_a_count():
     # aggregation to hh mints, so a declaration and an aggregation compose and
     # compare cleanly (GEP 10).
     at_hh = resolve_compositional_param_unit(
-        unit=Unit.PERSON_COUNT.PER_HH, where="test"
+        unit=TTSIMUnit.PERSON_COUNT.PER_HH, where="test", registry=REGISTRY
     )
     assert units_are_equivalent(
-        left=at_hh, right=grouping_level_count_unit(target_level="hh")
+        left=at_hh,
+        right=grouping_level_count_unit(target_level="hh", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_person_at_person_level_is_dimensionless():
     # A head count per individual is [person]/[person] = a plain number. The
-    # person leaf is implied, so the bare Unit.PERSON_COUNT count resolves there.
-    at_person = resolve_compositional_param_unit(unit=Unit.PERSON_COUNT, where="test")
-    assert units_are_equivalent(left=at_person, right=UNIT_REGISTRY.dimensionless)
+    # person leaf is implied, so the bare TTSIMUnit.PERSON_COUNT count resolves there.
+    at_person = resolve_compositional_param_unit(
+        unit=TTSIMUnit.PERSON_COUNT, where="test", registry=REGISTRY
+    )
+    assert units_are_equivalent(
+        left=at_person, right=REGISTRY.dimensionless, registry=REGISTRY
+    )
 
 
 def test_declared_person_per_group_bridges_like_a_count():
     # A *declared* PERSON_COUNT_PER_HH divides a per-[hh] amount down to a per-person
     # one, exactly as an aggregated COUNT would: the two are interchangeable.
     headcount_at_hh = resolve_compositional_param_unit(
-        unit=Unit.PERSON_COUNT.PER_HH, where="test"
+        unit=TTSIMUnit.PERSON_COUNT.PER_HH, where="test", registry=REGISTRY
     )
-    per_hh = divide_by_grouping_level(unit=parse_unit("CURRENCY / month"), level="hh")
+    per_hh = divide_by_grouping_level(
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level="hh",
+        registry=REGISTRY,
+    )
     bridged = (
-        UNIT_REGISTRY.Quantity(1.0, per_hh)
-        / UNIT_REGISTRY.Quantity(1.0, headcount_at_hh)
+        REGISTRY.Quantity(1.0, per_hh) / REGISTRY.Quantity(1.0, headcount_at_hh)
     ).units
     expected = divide_by_grouping_level(
-        unit=parse_unit("CURRENCY / month"), level=PERSON_LEVEL
+        unit=parse_unit("CURRENCY / month", registry=REGISTRY),
+        level=PERSON_LEVEL,
+        registry=REGISTRY,
     )
-    assert units_are_equivalent(left=bridged, right=expected)
+    assert units_are_equivalent(left=bridged, right=expected, registry=REGISTRY)
 
 
 def test_count_aggregation_token_is_person():
     # COUNT mints the PERSON_COUNT placeholder unit (group and PID alike); the
     # level-aware resolved unit is recomputed downstream.
     assert (
-        unit_for_aggregation(source_unit=Unit.DIMENSIONLESS, agg_type=AggType.COUNT)
-        == Unit.PERSON_COUNT
+        unit_for_aggregation(
+            source_unit=TTSIMUnit.DIMENSIONLESS, agg_type=AggType.COUNT
+        )
+        == TTSIMUnit.PERSON_COUNT
     )
 
 
 @pytest.mark.parametrize("agg_type", [AggType.ANY, AggType.ALL])
 def test_any_all_aggregation_token_is_dimensionless(agg_type):
     assert (
-        unit_for_aggregation(source_unit=Unit.DIMENSIONLESS, agg_type=agg_type)
-        == Unit.DIMENSIONLESS
+        unit_for_aggregation(source_unit=TTSIMUnit.DIMENSIONLESS, agg_type=agg_type)
+        == TTSIMUnit.DIMENSIONLESS
     )
 
 
 def test_sum_aggregation_token_takes_the_target_level():
     assert (
         unit_for_aggregation(
-            source_unit=Unit.CURRENCY.PER_MONTH,
+            source_unit=TTSIMUnit.CURRENCY.PER_MONTH,
             agg_type=AggType.SUM,
             target_level="hh",
         )
-        == Unit.CURRENCY.PER_MONTH.PER_HH
+        == TTSIMUnit.CURRENCY.PER_MONTH.PER_HH
     )
 
 
 def test_min_aggregation_token_over_a_level_less_base_takes_the_target_level():
     assert (
         unit_for_aggregation(
-            source_unit=Unit.MONTHS, agg_type=AggType.MIN, target_level="hh"
+            source_unit=TTSIMUnit.MONTHS, agg_type=AggType.MIN, target_level="hh"
         )
-        == Unit.MONTHS.PER_HH
+        == TTSIMUnit.MONTHS.PER_HH
     )
 
 
@@ -574,9 +739,9 @@ def test_mean_aggregation_token_strips_to_the_individual_spelling():
     # implied for a level-carrying base, bare for an intensive one.
     assert (
         unit_for_aggregation(
-            source_unit=Unit.CURRENCY.PER_MONTH.PER_HH,
+            source_unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_HH,
             agg_type=AggType.MEAN,
             target_level="hh",
         )
-        == Unit.CURRENCY.PER_MONTH
+        == TTSIMUnit.CURRENCY.PER_MONTH
     )

--- a/tests/tt/test_rounding.py
+++ b/tests/tt/test_rounding.py
@@ -4,11 +4,11 @@ import datetime
 import inspect
 from typing import Any, cast
 
-import mettsim.middle_earth  # noqa: F401
 import numpy
 import pandas as pd
 import pytest
 from beartype.roar import BeartypeCallHintViolation
+from mettsim import middle_earth
 from pandas._testing import assert_series_equal
 
 from ttsim import InputData, TTTargets, main
@@ -22,19 +22,19 @@ from ttsim.interface_dag_elements.policy_environment import (
 )
 from ttsim.tt import (
     RoundingSpec,
-    Unit,
+    TTSIMUnit,
     policy_function,
     policy_input,
 )
 from ttsim.typing import FloatColumn, IntColumn
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def x() -> int:
     pass
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def p_id() -> int:
     pass
 
@@ -91,7 +91,7 @@ rounding_specs_and_exp_results = [
 def test_decorator():
     rs = RoundingSpec(base=1, direction="up")
 
-    @policy_function(rounding_spec=rs, unit=Unit.DIMENSIONLESS)
+    @policy_function(rounding_spec=rs, unit=TTSIMUnit.DIMENSIONLESS)
     def test_func() -> int:
         return 0
 
@@ -103,7 +103,7 @@ def test_malformed_rounding_specs():
 
         @policy_function(
             rounding_spec=cast("RoundingSpec", {"base": 1, "direction": "updsf"}),
-            unit=Unit.DIMENSIONLESS,
+            unit=TTSIMUnit.DIMENSIONLESS,
         )
         def test_func() -> int:
             return 0
@@ -117,7 +117,7 @@ def test_rounding(rounding_spec, input_values, exp_output, backend):
     """Check if rounding is correct."""
 
     # Define function that should be rounded
-    @policy_function(rounding_spec=rounding_spec, unit=Unit.DIMENSIONLESS)
+    @policy_function(rounding_spec=rounding_spec, unit=TTSIMUnit.DIMENSIONLESS)
     def test_func(x: float) -> float:
         return x
 
@@ -138,6 +138,7 @@ def test_rounding(rounding_spec, input_values, exp_output, backend):
         include_fail_nodes=False,
         include_warn_nodes=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     assert_series_equal(
         pd.Series(results__tree["namespace"]["test_func"]),
@@ -152,7 +153,8 @@ def test_rounding_with_time_conversion(backend, xnp):
 
     # Define function that should be rounded
     @policy_function(
-        rounding_spec=RoundingSpec(base=1, direction="down"), unit=Unit.DIMENSIONLESS
+        rounding_spec=RoundingSpec(base=1, direction="down"),
+        unit=TTSIMUnit.DIMENSIONLESS,
     )
     def test_func_m(x: float) -> float:
         return x
@@ -179,6 +181,7 @@ def test_rounding_with_time_conversion(backend, xnp):
         include_fail_nodes=False,
         include_warn_nodes=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     assert_series_equal(
         pd.Series(results__tree["test_func_y"]),
@@ -199,7 +202,7 @@ def test_no_rounding(
     backend,
 ):
     # Define function that should be rounded
-    @policy_function(rounding_spec=rounding_spec, unit=Unit.DIMENSIONLESS)
+    @policy_function(rounding_spec=rounding_spec, unit=TTSIMUnit.DIMENSIONLESS)
     def test_func(x: float) -> float:
         return x
 
@@ -222,6 +225,7 @@ def test_no_rounding(
         include_warn_nodes=False,
         rounding=False,
         backend=backend,
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
     assert_series_equal(
         pd.Series(results__tree["test_func"]),
@@ -521,9 +525,9 @@ def test_beartype_catches_structural_misuse_at_rounded_boundary(xnp) -> None:
 def test_policy_environment_rejects_non_statutory_rounding_spec_currency():
     @policy_function(
         rounding_spec=RoundingSpec(
-            base=4, direction="down", unit=Unit.SILVER_PENNY.PER_MONTH
+            base=4, direction="down", unit=TTSIMUnit.SILVER_PENNY.PER_MONTH
         ),
-        unit=Unit.CURRENCY.PER_MONTH,
+        unit=TTSIMUnit.CURRENCY.PER_MONTH,
     )
     def amount_m(x: float) -> float:
         return x
@@ -539,11 +543,11 @@ def test_policy_environment_rejects_non_statutory_rounding_spec_currency():
 
 
 def test_policy_environment_accepts_statutory_rounding_spec_currency():
-    spec = RoundingSpec(base=4, direction="down", unit=Unit.SILVER_PENNY.PER_MONTH)
+    spec = RoundingSpec(base=4, direction="down", unit=TTSIMUnit.SILVER_PENNY.PER_MONTH)
 
     @policy_function(
         rounding_spec=spec,
-        unit=Unit.CURRENCY.PER_MONTH,
+        unit=TTSIMUnit.CURRENCY.PER_MONTH,
     )
     def amount_m(x: float) -> float:
         return x

--- a/tests/tt/test_shared.py
+++ b/tests/tt/test_shared.py
@@ -263,6 +263,7 @@ def test_copy_full_policy_environment():
         main_target=MainTarget.policy_environment,
         policy_date_str="2025-01-01",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     copied_env = copy_environment(policy_env)
@@ -301,6 +302,7 @@ def test_deepcopy_fails_on_policy_environment():
         main_target=MainTarget.policy_environment,
         policy_date_str="2025-01-01",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     with pytest.raises((TypeError, AttributeError)) as excinfo:
@@ -317,6 +319,7 @@ def test_copy_environment_works_where_deepcopy_fails():
         main_target=MainTarget.policy_environment,
         policy_date_str="2025-01-01",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     # Confirm deepcopy fails
@@ -374,6 +377,7 @@ def test_policy_environment_type_inference():
         main_target=MainTarget.policy_environment,
         policy_date_str="2025-01-01",
         orig_policy_objects=OrigPolicyObjects.root(middle_earth.ROOT_PATH),
+        unit_system=middle_earth.UNIT_SYSTEM,
     )
 
     # Type checker should infer PolicyEnvironment -> PolicyEnvironment

--- a/tests/tt/test_ttsim_objects.py
+++ b/tests/tt/test_ttsim_objects.py
@@ -14,7 +14,7 @@ from ttsim.tt import (
     AggType,
     PolicyFunction,
     PolicyInput,
-    Unit,
+    TTSIMUnit,
     agg_by_group_function,
     agg_by_p_id_function,
     policy_function,
@@ -32,18 +32,18 @@ from ttsim.typing import FloatColumn
 # ======================================================================================
 
 
-@policy_function(unit=Unit.DIMENSIONLESS)
+@policy_function(unit=TTSIMUnit.DIMENSIONLESS)
 def simple_policy_function(x: int) -> int:
     return x
 
 
-@policy_function(leaf_name="simple_policy_function", unit=Unit.DIMENSIONLESS)
+@policy_function(leaf_name="simple_policy_function", unit=TTSIMUnit.DIMENSIONLESS)
 def policy_function_with_different_leaf_name(x: int) -> int:
     return x
 
 
 @policy_function(
-    start_date="2007-01-01", end_date="2011-12-31", unit=Unit.DIMENSIONLESS
+    start_date="2007-01-01", end_date="2011-12-31", unit=TTSIMUnit.DIMENSIONLESS
 )
 def policy_function_with_dates(x: int) -> int:
     return x
@@ -81,17 +81,19 @@ def test_policy_function_with_dates():
 # ======================================================================================
 
 
-@param_function(unit=Unit.DIMENSIONLESS)
+@param_function(unit=TTSIMUnit.DIMENSIONLESS)
 def simple_param_function(x: int) -> int:
     return x
 
 
-@param_function(leaf_name="simple_param_function", unit=Unit.DIMENSIONLESS)
+@param_function(leaf_name="simple_param_function", unit=TTSIMUnit.DIMENSIONLESS)
 def param_function_with_different_leaf_name(x: int) -> int:
     return x
 
 
-@param_function(start_date="2007-01-01", end_date="2011-12-31", unit=Unit.DIMENSIONLESS)
+@param_function(
+    start_date="2007-01-01", end_date="2011-12-31", unit=TTSIMUnit.DIMENSIONLESS
+)
 def param_function_with_dates(x: int) -> int:
     return x
 
@@ -128,12 +130,14 @@ def test_param_function_with_dates():
 # ======================================================================================
 
 
-@policy_input(unit=Unit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
 def simple_policy_input() -> float:
     pass
 
 
-@policy_input(start_date="2007-01-01", end_date="2011-12-31", unit=Unit.DIMENSIONLESS)
+@policy_input(
+    start_date="2007-01-01", end_date="2011-12-31", unit=TTSIMUnit.DIMENSIONLESS
+)
 def policy_input_with_dates() -> float:
     pass
 
@@ -159,12 +163,16 @@ def test_policy_input_with_dates():
 # ======================================================================================
 
 
-@agg_by_group_function(agg_type=AggType.COUNT)
+@agg_by_group_function(
+    agg_type=AggType.COUNT, unit=TTSIMUnit.PERSON_COUNT.PER_LEVEL("group")
+)
 def aggregate_by_group_count(group_id: int) -> int:
     pass
 
 
-@agg_by_group_function(agg_type=AggType.SUM)
+@agg_by_group_function(
+    agg_type=AggType.SUM, unit=TTSIMUnit.DIMENSIONLESS.PER_LEVEL("group")
+)
 def aggregate_by_group_sum(group_id: int, source: int) -> int:
     pass
 
@@ -233,17 +241,35 @@ def test_wrong_number_of_group_ids_present():
             pass
 
 
+def test_agg_by_group_function_requires_unit():
+    with pytest.raises(AggregationDefinitionError, match="must declare a `unit"):
+
+        @agg_by_group_function(agg_type=AggType.SUM)
+        def aggregate_by_group_sum_without_unit(group_id: int, source: int) -> int:
+            pass
+
+
+def test_agg_by_p_id_function_requires_unit():
+    with pytest.raises(AggregationDefinitionError, match="must declare a `unit"):
+
+        @agg_by_p_id_function(agg_type=AggType.SUM)
+        def aggregate_by_p_id_sum_without_unit(
+            p_id: int, p_id_specifier: int, column: int
+        ) -> int:
+            pass
+
+
 # ======================================================================================
 # AggByPIDFunction and agg_by_p_id_function
 # ======================================================================================
 
 
-@agg_by_p_id_function(agg_type=AggType.COUNT)
+@agg_by_p_id_function(agg_type=AggType.COUNT, unit=TTSIMUnit.PERSON_COUNT)
 def aggregate_by_p_id_count(p_id: int, p_id_specifier: int) -> int:
     pass
 
 
-@agg_by_p_id_function(agg_type=AggType.SUM)
+@agg_by_p_id_function(agg_type=AggType.SUM, unit=TTSIMUnit.DIMENSIONLESS)
 def aggregate_by_p_id_sum(p_id: int, p_id_specifier: int, column: int) -> int:
     pass
 
@@ -326,7 +352,7 @@ def test_agg_by_p_id_sum_with_all_missing_p_ids(backend, xnp):
 def test_policy_function_rejects_missing_return_annotation() -> None:
     with pytest.raises(PolicyFunctionDefinitionError, match="missing: return"):
 
-        @policy_function(unit=Unit.DIMENSIONLESS)
+        @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
         def unannotated_return(x: int):
             return x
 
@@ -334,7 +360,7 @@ def test_policy_function_rejects_missing_return_annotation() -> None:
 def test_policy_function_rejects_missing_param_annotation() -> None:
     with pytest.raises(PolicyFunctionDefinitionError, match="param 'x'"):
 
-        @policy_function(unit=Unit.DIMENSIONLESS)
+        @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
         def unannotated_param(x) -> int:
             return x
 
@@ -342,7 +368,7 @@ def test_policy_function_rejects_missing_param_annotation() -> None:
 def test_param_function_rejects_missing_annotation() -> None:
     with pytest.raises(ParamFunctionDefinitionError, match="missing: return"):
 
-        @param_function(unit=Unit.DIMENSIONLESS)
+        @param_function(unit=TTSIMUnit.DIMENSIONLESS)
         def unannotated_param_function(x: int):
             return x
 
@@ -366,7 +392,7 @@ def test_agg_by_p_id_function_rejects_missing_annotation() -> None:
 def test_group_creation_function_rejects_missing_annotation() -> None:
     with pytest.raises(GroupCreationDefinitionError, match="missing: return"):
 
-        @group_creation_function(unit=Unit.DIMENSIONLESS)
+        @group_creation_function(unit=TTSIMUnit.DIMENSIONLESS)
         def unannotated_group_creation(p_id: int):
             return p_id
 
@@ -378,7 +404,9 @@ def test_policy_function_dual_mode_check_resolves_stringified_annotations() -> N
     """
     with pytest.raises(PolicyFunctionDefinitionError, match="scalar annotations"):
 
-        @policy_function(vectorization_strategy="vectorize", unit=Unit.DIMENSIONLESS)
+        @policy_function(
+            vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS
+        )
         def column_arg_on_vectorized(x: FloatColumn) -> FloatColumn:
             return x
 
@@ -387,6 +415,8 @@ def test_policy_function_dual_mode_check_resolves_strings_not_required() -> None
     """Mirror of the above for `not_required`: a scalar annotation must raise."""
     with pytest.raises(PolicyFunctionDefinitionError, match="column annotations"):
 
-        @policy_function(vectorization_strategy="not_required", unit=Unit.DIMENSIONLESS)
+        @policy_function(
+            vectorization_strategy="not_required", unit=TTSIMUnit.DIMENSIONLESS
+        )
         def scalar_arg_on_not_required(x: int) -> int:
             return x

--- a/tests/tt/test_type_resolution.py
+++ b/tests/tt/test_type_resolution.py
@@ -18,7 +18,7 @@ from ttsim.exceptions import TTSIMError
 from ttsim.interface_dag_elements.automatically_added_functions import (
     create_agg_by_group_functions,
 )
-from ttsim.tt import ColumnFunction, Unit, policy_function
+from ttsim.tt import ColumnFunction, TTSIMUnit, policy_function
 from ttsim.tt.aggregation import (
     AggType,
     grouped_all,
@@ -227,7 +227,7 @@ def test_type_resolution_error_is_ttsim_error() -> None:
 def _auto_agg_wrapper_from_int_source() -> typing.Callable[..., object]:
     """Build the synthesized `x_hh` aggregation wrapper for an int source `x`."""
 
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def x(p_id: int) -> int:
         return p_id
 

--- a/tests/tt/test_unit_system.py
+++ b/tests/tt/test_unit_system.py
@@ -1,0 +1,62 @@
+"""The per-policy-system unit registry (GEP 10)."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from ttsim.exceptions import UnitDefinitionError
+from ttsim.tt.currencies import UnitSystem
+
+
+@pytest.fixture
+def germany() -> UnitSystem:
+    return UnitSystem(
+        base_currency="EUR",
+        other_currencies={"DM": "EUR / 1.95583"},
+        statutory_currencies={"0001-01-01": "DM", "2002-01-01": "EUR"},
+        grouping_levels=["hh", "bg"],
+    )
+
+
+@pytest.fixture
+def middle_earth() -> UnitSystem:
+    return UnitSystem(
+        base_currency="CASTAR",
+        other_currencies={"SILVER_PENNY": "CASTAR / 4"},
+        statutory_currencies={"0001-01-01": "SILVER_PENNY", "2020-01-01": "CASTAR"},
+        grouping_levels=["sp", "fam", "kin"],
+    )
+
+
+def test_systems_with_different_base_currencies_coexist(germany, middle_earth):
+    """Two policy systems, each with its own base currency, live side by side."""
+    assert (germany.base_currency, middle_earth.base_currency) == ("EUR", "CASTAR")
+
+
+def test_each_system_converts_within_its_own_currencies(germany, middle_earth):
+    """A conversion factor is read off the system that defines both currencies."""
+    assert (
+        germany.currency_conversion_factor(source_currency="DM", target_currency="EUR"),
+        middle_earth.currency_conversion_factor(
+            source_currency="SILVER_PENNY", target_currency="CASTAR"
+        ),
+    ) == (pytest.approx(1 / 1.95583), pytest.approx(0.25))
+
+
+def test_conversion_across_systems_is_rejected(germany):
+    """A currency of another system is not convertible — no silent factor of 1."""
+    with pytest.raises(UnitDefinitionError, match="'CASTAR' is not a registered"):
+        germany.currency_conversion_factor(
+            source_currency="EUR", target_currency="CASTAR"
+        )
+
+
+def test_statutory_currency_follows_each_system_mapping(germany, middle_earth):
+    """Each system reads the statutory currency off its own dated mapping."""
+    date = datetime.date(2019, 12, 31)
+    assert (
+        germany.statutory_currency_for_date(date),
+        middle_earth.statutory_currency_for_date(date),
+    ) == ("EUR", "SILVER_PENNY")

--- a/tests/tt/test_units.py
+++ b/tests/tt/test_units.py
@@ -24,21 +24,16 @@ from ttsim.tt import (
     UNSET_UNIT,
     AggType,
     CompositeUnit,
-    Unit,
+    TTSIMUnit,
+    UnitSystem,
     cast_unit,
     policy_function,
     policy_input,
-    register_currency,
     register_unit_builder_levels,
-)
-from ttsim.tt.currencies import (
-    currency_conversion_factor,
-    isolated_currency_registration,
 )
 from ttsim.tt.grouping_levels import register_grouping_levels
 from ttsim.tt.units import (
     CURRENCY_TOKEN,
-    UNIT_REGISTRY,
     coerce_to_composite_unit,
     composite_from_resolved_unit,
     fail_if_units_are_missing,
@@ -58,6 +53,17 @@ from ttsim.tt.units import (
     units_are_equivalent,
 )
 
+# A representative policy system for the compositional tests: its registry holds
+# Middle Earth's currencies (CASTAR base, SILVER_PENNY) and the GETTSIM-style
+# grouping levels the resolution tests build on.
+SYSTEM = UnitSystem(
+    base_currency="CASTAR",
+    other_currencies={"SILVER_PENNY": "CASTAR / 4"},
+    statutory_currencies={"0001-01-01": "SILVER_PENNY", "2020-01-01": "CASTAR"},
+    grouping_levels=["bg", "hh"],
+)
+REGISTRY = SYSTEM.registry
+
 
 @pytest.fixture(autouse=True)
 def _registered_levels():
@@ -66,7 +72,7 @@ def _registered_levels():
     Autouse (and idempotent), so every compositional test sees ``bg`` / ``hh``
     without threading the fixture through its signature.
     """
-    register_grouping_levels(["bg", "hh"])
+    register_grouping_levels(names=["bg", "hh"], registry=REGISTRY)
     register_unit_builder_levels(["bg", "hh"])
 
 
@@ -86,21 +92,18 @@ def _return_true() -> bool:
 
 
 def test_currency_token_anchors_currency_dimension():
-    assert UNIT_REGISTRY.Quantity(1.0, CURRENCY_TOKEN).dimensionality == {
-        "[currency]": 1
-    }
+    assert REGISTRY.Quantity(1.0, CURRENCY_TOKEN).dimensionality == {"[currency]": 1}
 
 
 def test_quarter_year_is_a_quarter_of_a_year():
     ratio = (
-        UNIT_REGISTRY.Quantity(1.0, "year")
-        / UNIT_REGISTRY.Quantity(1.0, "quarter_year")
+        REGISTRY.Quantity(1.0, "year") / REGISTRY.Quantity(1.0, "quarter_year")
     ).to("dimensionless")
     assert ratio.magnitude == pytest.approx(4.0)
 
 
 def test_hectare_is_an_area():
-    assert UNIT_REGISTRY.Quantity(1.0, "hectare").dimensionality == {"[length]": 2}
+    assert REGISTRY.Quantity(1.0, "hectare").dimensionality == {"[length]": 2}
 
 
 # ----------------------------------------------------------------------------
@@ -159,7 +162,7 @@ def test_coerce_to_composite_unit_rejects_none():
     "value",
     [
         # The old pint-string surface is gone: one token = one meaning. (Bare
-        # "CURRENCY" is now the agnostic stock token Unit.CURRENCY, so it is
+        # "CURRENCY" is now the agnostic stock token TTSIMUnit.CURRENCY, so it is
         # valid — only composite/pint spellings remain rejected.)
         "CURRENCY / year",
         "year",
@@ -176,9 +179,9 @@ def test_coerce_to_composite_unit_rejects_non_members(value):
 
 def test_compositional_flow_is_marked_by_a_period():
     # A unit is a flow iff it spells a period denominator (GEP 10).
-    assert Unit.CURRENCY.PER_MONTH.is_flow
-    assert not Unit.CURRENCY.is_flow
-    assert not Unit.YEARS.is_flow
+    assert TTSIMUnit.CURRENCY.PER_MONTH.is_flow
+    assert not TTSIMUnit.CURRENCY.is_flow
+    assert not TTSIMUnit.YEARS.is_flow
 
 
 # ----------------------------------------------------------------------------
@@ -200,7 +203,7 @@ def test_compositional_flow_is_marked_by_a_period():
     ],
 )
 def test_parse_unit_accepts_known_units(unit_str):
-    parse_unit(unit_str)
+    parse_unit(unit_str, registry=REGISTRY)
 
 
 @pytest.mark.parametrize(
@@ -220,7 +223,7 @@ def test_parse_unit_accepts_known_units(unit_str):
 )
 def test_parse_unit_rejects_unknown_unit_tokens(unit_str):
     with pytest.raises(UnitDefinitionError, match="does not know about"):
-        parse_unit(unit_str)
+        parse_unit(unit_str, registry=REGISTRY)
 
 
 @pytest.mark.parametrize("unit_str", ["dimensionless", ""])
@@ -228,64 +231,34 @@ def test_parse_unit_rejects_dimensionless_spellings(unit_str):
     # There is exactly one way to declare a dimensionless quantity:
     # `DIMENSIONLESS` — a pint-string spelling is rejected.
     with pytest.raises(UnitDefinitionError, match="DIMENSIONLESS"):
-        parse_unit(unit_str)
+        parse_unit(unit_str, registry=REGISTRY)
 
 
 def test_parse_unit_rejects_unparseable_string():
     with pytest.raises(UnitDefinitionError, match="parse"):
-        parse_unit("this is not a unit")
+        parse_unit("this is not a unit", registry=REGISTRY)
 
 
 # ----------------------------------------------------------------------------
-# register_currency
+# UnitSystem currencies
 # ----------------------------------------------------------------------------
 
 
-def test_mettsim_base_currency_registered():
-    assert UNIT_REGISTRY.Quantity(1.0, "CASTAR").dimensionality == {"[currency]": 1}
+def test_base_currency_is_a_currency_dimension():
+    assert SYSTEM.registry.Quantity(1.0, "CASTAR").dimensionality == {"[currency]": 1}
 
 
-def test_register_relative_currency_bakes_correct_factor():
-    register_currency(name="SILVER_PENNY", definition="CASTAR / 4")
+def test_relative_currency_bakes_correct_factor():
+    # SILVER_PENNY = CASTAR / 4, so a silver penny is a quarter of a castar.
     factor = (
-        UNIT_REGISTRY.Quantity(1.0, "SILVER_PENNY")
-        / UNIT_REGISTRY.Quantity(1.0, "CASTAR")
+        SYSTEM.registry.Quantity(1.0, "SILVER_PENNY")
+        / SYSTEM.registry.Quantity(1.0, "CASTAR")
     ).to("dimensionless")
     assert factor.magnitude == pytest.approx(0.25)
 
 
-def test_register_currency_idempotent():
-    # Re-registering with a consistent definition is a no-op, not an error.
-    register_currency(name="SILVER_PENNY", definition="CASTAR / 4")
-
-
-def test_register_currency_with_inconsistent_factor_fails():
-    # Re-registering an existing currency with a *different* factor must fail
-    # loudly rather than silently keep the original definition (GEP 10).
-    register_currency(name="SILVER_PENNY", definition="CASTAR / 4")
-    with pytest.raises(UnitDefinitionError, match="must be consistent"):
-        register_currency(name="SILVER_PENNY", definition="CASTAR / 5")
-
-
-def test_second_base_currency_is_rejected():
-    # The process has a single base currency; CASTAR is already the base (from
-    # the mettsim import), so registering another base is an error (GEP 10).
-    with (
-        isolated_currency_registration(),
-        pytest.raises(UnitDefinitionError, match="already the base"),
-    ):
-        register_currency(name="mithril_coin", base=True)
-
-
-def test_register_currency_requires_exactly_one_of_base_or_definition():
-    with pytest.raises(UnitDefinitionError, match="exactly one"):
-        register_currency(name="bad_coin", base=True, definition="CASTAR")
-    with pytest.raises(UnitDefinitionError, match="exactly one"):
-        register_currency("bad_coin")
-
-
 # ----------------------------------------------------------------------------
-# Currency declaration tokens (registered currencies extend the vocabulary)
+# Currency declaration tokens (a system's currencies extend the vocabulary)
 # ----------------------------------------------------------------------------
 
 
@@ -299,7 +272,6 @@ def test_register_currency_requires_exactly_one_of_base_or_definition():
     ],
 )
 def test_registered_currency_is_a_compositional_base(spelling, currency, is_flow):
-    register_currency(name="SILVER_PENNY", definition="CASTAR / 4")
     token = coerce_to_composite_unit(value=spelling, where="test")
     assert isinstance(token, CompositeUnit)
     assert str(token) == spelling
@@ -317,8 +289,8 @@ def test_token_source_currency():
     assert token_source_currency(
         coerce_to_composite_unit(value="CASTAR_PER_MONTH", where="t")
     ) == ("CASTAR")
-    assert token_source_currency(Unit.CURRENCY.PER_MONTH) is None
-    assert token_source_currency(Unit.HECTARE) is None
+    assert token_source_currency(TTSIMUnit.CURRENCY.PER_MONTH) is None
+    assert token_source_currency(TTSIMUnit.HECTARE) is None
     assert token_source_currency(None) is None
 
 
@@ -334,7 +306,11 @@ def test_currency_agnostic_base_rejected_on_column_at_resolution():
     token = coerce_to_composite_unit(value="CASTAR_PER_MONTH", where="test")
     with pytest.raises(UnitDefinitionError, match="agnostic CURRENCY"):
         resolve_compositional_column_unit(
-            unit=token, time_unit_id="m", grouping_level="person", where="A column"
+            unit=token,
+            time_unit_id="m",
+            grouping_level="person",
+            where="A column",
+            registry=REGISTRY,
         )
 
 
@@ -344,23 +320,35 @@ def test_currency_agnostic_base_rejected_on_column_at_resolution():
 
 
 def test_same_unit_is_equivalent():
-    assert units_are_equivalent(left=parse_unit("hectare"), right=parse_unit("hectare"))
+    assert units_are_equivalent(
+        left=parse_unit("hectare", registry=REGISTRY),
+        right=parse_unit("hectare", registry=REGISTRY),
+        registry=REGISTRY,
+    )
 
 
 def test_base_currency_equivalent_to_currency_token():
-    assert units_are_equivalent(left=parse_unit("CASTAR"), right=parse_unit("CURRENCY"))
+    assert units_are_equivalent(
+        left=parse_unit("CASTAR", registry=REGISTRY),
+        right=parse_unit("CURRENCY", registry=REGISTRY),
+        registry=REGISTRY,
+    )
 
 
 def test_month_and_year_flows_are_not_equivalent():
     # Same dimensionality ([currency] / [time]) but different magnitude.
     assert not units_are_equivalent(
-        left=parse_unit("CURRENCY / month"), right=parse_unit("CURRENCY / year")
+        left=parse_unit("CURRENCY / month", registry=REGISTRY),
+        right=parse_unit("CURRENCY / year", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_different_dimensions_are_not_equivalent():
     assert not units_are_equivalent(
-        left=parse_unit("CURRENCY"), right=parse_unit("hectare")
+        left=parse_unit("CURRENCY", registry=REGISTRY),
+        right=parse_unit("hectare", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -368,34 +356,54 @@ def test_calendar_point_is_equivalent_to_itself():
     # A calendar point (affine offset unit) cannot be divided; equivalence is
     # decided by identity (GEP 10).
     assert units_are_equivalent(
-        left=parse_unit("calendar_year"), right=parse_unit("calendar_year")
+        left=parse_unit("calendar_year", registry=REGISTRY),
+        right=parse_unit("calendar_year", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_calendar_point_is_not_equivalent_to_a_duration():
     # The S1 distinction: a year on the calendar is not a duration in years.
     assert not units_are_equivalent(
-        left=parse_unit("calendar_year"), right=parse_unit("delta_calendar_year")
+        left=parse_unit("calendar_year", registry=REGISTRY),
+        right=parse_unit("delta_calendar_year", registry=REGISTRY),
+        registry=REGISTRY,
     )
     assert not units_are_equivalent(
-        left=parse_unit("calendar_year"), right=parse_unit("year")
+        left=parse_unit("calendar_year", registry=REGISTRY),
+        right=parse_unit("year", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_calendar_points_on_different_axes_are_not_equivalent():
     assert not units_are_equivalent(
-        left=parse_unit("calendar_year"), right=parse_unit("calendar_month")
+        left=parse_unit("calendar_year", registry=REGISTRY),
+        right=parse_unit("calendar_month", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_is_calendar_point_unit():
-    assert is_calendar_point_unit(parse_unit("calendar_year"))
-    assert is_calendar_point_unit(parse_unit("calendar_month"))
-    assert is_calendar_point_unit(parse_unit("calendar_day"))
+    assert is_calendar_point_unit(
+        parse_unit("calendar_year", registry=REGISTRY), registry=REGISTRY
+    )
+    assert is_calendar_point_unit(
+        parse_unit("calendar_month", registry=REGISTRY), registry=REGISTRY
+    )
+    assert is_calendar_point_unit(
+        parse_unit("calendar_day", registry=REGISTRY), registry=REGISTRY
+    )
     # Durations and ordinary units are not points.
-    assert not is_calendar_point_unit(parse_unit("delta_calendar_year"))
-    assert not is_calendar_point_unit(parse_unit("year"))
-    assert not is_calendar_point_unit(parse_unit("CURRENCY / month"))
+    assert not is_calendar_point_unit(
+        parse_unit("delta_calendar_year", registry=REGISTRY), registry=REGISTRY
+    )
+    assert not is_calendar_point_unit(
+        parse_unit("year", registry=REGISTRY), registry=REGISTRY
+    )
+    assert not is_calendar_point_unit(
+        parse_unit("CURRENCY / month", registry=REGISTRY), registry=REGISTRY
+    )
 
 
 def test_duration_token_is_equivalent_to_the_plain_time_unit():
@@ -403,12 +411,14 @@ def test_duration_token_is_equivalent_to_the_plain_time_unit():
     # are ratio 1 against year / month / day, so existing duration declarations
     # are unchanged.
     assert units_are_equivalent(
-        left=resolve_compositional_unit(Unit.YEARS),
-        right=parse_unit("year"),
+        left=resolve_compositional_unit(TTSIMUnit.YEARS, registry=REGISTRY),
+        right=parse_unit("year", registry=REGISTRY),
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
-        left=resolve_compositional_unit(Unit.MONTHS),
-        right=parse_unit("month"),
+        left=resolve_compositional_unit(TTSIMUnit.MONTHS, registry=REGISTRY),
+        right=parse_unit("month", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -418,15 +428,15 @@ def test_duration_token_is_equivalent_to_the_plain_time_unit():
 
 
 def test_policy_function_stores_unit():
-    @policy_function(unit=Unit.CURRENCY.PER_MONTH)
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def betrag_m(satz: float, anzahl: int) -> float:
         return satz * anzahl
 
-    assert betrag_m.unit == Unit.CURRENCY.PER_MONTH
+    assert betrag_m.unit == TTSIMUnit.CURRENCY.PER_MONTH
 
 
 def test_policy_function_rejects_invalid_unit_at_decoration():
-    # The decorator's type contract only admits `Unit` members (or None);
+    # The decorator's type contract only admits `TTSIMUnit` members (or None);
     # the beartype claw rejects anything else at decoration time.
     with pytest.raises(PolicyFunctionDefinitionError, match="unit"):
 
@@ -445,11 +455,11 @@ def test_policy_function_rejects_member_spelled_as_string_at_decoration():
 
 
 def test_policy_function_explicit_dimensionless():
-    @policy_function(unit=Unit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def some_share(x: float) -> float:
         return x
 
-    assert some_share.unit is Unit.DIMENSIONLESS
+    assert some_share.unit is TTSIMUnit.DIMENSIONLESS
 
 
 # ----------------------------------------------------------------------------
@@ -460,43 +470,53 @@ def test_policy_function_explicit_dimensionless():
 @pytest.mark.parametrize(
     ("token", "expected"),
     [
-        (Unit.CURRENCY.PER_MONTH, "CURRENCY / month"),
-        (Unit.CURRENCY.PER_YEAR, "CURRENCY / year"),
-        (Unit.CURRENCY.PER_QUARTER, "CURRENCY / quarter_year"),
-        (Unit.CURRENCY.PER_WEEK, "CURRENCY / week"),
-        (Unit.CURRENCY.PER_DAY, "CURRENCY / day"),
-        (Unit.DIMENSIONLESS.PER_YEAR, "1 / year"),  # e.g. a wealth-tax rate
-        (Unit.HOURS.PER_WEEK, "working_hour / week"),  # e.g. working hours
-        (Unit.CURRENCY.PER_SQUARE_METER.PER_MONTH, "CURRENCY / meter ** 2 / month"),
-        (Unit.CURRENCY, "CURRENCY"),  # stock
-        (Unit.YEARS, "year"),  # a duration, e.g. an age
-        (Unit.MONTHS, "month"),  # a duration in months
-        (Unit.DAYS, "day"),  # a duration in days
-        (Unit.CALENDAR_YEAR, "calendar_year"),  # a point, e.g. a birth year
-        (Unit.CALENDAR_MONTH, "calendar_month"),
-        (Unit.CALENDAR_DAY, "calendar_day"),
-        (Unit.SQUARE_METER, "meter ** 2"),
-        (Unit.HECTARE, "hectare"),
+        (TTSIMUnit.CURRENCY.PER_MONTH, "CURRENCY / month"),
+        (TTSIMUnit.CURRENCY.PER_YEAR, "CURRENCY / year"),
+        (TTSIMUnit.CURRENCY.PER_QUARTER, "CURRENCY / quarter_year"),
+        (TTSIMUnit.CURRENCY.PER_WEEK, "CURRENCY / week"),
+        (TTSIMUnit.CURRENCY.PER_DAY, "CURRENCY / day"),
+        (TTSIMUnit.DIMENSIONLESS.PER_YEAR, "1 / year"),  # e.g. a wealth-tax rate
+        (TTSIMUnit.HOURS.PER_WEEK, "working_hour / week"),  # e.g. working hours
+        (
+            TTSIMUnit.CURRENCY.PER_SQUARE_METER.PER_MONTH,
+            "CURRENCY / meter ** 2 / month",
+        ),
+        (TTSIMUnit.CURRENCY, "CURRENCY"),  # stock
+        (TTSIMUnit.YEARS, "year"),  # a duration, e.g. an age
+        (TTSIMUnit.MONTHS, "month"),  # a duration in months
+        (TTSIMUnit.DAYS, "day"),  # a duration in days
+        (TTSIMUnit.CALENDAR_YEAR, "calendar_year"),  # a point, e.g. a birth year
+        (TTSIMUnit.CALENDAR_MONTH, "calendar_month"),
+        (TTSIMUnit.CALENDAR_DAY, "calendar_day"),
+        (TTSIMUnit.SQUARE_METER, "meter ** 2"),
+        (TTSIMUnit.HECTARE, "hectare"),
     ],
 )
 def test_resolve_compositional_unit_period_mapping(token, expected):
-    resolved = resolve_compositional_unit(token)
-    assert units_are_equivalent(left=resolved, right=parse_unit(expected))
+    resolved = resolve_compositional_unit(token, registry=REGISTRY)
+    assert units_are_equivalent(
+        left=resolved, right=parse_unit(expected, registry=REGISTRY), registry=REGISTRY
+    )
 
 
 def test_resolve_compositional_unit_dimensionless():
-    # A share, a rate, a head count: declared `Unit.DIMENSIONLESS`.
+    # A share, a rate, a head count: declared `TTSIMUnit.DIMENSIONLESS`.
     assert units_are_equivalent(
-        left=resolve_compositional_unit(Unit.DIMENSIONLESS),
-        right=UNIT_REGISTRY.dimensionless,
+        left=resolve_compositional_unit(TTSIMUnit.DIMENSIONLESS, registry=REGISTRY),
+        right=REGISTRY.dimensionless,
+        registry=REGISTRY,
     )
 
 
 def test_flow_period_resolution_distinguishes_month_and_year():
     """A monthly flow and its yearly variant resolve to non-equivalent units."""
-    betrag_m = resolve_compositional_unit(Unit.CURRENCY.PER_MONTH)
-    betrag_y = resolve_compositional_unit(Unit.CURRENCY.PER_YEAR)
-    assert not units_are_equivalent(left=betrag_m, right=betrag_y)
+    betrag_m = resolve_compositional_unit(
+        TTSIMUnit.CURRENCY.PER_MONTH, registry=REGISTRY
+    )
+    betrag_y = resolve_compositional_unit(
+        TTSIMUnit.CURRENCY.PER_YEAR, registry=REGISTRY
+    )
+    assert not units_are_equivalent(left=betrag_m, right=betrag_y, registry=REGISTRY)
 
 
 # ----------------------------------------------------------------------------
@@ -509,7 +529,7 @@ def test_unit_converter_factors_sourced_from_pint():
     # factor against pint via the public converter functions.
     def per_year(name):
         return (
-            (UNIT_REGISTRY.Quantity(1.0, "year") / UNIT_REGISTRY.Quantity(1.0, name))
+            (REGISTRY.Quantity(1.0, "year") / REGISTRY.Quantity(1.0, name))
             .to("dimensionless")
             .magnitude
         )
@@ -530,7 +550,7 @@ def test_integral_factors_keep_integer_type():
 
 def test_duration_conversion_year_to_month():
     """A duration of 2 years is 24 months — sourced from pint."""
-    months = UNIT_REGISTRY.Quantity(2.0, "year").to("month")
+    months = REGISTRY.Quantity(2.0, "year").to("month")
     assert months.magnitude == pytest.approx(24.0)
 
 
@@ -542,17 +562,19 @@ def test_duration_conversion_year_to_month():
 def test_fail_if_units_are_missing_reports_unannotated_nodes():
     with pytest.raises(UnitDefinitionError, match="kindergeld__betrag_m"):
         fail_if_units_are_missing(
-            {"kindergeld__betrag_m": UNSET_UNIT, "alter": Unit.YEARS},
+            {"kindergeld__betrag_m": UNSET_UNIT, "alter": TTSIMUnit.YEARS},
         )
 
 
 def test_fail_if_units_are_missing_passes_when_all_annotated():
-    fail_if_units_are_missing({"a": Unit.CURRENCY, "b": Unit.YEARS})
+    fail_if_units_are_missing({"a": TTSIMUnit.CURRENCY, "b": TTSIMUnit.YEARS})
 
 
 def test_fail_if_units_are_missing_accepts_dimensionless():
     # `DIMENSIONLESS` *is* a declaration: a dimensionless quantity (GEP 10).
-    fail_if_units_are_missing({"some_share": Unit.DIMENSIONLESS, "alter": Unit.YEARS})
+    fail_if_units_are_missing(
+        {"some_share": TTSIMUnit.DIMENSIONLESS, "alter": TTSIMUnit.YEARS}
+    )
 
 
 def test_policy_input_rejects_invalid_unit_at_decoration():
@@ -571,17 +593,17 @@ def test_policy_input_rejects_invalid_unit_at_decoration():
 @pytest.mark.parametrize(
     ("agg_type", "source_unit", "expected"),
     [
-        (AggType.SUM, Unit.CURRENCY.PER_MONTH, Unit.CURRENCY.PER_MONTH),
-        (AggType.MEAN, Unit.CURRENCY.PER_MONTH, Unit.CURRENCY.PER_MONTH),
-        (AggType.MIN, Unit.CURRENCY.PER_MONTH, Unit.CURRENCY.PER_MONTH),
-        (AggType.MAX, Unit.CURRENCY.PER_MONTH, Unit.CURRENCY.PER_MONTH),
+        (AggType.SUM, TTSIMUnit.CURRENCY.PER_MONTH, TTSIMUnit.CURRENCY.PER_MONTH),
+        (AggType.MEAN, TTSIMUnit.CURRENCY.PER_MONTH, TTSIMUnit.CURRENCY.PER_MONTH),
+        (AggType.MIN, TTSIMUnit.CURRENCY.PER_MONTH, TTSIMUnit.CURRENCY.PER_MONTH),
+        (AggType.MAX, TTSIMUnit.CURRENCY.PER_MONTH, TTSIMUnit.CURRENCY.PER_MONTH),
         # A COUNT is a head count: the PERSON_COUNT base, independent of source
         # (GEP 10). The level-aware resolved unit is [person]/[target].
-        (AggType.COUNT, Unit.CURRENCY.PER_MONTH, Unit.PERSON_COUNT),
+        (AggType.COUNT, TTSIMUnit.CURRENCY.PER_MONTH, TTSIMUnit.PERSON_COUNT),
         # ANY / ALL yield booleans, which are dimensionless quantities (GEP 10),
         # independent of the source.
-        (AggType.ANY, Unit.CURRENCY.PER_MONTH, Unit.DIMENSIONLESS),
-        (AggType.ALL, Unit.CURRENCY.PER_MONTH, Unit.DIMENSIONLESS),
+        (AggType.ANY, TTSIMUnit.CURRENCY.PER_MONTH, TTSIMUnit.DIMENSIONLESS),
+        (AggType.ALL, TTSIMUnit.CURRENCY.PER_MONTH, TTSIMUnit.DIMENSIONLESS),
     ],
 )
 def test_unit_for_aggregation(agg_type, source_unit, expected):
@@ -595,7 +617,7 @@ def test_unit_for_aggregation_preserves_unannotated_source():
     # COUNT mints a head count and ANY/ALL a boolean, both independent of source.
     assert (
         unit_for_aggregation(source_unit=UNSET_UNIT, agg_type=AggType.COUNT)
-        is Unit.PERSON_COUNT
+        is TTSIMUnit.PERSON_COUNT
     )
 
 
@@ -607,20 +629,20 @@ def test_unit_for_aggregation_sum_over_boolean_is_a_head_count():
     # framework's own auto-assigned token.
     assert (
         unit_for_aggregation(
-            source_unit=Unit.DIMENSIONLESS,
+            source_unit=TTSIMUnit.DIMENSIONLESS,
             agg_type=AggType.SUM,
             source_is_boolean=True,
         )
-        is Unit.PERSON_COUNT
+        is TTSIMUnit.PERSON_COUNT
     )
     assert (
         unit_for_aggregation(
-            source_unit=Unit.DIMENSIONLESS,
+            source_unit=TTSIMUnit.DIMENSIONLESS,
             agg_type=AggType.SUM,
             target_level="fam",
             source_is_boolean=True,
         )
-        == Unit.PERSON_COUNT.PER_FAM
+        == TTSIMUnit.PERSON_COUNT.PER_FAM
     )
 
 
@@ -628,7 +650,7 @@ def test_time_conversion_variants_rebased_period():
     variants = create_time_conversion_functions(
         qname_policy_environment={
             "betrag_m": policy_function(
-                leaf_name="betrag_m", unit=Unit.CURRENCY.PER_MONTH
+                leaf_name="betrag_m", unit=TTSIMUnit.CURRENCY.PER_MONTH
             )(_return_one_float),
         },
         input_columns=set(),
@@ -636,10 +658,11 @@ def test_time_conversion_variants_rebased_period():
     )
     # Generated betrag_y re-bases the flow's period to its own _y suffix.
     betrag_y_unit = variants["betrag_y"].unit  # ty: ignore[unresolved-attribute]
-    assert betrag_y_unit == Unit.CURRENCY.PER_YEAR
+    assert betrag_y_unit == TTSIMUnit.CURRENCY.PER_YEAR
     assert units_are_equivalent(
-        left=resolve_compositional_unit(betrag_y_unit),
-        right=parse_unit("CURRENCY / year"),
+        left=resolve_compositional_unit(betrag_y_unit, registry=REGISTRY),
+        right=parse_unit("CURRENCY / year", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
@@ -649,7 +672,7 @@ def test_auto_aggregation_carries_the_target_level():
     aggs = create_agg_by_group_functions(
         column_functions={
             "betrag_m": policy_function(
-                leaf_name="betrag_m", unit=Unit.CURRENCY.PER_MONTH
+                leaf_name="betrag_m", unit=TTSIMUnit.CURRENCY.PER_MONTH
             )(_return_one_float),
         },
         qname_policy_environment={},
@@ -659,7 +682,7 @@ def test_auto_aggregation_carries_the_target_level():
     )
     assert (
         aggs["betrag_m_kin"].unit  # ty: ignore[unresolved-attribute]
-        == Unit.CURRENCY.PER_MONTH.PER_KIN
+        == TTSIMUnit.CURRENCY.PER_MONTH.PER_KIN
     )
 
 
@@ -670,9 +693,9 @@ def test_auto_aggregation_over_a_boolean_source_mints_a_head_count():
     # that used to fail the build on any boolean group aggregate (GEP 10).
     aggs = create_agg_by_group_functions(
         column_functions={
-            "is_adult": policy_function(leaf_name="is_adult", unit=Unit.DIMENSIONLESS)(
-                _return_true
-            ),
+            "is_adult": policy_function(
+                leaf_name="is_adult", unit=TTSIMUnit.DIMENSIONLESS
+            )(_return_true),
         },
         qname_policy_environment={},
         input_columns=set(),
@@ -681,7 +704,7 @@ def test_auto_aggregation_over_a_boolean_source_mints_a_head_count():
     )
     assert (
         aggs["is_adult_fam"].unit  # ty: ignore[unresolved-attribute]
-        == Unit.PERSON_COUNT.PER_FAM
+        == TTSIMUnit.PERSON_COUNT.PER_FAM
     )
 
 
@@ -698,11 +721,11 @@ def test_concrete_currency_per_square_meter_base():
 
 
 def test_token_is_agnostic_currency():
-    assert token_is_agnostic_currency(Unit.CURRENCY)
-    assert token_is_agnostic_currency(Unit.CURRENCY.PER_MONTH)
-    assert token_is_agnostic_currency(Unit.CURRENCY.PER_SQUARE_METER.PER_MONTH)
-    assert not token_is_agnostic_currency(Unit.HECTARE)
-    assert not token_is_agnostic_currency(Unit.DIMENSIONLESS.PER_YEAR)
+    assert token_is_agnostic_currency(TTSIMUnit.CURRENCY)
+    assert token_is_agnostic_currency(TTSIMUnit.CURRENCY.PER_MONTH)
+    assert token_is_agnostic_currency(TTSIMUnit.CURRENCY.PER_SQUARE_METER.PER_MONTH)
+    assert not token_is_agnostic_currency(TTSIMUnit.HECTARE)
+    assert not token_is_agnostic_currency(TTSIMUnit.DIMENSIONLESS.PER_YEAR)
     assert not token_is_agnostic_currency(None)
     assert not token_is_agnostic_currency(
         coerce_to_composite_unit(value="CASTAR", where="test")
@@ -715,21 +738,21 @@ def test_token_is_agnostic_currency():
 
 
 def test_currency_conversion_factor():
-    # silver_penny = castar / 4, registered by mettsim on import.
-    assert currency_conversion_factor(
+    # silver_penny = castar / 4, defined by the system's currencies.
+    assert SYSTEM.currency_conversion_factor(
         source_currency="CASTAR", target_currency="SILVER_PENNY"
     ) == pytest.approx(4.0)
-    assert currency_conversion_factor(
+    assert SYSTEM.currency_conversion_factor(
         source_currency="SILVER_PENNY", target_currency="CASTAR"
     ) == pytest.approx(0.25)
-    assert currency_conversion_factor(
+    assert SYSTEM.currency_conversion_factor(
         source_currency="CASTAR", target_currency="CASTAR"
     ) == pytest.approx(1.0)
 
 
 def test_currency_conversion_factor_rejects_unknown_currency():
     with pytest.raises(UnitDefinitionError, match="not a registered currency"):
-        currency_conversion_factor(
+        SYSTEM.currency_conversion_factor(
             source_currency="CASTAR", target_currency="dragon_hoard"
         )
 
@@ -741,57 +764,72 @@ def test_currency_conversion_factor_rejects_unknown_currency():
 
 def test_strip_at_boundary_converts_to_data_currency():
     # silver_penny tag, castar data currency -> divide by four.
-    tagged = UNIT_REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY")
+    tagged = REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY")
     bare = strip_input_quantity_at_boundary(
-        quantity=tagged, data_currency="CASTAR", column_label="wealth"
+        quantity=tagged,
+        data_currency="CASTAR",
+        column_label="wealth",
+        registry=REGISTRY,
     )
-    assert not isinstance(bare, UNIT_REGISTRY.Quantity)
+    assert not isinstance(bare, REGISTRY.Quantity)
     assert bare == pytest.approx([1.0])
 
 
 def test_strip_at_boundary_converts_flow_currency_preserving_period():
     # silver_penny / month -> castar / month: only the currency is rescaled. The
     # tag's /month matches the column's `_m` suffix.
-    tagged = UNIT_REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY / month")
+    tagged = REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY / month")
     bare = strip_input_quantity_at_boundary(
-        quantity=tagged, data_currency="CASTAR", column_label="income_m"
+        quantity=tagged,
+        data_currency="CASTAR",
+        column_label="income_m",
+        registry=REGISTRY,
     )
     assert bare == pytest.approx([1.0])
 
 
 def test_strip_at_boundary_fails_on_missing_period():
     # A flow column (`_m`) tagged without a period: strict mismatch.
-    tagged = UNIT_REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY")
+    tagged = REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY")
     with pytest.raises(UnitConsistencyError, match="must match the column's suffix"):
         strip_input_quantity_at_boundary(
-            quantity=tagged, data_currency="CASTAR", column_label="income_m"
+            quantity=tagged,
+            data_currency="CASTAR",
+            column_label="income_m",
+            registry=REGISTRY,
         )
 
 
 def test_strip_at_boundary_fails_on_wrong_period():
     # silver_penny / year against a `_m` column: 12-fold footgun, caught.
-    tagged = UNIT_REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY / year")
+    tagged = REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY / year")
     with pytest.raises(UnitConsistencyError, match="month"):
         strip_input_quantity_at_boundary(
-            quantity=tagged, data_currency="CASTAR", column_label="income_m"
+            quantity=tagged,
+            data_currency="CASTAR",
+            column_label="income_m",
+            registry=REGISTRY,
         )
 
 
 def test_strip_at_boundary_fails_on_period_for_unsuffixed_column():
     # A stock column (no suffix) tagged with a period.
-    tagged = UNIT_REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY / month")
+    tagged = REGISTRY.Quantity(np.array([4.0]), "SILVER_PENNY / month")
     with pytest.raises(UnitConsistencyError, match="no time suffix"):
         strip_input_quantity_at_boundary(
-            quantity=tagged, data_currency="CASTAR", column_label="wealth"
+            quantity=tagged,
+            data_currency="CASTAR",
+            column_label="wealth",
+            registry=REGISTRY,
         )
 
 
 def test_strip_at_boundary_does_not_flag_numerator_time_unit():
     # An age tagged in years: `year` is a numerator, not a flow period, so an
     # unsuffixed column is fine. Nothing to convert (no currency).
-    tagged = UNIT_REGISTRY.Quantity(np.array([30.0]), "year")
+    tagged = REGISTRY.Quantity(np.array([30.0]), "year")
     bare = strip_input_quantity_at_boundary(
-        quantity=tagged, data_currency="CASTAR", column_label="age"
+        quantity=tagged, data_currency="CASTAR", column_label="age", registry=REGISTRY
     )
     assert bare == pytest.approx([30.0])
 
@@ -800,32 +838,40 @@ def test_strip_at_boundary_keys_period_off_denominator_for_hours_flow():
     # `arbeitsstunden_w` is HOURS_FLOW (`working_hour / week`): the flow period
     # is the denominator (week), not the `[hours]` numerator. The tag's `/week`
     # matches the `_w` suffix; there is no currency, so the value passes through.
-    tagged = UNIT_REGISTRY.Quantity(np.array([40.0]), "working_hour / week")
+    tagged = REGISTRY.Quantity(np.array([40.0]), "working_hour / week")
     bare = strip_input_quantity_at_boundary(
-        quantity=tagged, data_currency="CASTAR", column_label="arbeitsstunden_w"
+        quantity=tagged,
+        data_currency="CASTAR",
+        column_label="arbeitsstunden_w",
+        registry=REGISTRY,
     )
     assert bare == pytest.approx([40.0])
 
     # A wrong period is still caught (month != week).
     with pytest.raises(UnitConsistencyError, match="week"):
         strip_input_quantity_at_boundary(
-            quantity=UNIT_REGISTRY.Quantity(np.array([40.0]), "working_hour / month"),
+            quantity=REGISTRY.Quantity(np.array([40.0]), "working_hour / month"),
             data_currency="CASTAR",
             column_label="arbeitsstunden_w",
+            registry=REGISTRY,
         )
 
 
 def test_strip_at_boundary_strips_matching_currency():
-    tagged = UNIT_REGISTRY.Quantity(np.array([3.0]), "CASTAR")
-    bare = strip_input_quantity_at_boundary(quantity=tagged, data_currency="CASTAR")
-    assert not isinstance(bare, UNIT_REGISTRY.Quantity)
+    tagged = REGISTRY.Quantity(np.array([3.0]), "CASTAR")
+    bare = strip_input_quantity_at_boundary(
+        quantity=tagged, data_currency="CASTAR", registry=REGISTRY
+    )
+    assert not isinstance(bare, REGISTRY.Quantity)
     assert list(bare) == [3.0]
 
 
 def test_strip_at_boundary_passes_non_currency_tag_through():
     # No currency component -> nothing to convert.
-    tagged = UNIT_REGISTRY.Quantity(np.array([5.0]), "working_hour")
-    bare = strip_input_quantity_at_boundary(quantity=tagged, data_currency="CASTAR")
+    tagged = REGISTRY.Quantity(np.array([5.0]), "working_hour")
+    bare = strip_input_quantity_at_boundary(
+        quantity=tagged, data_currency="CASTAR", registry=REGISTRY
+    )
     assert bare == pytest.approx([5.0])
 
 
@@ -836,21 +882,21 @@ def test_strip_at_boundary_passes_non_currency_tag_through():
 
 def test_builder_round_trips_with_flat_spelling():
     # The fluent `.py` builder and the flat YAML string are the same unit.
-    built = Unit.CURRENCY.PER_SQUARE_METER.PER_MONTH
+    built = TTSIMUnit.CURRENCY.PER_SQUARE_METER.PER_MONTH
     assert str(built) == "CURRENCY_PER_SQUARE_METER_PER_MONTH"
     assert parse_compositional_unit(str(built)) == built
 
 
 def test_builder_round_trips_with_level():
-    built = Unit.CURRENCY.PER_MONTH.PER_BG
+    built = TTSIMUnit.CURRENCY.PER_MONTH.PER_BG
     assert str(built) == "CURRENCY_PER_MONTH_PER_BG"
     assert parse_compositional_unit("CURRENCY_PER_MONTH_PER_BG") == built
 
 
 def test_builder_generic_per_level_matches_attribute():
     assert (
-        Unit.PERSON_COUNT.PER_LEVEL("bg")
-        == Unit.PERSON_COUNT.PER_BG
+        TTSIMUnit.PERSON_COUNT.PER_LEVEL("bg")
+        == TTSIMUnit.PERSON_COUNT.PER_BG
         == parse_compositional_unit("PERSON_COUNT_PER_BG")
     )
 
@@ -912,13 +958,13 @@ def test_builder_rejects_non_canonical_order():
     # Level before period, an area after a period, a second period — all caught
     # by the staged builder, mirroring the parser.
     with pytest.raises(UnitDefinitionError, match="precede"):
-        _ = Unit.CURRENCY.PER_BG.PER_MONTH
+        _ = TTSIMUnit.CURRENCY.PER_BG.PER_MONTH
     with pytest.raises(UnitDefinitionError, match="precede"):
-        _ = Unit.CURRENCY.PER_MONTH.PER_YEAR
+        _ = TTSIMUnit.CURRENCY.PER_MONTH.PER_YEAR
 
 
 def test_is_flow_property():
-    assert Unit.CURRENCY.PER_MONTH.is_flow
+    assert TTSIMUnit.CURRENCY.PER_MONTH.is_flow
     assert not parse_compositional_unit("CURRENCY").is_flow
 
 
@@ -940,33 +986,45 @@ def test_is_flow_property():
 def test_compositional_unit_resolves_to_expected_pint_unit(spelling, expected):
     # The leftover-token migration map: every compositional spelling resolves to
     # the identical pint unit the legacy token used to produce.
-    compositional = resolve_compositional_unit(parse_compositional_unit(spelling))
-    assert units_are_equivalent(left=compositional, right=parse_unit(expected))
+    compositional = resolve_compositional_unit(
+        parse_compositional_unit(spelling), registry=REGISTRY
+    )
+    assert units_are_equivalent(
+        left=compositional,
+        right=parse_unit(expected, registry=REGISTRY),
+        registry=REGISTRY,
+    )
 
 
 def test_person_per_level_resolves_to_head_count():
     # PERSON_COUNT_PER_BG is the old HEADCOUNT at bg: [person] / [bg], the unit a COUNT
     # aggregation to bg mints.
     compositional = resolve_compositional_unit(
-        parse_compositional_unit("PERSON_COUNT_PER_BG")
+        parse_compositional_unit("PERSON_COUNT_PER_BG"), registry=REGISTRY
     )
     assert units_are_equivalent(
-        left=compositional, right=grouping_level_count_unit(target_level="bg")
+        left=compositional,
+        right=grouping_level_count_unit(target_level="bg", registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_concrete_currency_base_resolves_like_agnostic():
     # For dimensionality a concrete currency means exactly what CURRENCY means.
-    concrete = resolve_compositional_unit(parse_compositional_unit("CASTAR_PER_MONTH"))
-    agnostic = resolve_compositional_unit(
-        parse_compositional_unit("CURRENCY_PER_MONTH")
+    concrete = resolve_compositional_unit(
+        parse_compositional_unit("CASTAR_PER_MONTH"), registry=REGISTRY
     )
-    assert units_are_equivalent(left=concrete, right=agnostic)
+    agnostic = resolve_compositional_unit(
+        parse_compositional_unit("CURRENCY_PER_MONTH"), registry=REGISTRY
+    )
+    assert units_are_equivalent(left=concrete, right=agnostic, registry=REGISTRY)
 
 
 def test_resolve_compositional_unit_rejects_unregistered_level():
     with pytest.raises(UnitDefinitionError, match="grouping level"):
-        resolve_compositional_unit(parse_compositional_unit("CURRENCY_PER_NEVERLAND"))
+        resolve_compositional_unit(
+            parse_compositional_unit("CURRENCY_PER_NEVERLAND"), registry=REGISTRY
+        )
 
 
 # ----------------------------------------------------------------------------
@@ -978,10 +1036,12 @@ def test_working_hour_is_its_own_dimension():
     # Working hours are `[hours]`, isolated from pint's `[time]`, so they cannot
     # convert to a period and a `working_hour / week` flow does not collapse to a
     # bare dimensionless number the way a `[time] / [time]` hour-flow would.
-    assert UNIT_REGISTRY.Quantity(1.0, "working_hour").dimensionality == {"[hours]": 1}
-    assert not UNIT_REGISTRY.Quantity(1.0, "working_hour").is_compatible_with("day")
-    hours_per_week = resolve_compositional_unit(Unit.HOURS.PER_WEEK)
-    assert UNIT_REGISTRY.Quantity(1.0, hours_per_week).dimensionality == {
+    assert REGISTRY.Quantity(1.0, "working_hour").dimensionality == {"[hours]": 1}
+    assert not REGISTRY.Quantity(1.0, "working_hour").is_compatible_with("day")
+    hours_per_week = resolve_compositional_unit(
+        TTSIMUnit.HOURS.PER_WEEK, registry=REGISTRY
+    )
+    assert REGISTRY.Quantity(1.0, hours_per_week).dimensionality == {
         "[hours]": 1,
         "[time]": -1,
     }
@@ -991,14 +1051,18 @@ def test_bare_time_hour_is_no_longer_an_admissible_token():
     # There is exactly one spelling for working hours; pint's `[time]` `hour` is
     # not admissible (GEP 10).
     with pytest.raises(UnitDefinitionError, match="does not know about"):
-        parse_unit("working_hour / hour")
+        parse_unit("working_hour / hour", registry=REGISTRY)
 
 
 def test_hours_per_week_rebases_period_only():
     # The one conversion working hours admit: re-basing the [time] period
     # (week -> month) leaves the [hours] numerator untouched.
-    per_week = resolve_compositional_unit(parse_compositional_unit("HOURS_PER_WEEK"))
-    per_month = resolve_compositional_unit(parse_compositional_unit("HOURS_PER_MONTH"))
+    per_week = resolve_compositional_unit(
+        parse_compositional_unit("HOURS_PER_WEEK"), registry=REGISTRY
+    )
+    per_month = resolve_compositional_unit(
+        parse_compositional_unit("HOURS_PER_MONTH"), registry=REGISTRY
+    )
     assert (
         per_week.dimensionality
         == per_month.dimensionality
@@ -1008,7 +1072,7 @@ def test_hours_per_week_rebases_period_only():
         }
     )
     # Different periods are not equivalent (a 52/12 factor apart).
-    assert not units_are_equivalent(left=per_week, right=per_month)
+    assert not units_are_equivalent(left=per_week, right=per_month, registry=REGISTRY)
 
 
 # ----------------------------------------------------------------------------
@@ -1020,8 +1084,8 @@ def test_cast_unit_is_the_identity_at_run_time():
     # Like `typing.cast`: no runtime effect, scalar or column, so the numeric
     # path and JAX tracing are untouched.
     column = np.array([1.0, 2.0])
-    assert cast_unit(column, Unit.CURRENCY.PER_MONTH) is column
-    assert cast_unit(3.5, Unit.MONTHS) == 3.5
+    assert cast_unit(column, TTSIMUnit.CURRENCY.PER_MONTH) is column
+    assert cast_unit(3.5, TTSIMUnit.MONTHS) == 3.5
 
 
 def test_cast_target_resolves_like_a_column_declaration():
@@ -1029,75 +1093,88 @@ def test_cast_target_resolves_like_a_column_declaration():
     # implied for a level-carrying base, an intensive base stays bare.
     assert units_are_equivalent(
         left=resolve_compositional_cast_unit(
-            unit=Unit.CURRENCY.PER_MONTH, where="test"
+            unit=TTSIMUnit.CURRENCY.PER_MONTH, where="test", registry=REGISTRY
         ),
         right=resolve_compositional_column_unit(
-            unit=Unit.CURRENCY.PER_MONTH,
+            unit=TTSIMUnit.CURRENCY.PER_MONTH,
             time_unit_id="m",
             grouping_level="person",
             where="test",
+            registry=REGISTRY,
         ),
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
-        left=resolve_compositional_cast_unit(unit=Unit.MONTHS, where="test"),
-        right=resolve_compositional_unit(Unit.MONTHS),
+        left=resolve_compositional_cast_unit(
+            unit=TTSIMUnit.MONTHS, where="test", registry=REGISTRY
+        ),
+        right=resolve_compositional_unit(TTSIMUnit.MONTHS, registry=REGISTRY),
+        registry=REGISTRY,
     )
 
 
 def test_cast_target_must_be_currency_agnostic():
     token = coerce_to_composite_unit(value="CASTAR_PER_MONTH", where="test")
     with pytest.raises(UnitDefinitionError, match="agnostic CURRENCY"):
-        resolve_compositional_cast_unit(unit=token, where="test")
+        resolve_compositional_cast_unit(unit=token, where="test", registry=REGISTRY)
 
 
 def test_hours_denominator_suppresses_the_implied_person_leaf():
     # A wage floor is a price, owned by nobody: the working-hours denominator
     # keeps the person leaf off, so `floor * hours` cancels to a person-level
     # amount (GEP 10) — the same rule as areas.
-    expected = parse_unit("CURRENCY / working_hour")
+    expected = parse_unit("CURRENCY / working_hour", registry=REGISTRY)
     assert units_are_equivalent(
         left=resolve_compositional_column_unit(
-            unit=Unit.CURRENCY.PER_HOURS,
+            unit=TTSIMUnit.CURRENCY.PER_HOURS,
             time_unit_id=None,
             grouping_level="person",
             where="test",
+            registry=REGISTRY,
         ),
         right=expected,
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
         left=resolve_compositional_param_unit(
             unit=coerce_to_composite_unit(value="CASTAR_PER_HOURS", where="test"),
             where="test",
+            registry=REGISTRY,
         ),
         right=expected,
+        registry=REGISTRY,
     )
 
 
 def test_composite_from_resolved_unit_reconstructs_the_hours_denominator():
     # The output-side label round trip for a wage floor: the working-hour
     # denominator maps back to the physical-denominator slot.
-    resolved = resolve_compositional_unit(unit=Unit.CURRENCY.PER_HOURS)
+    resolved = resolve_compositional_unit(
+        unit=TTSIMUnit.CURRENCY.PER_HOURS, registry=REGISTRY
+    )
     in_data_currency = output_unit_in_data_currency(
-        units=resolved, data_currency="CASTAR"
+        units=resolved, data_currency="CASTAR", registry=REGISTRY
     )
-    assert composite_from_resolved_unit(in_data_currency) == coerce_to_composite_unit(
-        value="CASTAR_PER_HOURS", where="test"
-    )
+    assert composite_from_resolved_unit(
+        units=in_data_currency, registry=REGISTRY
+    ) == coerce_to_composite_unit(value="CASTAR_PER_HOURS", where="test")
 
 
 def test_area_denominator_suppresses_the_implied_person_leaf():
     # A rent cap is a price, owned by nobody: the area denominator keeps the
     # person leaf off, so `cap * area` cancels to a person-level amount
     # (GEP 10). Both the column and the parameter resolver apply the rule.
-    expected = parse_unit("CURRENCY / meter ** 2 / month")
+    expected = parse_unit("CURRENCY / meter ** 2 / month", registry=REGISTRY)
     assert units_are_equivalent(
         left=resolve_compositional_column_unit(
-            unit=Unit.CURRENCY.PER_SQUARE_METER.PER_MONTH,
+            unit=TTSIMUnit.CURRENCY.PER_SQUARE_METER.PER_MONTH,
             time_unit_id="m",
             grouping_level="person",
             where="test",
+            registry=REGISTRY,
         ),
         right=expected,
+        registry=REGISTRY,
     )
     assert units_are_equivalent(
         left=resolve_compositional_param_unit(
@@ -1105,8 +1182,10 @@ def test_area_denominator_suppresses_the_implied_person_leaf():
                 value="CASTAR_PER_SQUARE_METER_PER_MONTH", where="test"
             ),
             where="test",
+            registry=REGISTRY,
         ),
         right=expected,
+        registry=REGISTRY,
     )
 
 
@@ -1115,10 +1194,12 @@ def test_bare_area_base_still_carries_the_person_leaf():
     # SQUARE_METER base takes the implied person leaf as any owned amount does.
     assert units_are_equivalent(
         left=resolve_compositional_column_unit(
-            unit=Unit.SQUARE_METER,
+            unit=TTSIMUnit.SQUARE_METER,
             time_unit_id=None,
             grouping_level="person",
             where="test",
+            registry=REGISTRY,
         ),
-        right=parse_unit("meter ** 2 / grouping_level_person"),
+        right=parse_unit("meter ** 2 / grouping_level_person", registry=REGISTRY),
+        registry=REGISTRY,
     )


### PR DESCRIPTION
Per-policy-system unit registries plus the two dry-run capabilities (scalar max/min preserve the operand unit; a schedule param function may declare its own output unit).

Replaces #145, which GitHub auto-marked "merged" during a stack reorder (its head became an ancestor of its base before the base was retargeted). Same head branch, now correctly based on the infra PR with the mettsim worked example (#141) stacked on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)