### PR TITLE
Bump ai-instructions; refresh pre-commit pins and re-sync the ty pins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-useless-excludes
       # - id: identity  # Prints all files passed to pre-commits. Debugging.
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.25.0
+    rev: v2.27.1
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/lyz-code/yamlfix
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: yamlfix
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.3
+    rev: 0.38.0
     hooks:
       - id: check-github-workflows
       - id: check-jsonschema
@@ -59,7 +59,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.19
+    rev: v0.16.2
     hooks:
       - id: ruff-check
         args:
@@ -74,7 +74,7 @@ repos:
           - pyi
           - python
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.52
+    rev: v0.0.71
     hooks:
       - id: ty
         name: ty (numpy backend)
@@ -95,7 +95,7 @@ repos:
         # Keep the ty pin in sync with the `ty-pre-commit` rev above.
         language: python
         additional_dependencies:
-          - ty==0.0.49
+          - ty==0.0.71
         entry: ty check --python .pixi/envs/py314-jax
         pass_filenames: false
         always_run: true

--- a/conftest.py
+++ b/conftest.py
@@ -94,7 +94,7 @@ def _force_loop_vectorization_for_coverage(request):
 
     # Monkey-patch PolicyFunction.vectorize to force "loop" strategy when running with
     # coverage.
-    PolicyFunction.vectorize = _vectorize_with_loop  # ty: ignore[invalid-assignment]
+    PolicyFunction.vectorize = _vectorize_with_loop
     yield
     # Restore the original vectorization strategy.
     PolicyFunction.vectorize = _original_vectorize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,13 @@ dependencies = [
 [[project.authors]]
 name = "Hans-Martin von Gaudecker"
 email = "hmgaudecker@uni-bonn.de"
+
 [[project.authors]]
 name = "Marvin Immesberger"
 [[project.maintainers]]
 name = "Hans-Martin von Gaudecker"
 email = "hmgaudecker@uni-bonn.de"
+
 [[project.maintainers]]
 name = "Marvin Immesberger"
 [project.urls]
@@ -151,6 +153,7 @@ unsafe-fixes = false
 select = [ "ALL" ]
 extend-ignore = [
   "COM812",  # Conflicts with ruff-format
+  "CPY001",  # Copyright notice at top of file
   "EM101",   # Exception must not use a string literal
   "EM102",   # Exception must not use an f-string literal
   "FIX002",  # Line contains TODO
@@ -169,6 +172,7 @@ extend-ignore = [
   "PLC2401", # Non-ASCII variable name (German policy names)
   "PLC2403", # Non-ASCII import name (German policy names)
   "PLR0913", # Too many arguments
+  "PLR0917", # Too many positional arguments
   "PLR5501", # Collapsible else-if
   "UP040",   # Non-PEP 695 type alias (can't use inside TYPE_CHECKING)
   "UP046",   # Non-PEP 695 generic class (needs careful migration)
@@ -234,7 +238,6 @@ pydocstyle.convention = "google"
 column_width = 88
 max_supported_python = "3.14"
 table_format = "long"
-collapse_tables = [ "tool.hatch", "tool.pytest", "tool.pytask", "tool.ty" ]
 expand_tables = [
   "tool.pixi.dependencies",
   "tool.pixi.environments",
@@ -263,6 +266,7 @@ expand_tables = [
   "tool.pixi.pypi-dependencies.ttsim-backend",
   "tool.pixi.workspace",
 ]
+collapse_tables = [ "tool.hatch", "tool.pytask", "tool.pytest", "tool.ty" ]
 
 [tool.ty]
 # Resolve third-party imports from a pixi-managed environment. The official ty

--- a/src/ttsim/_jaxtyping_patch.py
+++ b/src/ttsim/_jaxtyping_patch.py
@@ -53,4 +53,4 @@ def _patched_meta_dtype_getitem(
     return _ORIGINAL_META_DTYPE_GETITEM(cls, item)  # ty: ignore[invalid-argument-type]
 
 
-_array_types._MetaAbstractDtype.__getitem__ = _patched_meta_dtype_getitem  # noqa: SLF001  # ty: ignore[invalid-assignment]
+_array_types._MetaAbstractDtype.__getitem__ = _patched_meta_dtype_getitem  # noqa: SLF001

--- a/src/ttsim/entry_point.py
+++ b/src/ttsim/entry_point.py
@@ -282,7 +282,7 @@ def _harmonize_main_target(
         "output multiple elements, use `main_targets` instead."
     )
     if isinstance(main_target, tuple):
-        return dt.qname_from_tree_path(main_target)  # ty: ignore [invalid-argument-type]
+        return dt.qname_from_tree_path(main_target)
     if isinstance(main_target, dict):
         if len(optree.tree_flatten(main_target, none_is_leaf=True)[0]) > 1:  # ty: ignore [invalid-argument-type]
             raise ValueError(msg)

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -514,7 +514,7 @@ def group_variables_are_not_constant_within_groups(
             target_name=name,
             grouping_levels=labels__grouping_levels,
         )
-        if group_by_id in processed_data:
+        if group_by_id is not None and group_by_id in processed_data:
             group_by_id_series = pd.Series(processed_data[group_by_id])
             leaf_series = pd.Series(processed_data[name])
             unique_counts = leaf_series.groupby(group_by_id_series).nunique(

--- a/src/ttsim/tt/param_objects.py
+++ b/src/ttsim/tt/param_objects.py
@@ -38,8 +38,7 @@ class ParamObject:
     start_date: datetime.date | None = None
     end_date: datetime.date | None = None
     unit: (
-        None
-        | Literal[
+        Literal[
             "Euros",
             "DM",
             "Share",
@@ -50,9 +49,10 @@ class ParamObject:
             "Square Meters",
             "Euros / Square Meter",
         ]
+        | None
     ) = None
     reference_period: (
-        None | Literal["Year", "Quarter", "Month", "Week", "Day", "Hour"]
+        Literal["Year", "Quarter", "Month", "Week", "Day", "Hour"] | None
     ) = None
     name: dict[Literal["de", "en"], str] | None = None
     description: dict[Literal["de", "en"], str] | None = None
@@ -404,8 +404,8 @@ def get_year_based_phase_inout_of_age_thresholds_param_value(
     if not all(isinstance(k, int) for k in raw):
         raise ValueError("All keys must be integers")
     int_raw = cast("dict[int, Any]", raw)
-    first_year_phase_inout: int = sorted(int_raw)[0]
-    last_year_phase_inout: int = sorted(int_raw)[-1]
+    first_year_phase_inout: int = min(int_raw)
+    last_year_phase_inout: int = max(int_raw)
     if first_year_to_consider > first_year_phase_inout:
         raise ValueError(
             "`first_year_to_consider` must be less than or equal to "

--- a/src/ttsim/typing.py
+++ b/src/ttsim/typing.py
@@ -153,7 +153,7 @@ if TYPE_CHECKING:
         str, "FloatColumn | IntColumn | BoolColumn | NestedData"
     ]
     """Tree mapping TTSIM paths to 1d arrays."""
-    NestedStrings: TypeAlias = Mapping[str, "str | None | NestedStrings"]
+    NestedStrings: TypeAlias = Mapping[str, "str | NestedStrings | None"]
     """Tree mapping TTSIM paths to df column names, type hints, or `None`.
 
     A `None` leaf marks a target to compute (vs. a string that renames it);
@@ -164,7 +164,7 @@ else:
     # type is not a valid Python attribute name, so beartype cannot resolve
     # it. Widen to a one-level Mapping; the per-element type still narrows.
     NestedData = Mapping[str, FloatColumn | IntColumn | BoolColumn | Mapping]
-    NestedStrings = Mapping[str, str | None | Mapping]
+    NestedStrings = Mapping[str, str | Mapping | None]
 
 # `FlatData`: flattened tree mapping TTSIM tree paths (tuple) to 1-d arrays.
 # `QNameData`: mapping of qualified-name strings to 1-d arrays.
@@ -244,7 +244,7 @@ if TYPE_CHECKING:
         @overload
         def __getitem__(
             self, key: str
-        ) -> str | None | dict[Literal["de", "en"], str | None]: ...
+        ) -> str | dict[Literal["de", "en"], str | None] | None: ...
 
         @overload
         def __getitem__(
@@ -255,33 +255,33 @@ if TYPE_CHECKING:
             self, key: str | datetime.date
         ) -> (
             str
-            | None
             | dict[Literal["de", "en"], str | None]
             | dict[Literal["note", "reference"] | str | int, Any]
+            | None
         ): ...
 
         @overload
         def get(
             self, key: str, default: None = None
-        ) -> str | None | dict[Literal["de", "en"], str | None]: ...
+        ) -> str | dict[Literal["de", "en"], str | None] | None: ...
 
         @overload
         def get(
             self, key: str, default: str | bool | float
         ) -> (
-            str | None | dict[Literal["de", "en"], str | None] | bool | int | float
+            str | dict[Literal["de", "en"], str | None] | bool | int | float | None
         ): ...
 
         def get(
             self,
             key: str,
             default: str
-            | None
             | bool
             | float
-            | dict[Literal["de", "en"], str | None] = None,
+            | dict[Literal["de", "en"], str | None]
+            | None = None,
         ) -> (
-            str | None | dict[Literal["de", "en"], str | None] | bool | int | float
+            str | dict[Literal["de", "en"], str | None] | bool | int | float | None
         ): ...
 
         def __contains__(self, key: str | datetime.date) -> bool: ...


### PR DESCRIPTION
Moves the `.ai-instructions` submodule to the current tip and runs `prek autoupdate`:
pyproject-fmt `v2.25.0` → `v2.27.1`, check-jsonschema `0.37.3` → `0.38.0`,
ruff `v0.15.19` → `v0.16.2`, ty `v0.0.52` → `v0.0.71`.

### The ty pins had drifted

`autoupdate` rewrites remote `rev:` fields only, so the `ty-jax` **local** hook kept its own
`ty==0.0.49` in `additional_dependencies` — exactly the drift its comment warns about, and
already present before this bump (`0.0.52` vs `0.0.49`). The two versions disagreed about which
`ty: ignore` directives were live, so one backend reported a suppression as unused while the
other still needed it. This syncs the local pin to `0.0.71`.

### Two ruff rules left preview

`lint.select = ["ALL"]` picks both up on crossing 0.16; both join `extend-ignore`:

- `CPY001` (missing copyright notice) — 110 occurrences
- `PLR0917` (too many positional arguments) — 18 occurrences, the positional-only sibling of
  the already-ignored `PLR0913`

### Remaining findings, fixed in place

- `RUF036` ×2 — `None` moved to the end of two unions in `typing.py`. No semantic change.
- `FURB192` ×2 — `min(int_raw)` / `max(int_raw)` for `sorted(int_raw)[0]` / `[-1]`.
  Identical for non-empty input; **on an empty mapping the exception type changes from
  `IndexError` to `ValueError`.** The preceding `all(...)` check passes vacuously on empty, so
  that path is reachable in principle — I have not traced whether any caller can get there.
- Three `ty: ignore` directives that 0.0.71 reports as unused are removed.
- `fail_if.py` guards `group_by_id is not None` before the mapping lookup. `None in
  Mapping[str, …]` was already `False`, so runtime behaviour is unchanged; the guard lets ty
  narrow what the `in` test already guaranteed.

### Verification

`prek run --all-files` is green, both ty backends included. **The test suite was not run
locally** — the box's memory slice was at 77 GB of 90 GB with an active neighbour, and a run
would have risked OOM-killing it. CI is the check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)