### PR TITLE
Bump ai-instructions; refresh pre-commit pins and re-sync the ty pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-useless-excludes
       # - id: identity  # Prints all files passed to pre-commits. Debugging.
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.25.3
+    rev: v2.27.1
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/lyz-code/yamlfix
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: yamlfix
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.4
+    rev: 0.38.0
     hooks:
       - id: check-github-workflows
       - id: check-jsonschema
@@ -59,7 +59,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.3
     hooks:
       - id: ruff-check
         args:
@@ -74,7 +74,7 @@ repos:
           - pyi
           - python
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.63
+    rev: v0.0.71
     hooks:
       - id: ty
         name: ty (numpy backend)
@@ -95,7 +95,7 @@ repos:
         # Keep the ty pin in sync with the `ty-pre-commit` rev above.
         language: python
         additional_dependencies:
-          - ty==0.0.63
+          - ty==0.0.71
         entry: ty check --python .pixi/envs/py314-jax
         pass_filenames: false
         always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,6 @@ pydocstyle.convention = "google"
 column_width = 88
 max_supported_python = "3.14"
 table_format = "long"
-collapse_tables = [ "tool.hatch", "tool.pytest", "tool.pytask", "tool.ty" ]
 expand_tables = [
   "tool.pixi.dependencies",
   "tool.pixi.environments",
@@ -269,6 +268,7 @@ expand_tables = [
   "tool.pixi.pypi-dependencies.ttsim-backend",
   "tool.pixi.workspace",
 ]
+collapse_tables = [ "tool.hatch", "tool.pytask", "tool.pytest", "tool.ty" ]
 
 [tool.ty]
 # Resolve third-party imports from a pixi-managed environment. The official ty

--- a/src/ttsim/entry_point.py
+++ b/src/ttsim/entry_point.py
@@ -297,7 +297,7 @@ def _harmonize_main_target(
         "output multiple elements, use `main_targets` instead."
     )
     if isinstance(main_target, tuple):
-        return dt.qname_from_tree_path(main_target)  # ty: ignore [invalid-argument-type]
+        return dt.qname_from_tree_path(main_target)
     if isinstance(main_target, dict):
         if len(optree.tree_flatten(main_target, none_is_leaf=True)[0]) > 1:  # ty: ignore [invalid-argument-type]
             raise ValueError(msg)


### PR DESCRIPTION
Targets `gep10-infra-1-dimensional-core`, the branch gettsim's `gep10-rollout` pins as its
ttsim backend — so the bump lands where the active work is rather than on `main`.

Moves `.ai-instructions` from `68dc3f4` to the current tip and runs `prek autoupdate`:
pyproject-fmt `v2.25.3` → `v2.27.1`, check-jsonschema `0.37.4` → `0.38.0`,
ruff `v0.16.0` → `v0.16.3`, ty `v0.0.63` → `v0.0.71`.

`autoupdate` rewrites remote `rev:` fields only, so the `ty-jax` local hook's
`additional_dependencies` pin does not move with it. Set to `0.0.71` alongside, as its own
comment asks. (This branch had them in sync, unlike `main`, where they had drifted to
`v0.0.52` vs `0.0.49`.)

Drops the `ty: ignore` on the `qname_from_tree_path` call in `entry_point.py`, which 0.0.71
reports as unused.

### Two hooks stay red — both identically on the base branch

Measured by stashing this change and re-running against the base:

| Hook | Base | This PR |
| --- | --- | --- |
| `check-jsonschema` | `tax_schedule.unit: 'Euros'` invalid, at 0.37.4 | same, at 0.38.0 |
| `ty` | 45 `missing-argument` per backend, at 0.0.63 | same, at 0.0.71 |

Neither is introduced here. The `pint` imports that also failed initially were a stale local
environment, cleared by `pixi install -e py314 -e py314-jax` — worth doing before reproducing.

### Relation to #148

#148 carries the equivalent bump against `main`. `main` additionally needs `CPY001` and
`PLR0917` added to `extend-ignore` and a few small ruff/ty fixes; this branch already has all
of that, being 84 commits ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)