### PR TITLE
GEP 10: screen truth values, where conditions, join operands, and date regimes

### DIFF
--- a/src/ttsim/_quantity_kinds.py
+++ b/src/ttsim/_quantity_kinds.py
@@ -1,0 +1,155 @@
+"""Narrow semantic evidence needed by GEP 10's grouping-level safeguards.
+
+These labels are internal checker metadata, not additional public units. They only
+distinguish explicit head counts and yes/no indicators from other quantities where
+the restricted group arithmetic needs that fact.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping
+from typing import Any, TypeAlias, cast
+
+from ttsim.interface_dag_elements.shared import FRAMEWORK_PARTIAL_ARGUMENTS
+from ttsim.tt.aggregation import AggType
+from ttsim.tt.column_objects_param_function import (
+    AggByGroupFunction,
+    ColumnObject,
+    ParamFunction,
+    PolicyInput,
+    qname_is_person_pointer,
+)
+from ttsim.tt.param_objects import ParamObject
+from ttsim.tt.type_resolution import (
+    BOOL_KINDS,
+    ResolvedKind,
+    TypeResolutionError,
+    resolve_kind_of_annotation,
+    resolve_kind_of_column_function,
+)
+from ttsim.tt.units import CompositeUnit, QuantityKind
+
+QuantityKindTree: TypeAlias = QuantityKind | Mapping[str | int, Any]
+
+
+def quantity_kind(
+    qname: str,
+    obj: Any,  # noqa: ANN401
+    env: Mapping[str, Any],
+) -> QuantityKind:
+    """Return the count/indicator evidence independently known for one node."""
+    if isinstance(obj, AggByGroupFunction):
+        if obj.agg_type is AggType.COUNT:
+            return QuantityKind.COUNT
+        if obj.agg_type in (AggType.ANY, AggType.ALL):
+            return QuantityKind.INDICATOR
+        if obj.agg_type is AggType.SUM and _aggregation_source_is_boolean(obj, env):
+            return QuantityKind.COUNT
+    declaration = getattr(obj, "unit", None)
+    if isinstance(declaration, CompositeUnit) and (
+        declaration.kind is not QuantityKind.GENERIC
+    ):
+        return declaration.kind
+    kind = _resolved_kind(qname=qname, obj=obj)
+    if kind in BOOL_KINDS or _parameter_values_are_booleans(obj):
+        return QuantityKind.INDICATOR
+    return QuantityKind.GENERIC
+
+
+def quantity_kind_for_leaf(
+    declaration: CompositeUnit,
+    value: Any,  # noqa: ANN401
+) -> QuantityKind:
+    """Return evidence for one parameter leaf, without consulting its siblings."""
+    if declaration.kind is not QuantityKind.GENERIC:
+        return declaration.kind
+    if isinstance(value, bool):
+        return QuantityKind.INDICATOR
+    return QuantityKind.GENERIC
+
+
+def quantity_kind_for_scalar_type(
+    declaration: CompositeUnit,
+    scalar_type: Any,  # noqa: ANN401
+) -> QuantityKind:
+    """Return evidence for one annotated scalar field."""
+    if declaration.kind is not QuantityKind.GENERIC:
+        return declaration.kind
+    if scalar_type is bool:
+        return QuantityKind.INDICATOR
+    return QuantityKind.GENERIC
+
+
+def quantity_kinds_by_qname(
+    env: Mapping[str, Any],
+) -> dict[str, QuantityKindTree]:
+    """Collect the narrow evidence for every environment node."""
+    return {
+        qname: (
+            _quantity_kind_tree(
+                declaration=cast("Mapping[str | int, Any]", obj.unit),
+                value=getattr(obj, "value", None),
+            )
+            if isinstance(getattr(obj, "unit", None), Mapping)
+            else quantity_kind(qname=qname, obj=obj, env=env)
+        )
+        for qname, obj in env.items()
+    }
+
+
+def _quantity_kind_tree(
+    declaration: Mapping[str | int, Any] | CompositeUnit,
+    value: Any,  # noqa: ANN401
+) -> QuantityKindTree:
+    """Mirror a mapping declaration while retaining each leaf semantic."""
+    if isinstance(declaration, Mapping):
+        values = value if isinstance(value, Mapping) else {}
+        return {
+            key: _quantity_kind_tree(
+                declaration=token,
+                value=values.get(key),
+            )
+            for key, token in declaration.items()
+        }
+    return quantity_kind_for_leaf(declaration=declaration, value=value)
+
+
+def _aggregation_source_is_boolean(
+    obj: AggByGroupFunction, env: Mapping[str, Any]
+) -> bool:
+    sources = [
+        name
+        for name in inspect.signature(obj.function).parameters
+        if not name.endswith("_id")
+        and not qname_is_person_pointer(name)
+        and name not in FRAMEWORK_PARTIAL_ARGUMENTS
+    ]
+    if len(sources) != 1 or sources[0] not in env:
+        return False
+    return _resolved_kind(qname=sources[0], obj=env[sources[0]]) in BOOL_KINDS
+
+
+def _resolved_kind(qname: str, obj: Any) -> ResolvedKind | None:  # noqa: ANN401
+    try:
+        if isinstance(obj, PolicyInput):
+            return resolve_kind_of_annotation(annotation=obj.data_type, node_name=qname)
+        if isinstance(obj, ColumnObject | ParamFunction):
+            return resolve_kind_of_column_function(func=obj.function, node_name=qname)
+    except TypeResolutionError:
+        pass
+    return None
+
+
+def _parameter_values_are_booleans(obj: Any) -> bool:  # noqa: ANN401
+    return isinstance(obj, ParamObject) and _all_leaves(
+        getattr(obj, "value", None), predicate=lambda value: isinstance(value, bool)
+    )
+
+
+def _all_leaves(value: Any, predicate: Any) -> bool:  # noqa: ANN401
+    if isinstance(value, Mapping):
+        return bool(value) and all(
+            _all_leaves(part, predicate) for part in value.values()
+        )
+    return predicate(value)

--- a/src/ttsim/_unit_inference.py
+++ b/src/ttsim/_unit_inference.py
@@ -194,13 +194,27 @@ def _as_boolean_level(unit: pint.Unit, registry: pint.UnitRegistry) -> BooleanLe
     ``1 / [fam]`` → ``(True, "fam")``; a plain ``1`` → ``(True, None)``;
     ``EUR_PER_MONTH`` or ``[hh]`` → ``(False, None)``.
     """
-    if _has_grouping_level_numerator(unit):
-        return BooleanLevel(is_boolean=False, level=None)
-    if not registry.Quantity(
-        1.0, _unit_without_grouping_levels(unit=unit, registry=registry)
-    ).dimensionless:
+    if not _is_dimensionless_up_to_grouping_level(unit=unit, registry=registry):
         return BooleanLevel(is_boolean=False, level=None)
     return BooleanLevel(is_boolean=True, level=_unit_level_denominator(unit))
+
+
+def _is_dimensionless_up_to_grouping_level(
+    unit: pint.Unit, registry: pint.UnitRegistry
+) -> bool:
+    """Whether ``unit`` is a plain number, apart from a grouping-level denominator.
+
+    ``1``, ``1 / [fam]`` → ``True``; ``EUR_PER_MONTH``, ``[hh]``, a calendar point
+    → ``False``. This is what the unit model can say about the values that carry no
+    physical content — truth values, identifiers, shares, counts. It cannot tell
+    them apart from one another (GEP 10 leaves semantic kinds to a later stage), so
+    a screen built on it rejects physical content rather than certifying a kind.
+    """
+    if _has_grouping_level_numerator(unit):
+        return False
+    return registry.Quantity(
+        1.0, _unit_without_grouping_levels(unit=unit, registry=registry)
+    ).dimensionless
 
 
 def _boolean_quantity(level: str | None, registry: pint.UnitRegistry) -> pint.Quantity:
@@ -325,6 +339,14 @@ def _run_one_path(
             qname=qname,
             reason=f"it makes more than {_MAX_DECISIONS_PER_RUN} branch decisions "
             "in one run — a data-driven loop?",
+        ), True
+    except _ReductionNotEvaluableError as err:
+        return _opt_out_required_error(
+            qname=qname,
+            reason=f"it reduces an array in the body (`xnp.{err.op}`) — a reduction "
+            "changes which rows the result belongs to, and the unit check has no "
+            "array-axis information to derive the result's grouping level from; an "
+            "aggregation node states that level instead",
         ), True
     except _LookupArityError as err:
         return (
@@ -599,6 +621,22 @@ class _ScheduleNotEvaluableError(_UnitCheckError):
     """
 
 
+class _ReductionNotEvaluableError(_UnitCheckError):
+    """An in-body array reduction the unit check cannot type.
+
+    A reduction over rows changes which entity the result belongs to — per-person
+    amounts summed over a group are the group's total — and the unit check sees no
+    array axes to read that from, so it can neither preserve nor derive the
+    result's grouping level. Caught by :func:`_run_one_path` and reported as
+    needing an explicit ``verify_units=False`` opt-out; an aggregation node, which
+    states its target level, is the checked alternative.
+    """
+
+    def __init__(self, op: str) -> None:
+        super().__init__()
+        self.op = op
+
+
 class _LookupArityError(_UnitCheckError):
     """A multi-dimensional ``look_up`` call supplies the wrong number of arguments.
 
@@ -711,9 +749,11 @@ class _UnitCheckQuantity:
     in a real run (the whole point of the check). Comparisons and truth tests
     instead return an explorer-controlled value, so the explorer — not the
     representative magnitude — decides which branch is taken; the magnitude is
-    always ``1.0`` and never matters. Anything the wrapper cannot model raises,
-    which the caller treats as "not evaluable on this path" and falls back to
-    the declaration — so the wrapper can never produce a false positive.
+    always ``1.0`` and never matters. A truth test is screened before it is
+    handed on: only a boolean may control a branch. Anything the wrapper cannot
+    model raises, which the caller treats as "not evaluable on this path" and
+    falls back to the declaration — so the wrapper can never produce a false
+    positive.
     """
 
     __slots__ = ("_explorer", "_label", "_unit_system", "q")
@@ -913,7 +953,28 @@ class _UnitCheckQuantity:
             )
 
     def __bool__(self) -> bool:
+        """Resolve a truth context — an ``if``, a conditional expression, ``and``,
+        ``or`` — on the explorer, once the value is established to be a truth value.
+
+        A branch condition is a demand that the operand have boolean semantics, not
+        merely that Python accept its numerical truthiness: a stock, a flow, a
+        calendar point or a duration controlling a branch is a bug (GEP 10). The
+        screen is the one the logical operators use, so ``if x`` and ``~x`` agree on
+        what a boolean is.
+        """
+        self._fail_if_not_a_truth_value(op=_TRUTH_VALUE_OP)
         return self._explorer.decide(self._label)
+
+    def _fail_if_not_a_truth_value(self, op: str) -> None:
+        """Reject a value with physical content where a boolean is required."""
+        if not _as_boolean_level(
+            unit=cast("pint.Unit", self.q.units), registry=self._registry
+        ).is_boolean:
+            raise _UnitMixError(
+                op=op,
+                left=cast("pint.Unit", self.q.units),
+                right=_dimensionless_unit(self._registry),
+            )
 
     # Ordering comparisons are unit-blind at run time, so a non-equivalent
     # unit-carrying operand is a bug; the explorer still forces which branch runs.
@@ -1479,7 +1540,10 @@ class _UnitCheckXnp:
     at full parity with a scalar one.
 
     An op not modelled here falls through to raw NumPy, raises, and is reported as
-    needing ``verify_units=False`` — never silently passed through.
+    needing ``verify_units=False`` — never silently passed through. The array
+    reductions are modelled only to refuse them: their result belongs to rows the
+    unit check cannot identify without array-axis metadata (see
+    :class:`_ReductionNotEvaluableError`).
     """
 
     @staticmethod
@@ -1503,7 +1567,8 @@ class _UnitCheckXnp:
         return _clamping_op(left=left, right=right, op="minimum")
 
     @staticmethod
-    def where(condition: Any, x: Any, y: Any) -> Any:  # noqa: ANN401, ARG004
+    def where(condition: Any, x: Any, y: Any) -> Any:  # noqa: ANN401
+        _fail_if_condition_is_not_a_truth_value(condition=condition)
         return _where_op(x=x, y=y)
 
     @staticmethod
@@ -1511,16 +1576,16 @@ class _UnitCheckXnp:
         return _clip_op(value=value, a_min=a_min, a_max=a_max)
 
     @staticmethod
-    def sum(value: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG004
-        return _unit_preserving_op(value)
+    def sum(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG004
+        raise _ReductionNotEvaluableError(op="sum")
 
     @staticmethod
-    def amin(value: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG004
-        return _unit_preserving_op(value)
+    def amin(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG004
+        raise _ReductionNotEvaluableError(op="amin")
 
     @staticmethod
-    def amax(value: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG004
-        return _unit_preserving_op(value)
+    def amax(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG004
+        raise _ReductionNotEvaluableError(op="amax")
 
     @staticmethod
     def floor(value: Any) -> Any:  # noqa: ANN401
@@ -1570,20 +1635,70 @@ def _piecewise_polynomial_for_unit_check(x: Any, parameters: Any, xnp: Any) -> A
 
 
 def _join_for_unit_check(
-    foreign_key: Any,  # noqa: ANN401, ARG001
-    primary_key: Any,  # noqa: ANN401, ARG001
+    foreign_key: Any,  # noqa: ANN401
+    primary_key: Any,  # noqa: ANN401
     target: Any,  # noqa: ANN401
-    value_if_foreign_key_is_missing: Any,  # noqa: ANN401, ARG001
+    value_if_foreign_key_is_missing: Any,  # noqa: ANN401
     xnp: Any,  # noqa: ANN401, ARG001
 ) -> Any:  # noqa: ANN401
-    """Unit-check stand-in for ``join``.
+    """Unit-check stand-in for ``join``, screening every operand it can read.
 
-    A person-to-person gather preserves the ``target`` column's unit and level
-    (the keys are dimensionless ``p_id``s, the missing-value a sentinel literal).
+    A gather hands on the ``target`` column's unit and grouping level, but only if
+    the rest of the call is sound (GEP 10):
+
+    - both keys must be identifiers — values with no physical content. A currency,
+      a flow, or a calendar point never identifies a row, and the run-time gather
+      would take it as an index without complaint. (That two identifiers belong to
+      the *same* key domain is beyond what the unit model can say.)
+    - the missing-key fallback becomes part of the gathered column, so it is
+      screened against the target exactly as an arm of ``where`` is: a fallback in
+      another unit is a bug that only unmatched keys would ever expose, and a bare
+      sentinel next to a dimensionless target (``-1`` for a group id) stays
+      admissible.
     """
-    if isinstance(target, _UnitCheckQuantity):
-        return target._wrap(target.q)  # noqa: SLF001
-    raise _ScheduleNotEvaluableError
+    _fail_if_join_key_is_not_an_identifier(key=foreign_key, name="foreign_key")
+    _fail_if_join_key_is_not_an_identifier(key=primary_key, name="primary_key")
+    if not isinstance(target, _UnitCheckQuantity):
+        raise _ScheduleNotEvaluableError
+    target._fail_if_other_unit_is_not_equivalent(  # noqa: SLF001
+        other=value_if_foreign_key_is_missing, op=_JOIN_FALLBACK_OP
+    )
+    return target._wrap(target.q)  # noqa: SLF001
+
+
+def _fail_if_join_key_is_not_an_identifier(key: Any, name: str) -> None:  # noqa: ANN401
+    """Reject a ``join`` key carrying physical content.
+
+    A raw key (a literal, an array the check does not model) carries no unit to
+    screen and passes; a structured pluck is reported at the pluck, as anywhere.
+    """
+    if isinstance(key, _UnitCheckStructuredValue):
+        key._raise_used_as_quantity(f"join {name}")  # noqa: SLF001
+    if not isinstance(key, _UnitCheckQuantity):
+        return
+    if not _is_dimensionless_up_to_grouping_level(
+        unit=cast("pint.Unit", key.q.units),
+        registry=key._registry,  # noqa: SLF001
+    ):
+        raise _UnitMixError(
+            op=_JOIN_KEY_OP,
+            left=cast("pint.Unit", key.q.units),
+            right=_dimensionless_unit(key._registry),  # noqa: SLF001
+        )
+
+
+def _fail_if_condition_is_not_a_truth_value(condition: Any) -> None:  # noqa: ANN401
+    """Screen a selection primitive's condition as a truth value.
+
+    The vectorized selectors run the same screen as a scalar branch, so
+    ``xnp.where(wealth, …)`` is rejected exactly as ``… if wealth else …`` is
+    (GEP 10). A raw condition — a bare literal, an array the check does not model
+    — carries no unit to screen and passes.
+    """
+    if isinstance(condition, _UnitCheckStructuredValue):
+        condition._raise_used_as_quantity(_TRUTH_VALUE_OP)  # noqa: SLF001
+    if isinstance(condition, _UnitCheckQuantity):
+        condition._fail_if_not_a_truth_value(op=_TRUTH_VALUE_OP)  # noqa: SLF001
 
 
 def _cast_ttsim_unit_for_unit_check(
@@ -1734,7 +1849,7 @@ def _clip_op(value: Any, a_min: Any, a_max: Any) -> Any:  # noqa: ANN401
 
 
 def _unit_preserving_op(value: Any) -> Any:  # noqa: ANN401
-    """A unit-preserving reduction/unary op (``sum``/``floor``/``abs``/…)."""
+    """An elementwise unit-preserving op (``floor``/``ceil``/``round``/``abs``)."""
     if isinstance(value, _UnitCheckQuantity):
         return value._wrap(value.q)  # noqa: SLF001
     return value
@@ -1752,6 +1867,13 @@ def _is_scalar_literal(value: Any) -> bool:  # noqa: ANN401
 
 #: The logical operators the unit check screens for boolean (dimensionless) operands.
 _LOGICAL_OPS = frozenset({"&", "|", "^", "~"})
+
+#: Names the screens above report themselves under, where the offending construct is
+#: not an operator: a truth context (a branch, a selector's condition) and the two
+#: `join` operands beyond the target.
+_TRUTH_VALUE_OP = "truth value"
+_JOIN_KEY_OP = "join key"
+_JOIN_FALLBACK_OP = "missing-key fallback"
 
 
 def _inferred_result_error(
@@ -1930,11 +2052,15 @@ def _unit_mix_error_message(qname: str, mix: _UnitMixError, detail: str) -> str:
     """Message for a body that combined two units unsoundly.
 
     A logical operator (``&``/``|``/``^``/``~``) carrying a real quantity is
-    reported as a non-boolean operand; an ordering comparison against a bare
-    non-zero literal is reported as an untagged threshold; ``+``/``-``/an ordering
-    comparison of non-equivalent quantities is reported as a unit mix (no run-time
-    conversion).
+    reported as a non-boolean operand; a dimensioned branch condition or selector
+    as a non-boolean truth value; a ``join`` key or missing-key fallback against
+    the contract it broke; an ordering comparison against a bare non-zero literal
+    as an untagged threshold; ``+``/``-``/an ordering comparison of non-equivalent
+    quantities as a unit mix (no run-time conversion).
     """
+    named_screen = _named_screen_message(qname=qname, mix=mix, detail=detail)
+    if named_screen is not None:
+        return named_screen
     if mix.literal is not None:
         return (
             f"{qname}: combines '{mix.left}' {mix.op} the bare literal "
@@ -1957,6 +2083,52 @@ def _unit_mix_error_message(qname: str, mix: _UnitMixError, detail: str) -> str:
         f"{qname}: applies '{mix.op}' to non-boolean operands '{mix.left}' and "
         f"'{mix.right}'{detail} — logical operators expect boolean "
         f"(dimensionless) operands."
+    )
+
+
+def _named_screen_message(qname: str, mix: _UnitMixError, detail: str) -> str | None:
+    """Message for the screens that name themselves rather than an operator.
+
+    A truth context, a ``join`` key, and a ``join`` fallback each broke a contract
+    of their own, so each is reported in its own terms; ``None`` where the offence
+    is an operator's and :func:`_unit_mix_error_message` phrases it.
+    """
+    if mix.op == _TRUTH_VALUE_OP:
+        return (
+            f"{qname}: uses '{mix.left}' as a truth value{detail} — only a boolean "
+            f"may control a branch or select between two arms; compare it against "
+            f"a quantity in the same unit instead (GEP 10)."
+        )
+    if mix.op == _JOIN_KEY_OP:
+        return (
+            f"{qname}: gathers with '{mix.left}' as a `join` key{detail} — a key is "
+            f"an identifier and carries no physical content, so a dimensioned "
+            f"column cannot identify a row (GEP 10)."
+        )
+    if mix.op == _JOIN_FALLBACK_OP:
+        return _join_fallback_message(qname=qname, mix=mix, detail=detail)
+    return None
+
+
+def _join_fallback_message(qname: str, mix: _UnitMixError, detail: str) -> str:
+    """Message for a ``join`` whose missing-key fallback is not in the target's unit.
+
+    The fallback fills the rows whose key found no match, so it lands in the
+    gathered column next to the target's own values — a bare non-zero literal
+    carries the target's unit silently, another unit is not converted at run time.
+    """
+    if mix.literal is not None:
+        return (
+            f"{qname}: gathers with the bare literal {mix.literal} as the "
+            f"missing-key fallback for a '{mix.left}' target{detail} — the fallback "
+            f"lands in the gathered column and silently carries the target's unit; "
+            f"promote it to a parameter, tag it with `cast_ttsim_unit`, or use 0 "
+            f"(GEP 10)."
+        )
+    return (
+        f"{qname}: gathers a '{mix.left}' target with a '{mix.right}' missing-key "
+        f"fallback{detail} — the fallback fills the unmatched rows of the same "
+        f"column, and there is no unit conversion at run time (GEP 10)."
     )
 
 

--- a/src/ttsim/_unit_inference.py
+++ b/src/ttsim/_unit_inference.py
@@ -5,6 +5,7 @@ GEP 10 specifies the declaration rules the inferred units are checked against.
 
 from __future__ import annotations
 
+import ast
 import functools
 import inspect
 from collections.abc import Callable, Mapping
@@ -18,6 +19,11 @@ from typing import (
 import numpy
 import pint
 
+from ttsim._quantity_kinds import (
+    QuantityKind,
+    QuantityKindTree,
+    quantity_kinds_by_qname,
+)
 from ttsim.exceptions import (
     TTSIMError,
     UnitDefinitionError,
@@ -25,7 +31,10 @@ from ttsim.exceptions import (
 from ttsim.interface_dag_elements.shared import (
     FRAMEWORK_PARTIAL_ARGUMENTS,
 )
-from ttsim.tt._function_rewriting import recompile_with_logical_ops_as_calls
+from ttsim.tt._function_rewriting import (
+    func_to_ast,
+    recompile_with_logical_ops_as_calls,
+)
 from ttsim.tt.column_objects_param_function import (
     ColumnObject,
     ParamFunction,
@@ -46,6 +55,8 @@ from ttsim.tt.units import (
     _grouping_levels_with_exponent,
     _unit_level_denominator,
     _unit_without_grouping_levels,
+    cast_ttsim_unit,
+    is_calendar_ordinal_unit,
     is_calendar_point_unit,
     pint_unit_from_ttsim_unit_for_column,
     ttsim_unit_from_yaml_value,
@@ -60,6 +71,7 @@ from ttsim.unit_resolution import (
     _resolve_schedule_input_unit,
     _resolved_return_structure,
     _returns_a_schedule,
+    _ScalarFieldKind,
     _ScheduleFieldKind,
     _structured_field_kinds,
     node_is_boolean,
@@ -83,6 +95,7 @@ def body_verification_errors(
     representative_values = _representative_values_by_qname(
         env=env, resolved_pint_units=resolved_pint_units, unit_system=unit_system
     )
+    quantity_kinds = quantity_kinds_by_qname(env)
     boolean_nodes = {
         qname
         for qname, obj in env.items()
@@ -137,17 +150,26 @@ def body_verification_errors(
                 func=obj.function,
                 module="xnp",
                 module_obj=_NON_UNIT_ARGUMENT_VALUES["xnp"],
-                extra_globals=unit_check_helper_stand_ins,
+                extra_globals=_unit_check_scope_bindings(
+                    function=obj.function,
+                    stand_ins=unit_check_helper_stand_ins,
+                ),
             ),
             declared=declared,
             boolean_values=boolean_values,
             base_kwargs=base_kwargs,
             unit_system=unit_system,
             explorer_holder=explorer_holder,
+            quantity_kinds=quantity_kinds,
         )
         if error is not None:
             errors.append(error)
     return errors
+
+
+def body_error_is_unsupported(error: str) -> bool:
+    """Whether ``error`` means symbolic evaluation is unsupported, not invalid."""
+    return isinstance(error, _UnsupportedBodyError)
 
 
 def _anchor_schedules_on_body_explorer(
@@ -169,6 +191,11 @@ def _anchor_schedules_on_body_explorer(
 def _has_grouping_level_numerator(unit: pint.Unit) -> bool:
     """Whether a unit carries a grouping level as a *numerator*."""
     return any(exponent > 0 for _, exponent in _grouping_levels_with_exponent(unit))
+
+
+def _has_grouping_component(unit: pint.Unit) -> bool:
+    """Whether a unit carries any grouping level, in numerator or denominator."""
+    return bool(_grouping_levels_with_exponent(unit))
 
 
 class BooleanLevel(NamedTuple):
@@ -250,6 +277,7 @@ def _verify_one_body(
     base_kwargs: dict[str, Any],
     unit_system: UnitSystem,
     explorer_holder: list[_PathExplorer | None],
+    quantity_kinds: Mapping[str, QuantityKindTree],
 ) -> str | None:
     """Unit-check one body on every reachable branch path; return an error or ``None``.
 
@@ -293,6 +321,7 @@ def _verify_one_body(
                 explorer=explorer,
                 unit_system=unit_system,
                 label=name,
+                kind=quantity_kinds.get(name, QuantityKind.GENERIC),
             )
             for name, value in {**base_kwargs, **boolean_values}.items()
         }
@@ -357,6 +386,8 @@ def _run_one_path(
             f"counts must match (GEP 10)."
         ), True
     except (
+        _CalendarOrdinalArithmeticError,
+        _UnsupportedGroupArithmeticError,
         _UnitMixError,
         _StructuredValueUsedAsQuantityError,
         pint.OffsetUnitCalculusError,
@@ -377,13 +408,14 @@ def _run_one_path(
             "lookup table, `join`, a raw `xnp` op) or a defect in the body itself, "
             "which this message reproduces verbatim so the two can be told apart",
         ), True
-    return _inferred_result_error(
+    error = _inferred_result_error(
         qname=qname,
         inferred=_unwrap(result),
         declared=declared,
         detail=explorer.branch_detail(),
         unit_system=unit_system,
-    ), False
+    )
+    return error, isinstance(error, _UnsupportedBodyError)
 
 
 def _representative_values_by_qname(
@@ -413,6 +445,7 @@ def _representative_values_by_qname(
             out[qname] = _UnitCheckSchedule(
                 input_unit=_resolve_schedule_input_unit(obj=obj, registry=registry),
                 output_unit=cast("pint.Unit", unit),
+                output_kind=cast("CompositeUnit", obj.output_unit).kind,
                 unit_system=unit_system,
             )
         elif (
@@ -432,6 +465,7 @@ def _representative_values_by_qname(
                     where=f"Schedule param function {qname!r}",
                 ),
                 output_unit=cast("pint.Unit", unit),
+                output_kind=obj.unit.output_unit.kind,
                 unit_system=unit_system,
             )
         elif isinstance(obj, DictParam | RawParam) and not isinstance(unit, dict):
@@ -556,6 +590,144 @@ def _unit_check_helper_stand_ins(
     return stand_ins, explorer_holder
 
 
+class _ObjectWithCastStandIn:
+    """Delegate every attribute except the canonical unit cast to an object."""
+
+    def __init__(self, wrapped: Any, cast_stand_in: Any) -> None:  # noqa: ANN401
+        self._wrapped = wrapped
+        self.cast_ttsim_unit = cast_stand_in
+
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+        return getattr(self._wrapped, name)
+
+
+def _function_scope(function: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Return the globals and dereferenced closure cells visible to a function."""
+    scope = dict(getattr(function, "__globals__", {}))
+    closure = getattr(function, "__closure__", None)
+    code = getattr(function, "__code__", None)
+    if closure and code is not None:
+        scope.update(
+            dict(
+                zip(
+                    code.co_freevars,
+                    (cell.cell_contents for cell in closure),
+                    strict=True,
+                )
+            )
+        )
+    return scope
+
+
+def _unit_check_scope_bindings(
+    function: Any,  # noqa: ANN401
+    stand_ins: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Add every true alias of ``cast_ttsim_unit`` to checker stand-ins.
+
+    Identity, not spelling, is authoritative. Import aliases and closure aliases
+    are rebound directly. A module alias is replaced by a delegating proxy whose
+    cast attribute is the stand-in, so its other helpers remain untouched.
+    """
+    cast_stand_in = stand_ins["cast_ttsim_unit"]
+    bindings = {
+        name: value for name, value in stand_ins.items() if name != "cast_ttsim_unit"
+    }
+    for name, value in _function_scope(function).items():
+        if value is cast_ttsim_unit:
+            bindings[name] = cast_stand_in
+        else:
+            try:
+                attribute = inspect.getattr_static(value, "cast_ttsim_unit")
+            except AttributeError:
+                continue
+            if attribute is cast_ttsim_unit:
+                bindings[name] = _ObjectWithCastStandIn(value, cast_stand_in)
+    return bindings
+
+
+def _cast_aliases_in_scope(scope: Mapping[str, Any]) -> tuple[set[str], set[str]]:
+    """Return direct and module aliases that resolve to the canonical cast."""
+    direct_aliases = {name for name, value in scope.items() if value is cast_ttsim_unit}
+    module_aliases: set[str] = set()
+    for name, value in scope.items():
+        try:
+            attribute = inspect.getattr_static(value, "cast_ttsim_unit")
+        except AttributeError:
+            continue
+        if attribute is cast_ttsim_unit:
+            module_aliases.add(name)
+    return direct_aliases, module_aliases
+
+
+def _assignment_rhs_is_cast(
+    node: ast.Assign,
+    aliases: set[str],
+    module_aliases: set[str],
+) -> bool:
+    """Whether an assignment copies a known canonical-cast alias."""
+    return (isinstance(node.value, ast.Name) and node.value.id in aliases) or (
+        isinstance(node.value, ast.Attribute)
+        and node.value.attr == "cast_ttsim_unit"
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id in module_aliases
+    )
+
+
+def _local_cast_aliases(
+    tree: ast.Module,
+    direct_aliases: set[str],
+    module_aliases: set[str],
+) -> set[str]:
+    """Expand aliases through local ``alias = existing_alias`` assignments."""
+    aliases = set(direct_aliases)
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or not _assignment_rhs_is_cast(
+                node=node, aliases=aliases, module_aliases=module_aliases
+            ):
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id not in aliases:
+                    aliases.add(target.id)
+                    changed = True
+    return aliases
+
+
+def function_uses_local_cast(function: Any) -> bool:  # noqa: ANN401
+    """Whether a body calls the canonical cast, directly or through a true alias."""
+    direct_aliases, module_aliases = _cast_aliases_in_scope(_function_scope(function))
+    try:
+        tree = func_to_ast(function)
+    except (OSError, TypeError, IndentationError, SyntaxError):
+        code = getattr(function, "__code__", None)
+        return code is not None and bool(
+            set(code.co_names).intersection(direct_aliases | module_aliases)
+            or set(code.co_freevars).intersection(direct_aliases)
+        )
+
+    aliases = _local_cast_aliases(
+        tree=tree,
+        direct_aliases=direct_aliases,
+        module_aliases=module_aliases,
+    )
+    return any(
+        isinstance(node, ast.Call)
+        and (
+            (isinstance(node.func, ast.Name) and node.func.id in aliases)
+            or (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "cast_ttsim_unit"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in module_aliases
+            )
+        )
+        for node in ast.walk(tree)
+    )
+
+
 # Caps on the path-exploring unit check (see ``_PathExplorer``): only a pathological
 # body (deep independent branching, or a data-driven loop) hits them, so the build
 # check can never blow up.
@@ -609,6 +781,24 @@ class _UnitMixError(_UnitCheckError):
         # The bare numeric literal an ordering comparison was made against, when
         # that is the offence; ``None`` for the unit-vs-unit mismatch cases.
         self.literal = literal
+
+
+class _CalendarOrdinalArithmeticError(_UnitCheckError):
+    """A quarter-, month-, or day-within-period value was used arithmetically."""
+
+    def __init__(self, op: str) -> None:
+        super().__init__()
+        self.op = op
+
+
+class _UnsupportedGroupArithmeticError(_UnitCheckError):
+    """A product or ratio lies outside GEP 10's restricted group rules."""
+
+    def __init__(self, op: str, left: pint.Unit, right: pint.Unit) -> None:
+        super().__init__()
+        self.op = op
+        self.left = left
+        self.right = right
 
 
 class _ScheduleNotEvaluableError(_UnitCheckError):
@@ -756,7 +946,7 @@ class _UnitCheckQuantity:
     positive.
     """
 
-    __slots__ = ("_explorer", "_label", "_unit_system", "q")
+    __slots__ = ("_explorer", "_kind", "_label", "_unit_system", "q")
     # Keep NumPy from broadcasting over us: defer binary ops with a NumPy operand
     # to our reflected dunders instead.
     __array_ufunc__ = None
@@ -769,12 +959,14 @@ class _UnitCheckQuantity:
         explorer: _PathExplorer,
         unit_system: UnitSystem,
         label: str | None = None,
+        kind: QuantityKind = QuantityKind.GENERIC,
     ) -> None:
         self.q = q
         self._explorer = explorer
         # The system whose registry `q` lives in — every unit the wrapper mints
         # (a boolean's level, a dimensionless truth value) must land there too.
         self._unit_system = unit_system
+        self._kind = kind
         # How the body's author would name this value — the argument name for a
         # direct input, a composed description for a comparison or logical
         # combination, ``None`` once arithmetic has mixed it beyond naming. Used
@@ -785,9 +977,16 @@ class _UnitCheckQuantity:
     def _registry(self) -> pint.UnitRegistry:
         return self._unit_system.registry
 
-    def _wrap(self, q: Any) -> _UnitCheckQuantity:  # noqa: ANN401
+    def _wrap(
+        self,
+        q: Any,  # noqa: ANN401
+        kind: QuantityKind = QuantityKind.GENERIC,
+    ) -> _UnitCheckQuantity:
         return _UnitCheckQuantity(
-            q=q, explorer=self._explorer, unit_system=self._unit_system
+            q=q,
+            explorer=self._explorer,
+            unit_system=self._unit_system,
+            kind=kind,
         )
 
     def _controlled_bool_at(
@@ -798,6 +997,7 @@ class _UnitCheckQuantity:
             explorer=self._explorer,
             unit_system=self._unit_system,
             label=label,
+            kind=QuantityKind.INDICATOR,
         )
 
     def _composed_label(self, other: Any, op: str) -> str | None:  # noqa: ANN401
@@ -890,6 +1090,7 @@ class _UnitCheckQuantity:
         other_q = _unwrap(other)
         if isinstance(other_q, _UnitCheckStructuredValue):
             other_q._raise_used_as_quantity(op)  # noqa: SLF001
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op=op)
         self_is_point = is_calendar_point_unit(
             unit=cast("pint.Unit", self.q.units), registry=self._registry
         )
@@ -913,6 +1114,150 @@ class _UnitCheckQuantity:
         if self_is_point or other_is_point:
             return
         self._fail_if_other_unit_is_not_equivalent(other=other, op=op)
+
+    def _fail_if_calendar_ordinal_arithmetic(self, other: Any, op: str) -> None:  # noqa: ANN401
+        """Reject arithmetic on month/day/quarter ordinals.
+
+        These values can be ordered on the same scale, but neither a difference
+        nor a shift has a calendar-independent meaning.
+        """
+        other_q = _unwrap(other)
+        if is_calendar_ordinal_unit(cast("pint.Unit", self.q.units)) or (
+            isinstance(other_q, pint.Quantity)
+            and is_calendar_ordinal_unit(cast("pint.Unit", other_q.units))
+        ):
+            raise _CalendarOrdinalArithmeticError(op=op)
+
+    def _group_arithmetic(
+        self,
+        other: Any,  # noqa: ANN401
+        *,
+        op: str,
+        reflected: bool = False,
+    ) -> tuple[Any, QuantityKind]:
+        """Apply multiplication/division under the restricted group rules."""
+        other_q = _unwrap(other)
+        if isinstance(other_q, _UnitCheckStructuredValue):
+            other_q._raise_used_as_quantity(op)  # noqa: SLF001
+        if not isinstance(other_q, pint.Quantity):
+            left_q, right_q = (other_q, self.q) if reflected else (self.q, other_q)
+            if (
+                op == "/"
+                and reflected
+                and _has_grouping_component(cast("pint.Unit", self.q.units))
+            ):
+                # ``bare / group_quantity`` creates a grouping numerator. Reject it
+                # at the reciprocal rather than allowing a later multiplication to
+                # cancel the marker and hide the illegal route.
+                raise _UnsupportedGroupArithmeticError(
+                    op=op,
+                    left=_dimensionless_unit(self._registry),
+                    right=cast("pint.Unit", self.q.units),
+                )
+            if op == "*":
+                result = left_q * right_q
+            else:
+                try:
+                    result = left_q / right_q
+                except ZeroDivisionError:
+                    result = left_q / self._nonzero_like(right_q)
+            # Arithmetic no longer carries independent evidence that a value is
+            # exactly a head count or a yes/no indicator.
+            return result, QuantityKind.GENERIC
+
+        other_kind = (
+            other._kind  # noqa: SLF001
+            if isinstance(other, _UnitCheckQuantity)
+            else QuantityKind.GENERIC
+        )
+        left_q, right_q = (other_q, self.q) if reflected else (self.q, other_q)
+        left_kind, right_kind = (
+            (other_kind, self._kind) if reflected else (self._kind, other_kind)
+        )
+        left_level = _unit_level_denominator(cast("pint.Unit", left_q.units))
+        right_level = _unit_level_denominator(cast("pint.Unit", right_q.units))
+
+        if left_level is not None and right_level is not None:
+            return self._group_arithmetic_with_two_levels(
+                op=op,
+                left_q=left_q,
+                right_q=right_q,
+                left_kind=left_kind,
+                right_kind=right_kind,
+                levels_match=left_level == right_level,
+            )
+
+        if op == "/" and left_level is None and right_level is not None:
+            # This would create a grouping level in the numerator. GEP 10 only
+            # derives the reverse, group-total / matching-head-count bridge.
+            raise _UnsupportedGroupArithmeticError(
+                op=op,
+                left=cast("pint.Unit", left_q.units),
+                right=cast("pint.Unit", right_q.units),
+            )
+
+        if op == "*":
+            result = left_q * right_q
+        else:
+            try:
+                result = left_q / right_q
+            except ZeroDivisionError:
+                result = left_q / self._nonzero_like(right_q)
+        return result, QuantityKind.GENERIC
+
+    @staticmethod
+    def _group_arithmetic_with_two_levels(
+        *,
+        op: str,
+        left_q: pint.Quantity,
+        right_q: pint.Quantity,
+        left_kind: QuantityKind,
+        right_kind: QuantityKind,
+        levels_match: bool,
+    ) -> tuple[pint.Quantity, QuantityKind]:
+        """Apply the matching-count and same-level-indicator exceptions."""
+        if (
+            levels_match
+            and op == "*"
+            and QuantityKind.INDICATOR
+            in (
+                left_kind,
+                right_kind,
+            )
+        ):
+            # A known yes/no value masks rather than multiplies the group marker.
+            if left_kind is QuantityKind.INDICATOR:
+                return right_q * left_q.magnitude, right_kind
+            return left_q * right_q.magnitude, left_kind
+        if levels_match and op == "/" and right_kind is QuantityKind.COUNT:
+            return left_q / right_q, QuantityKind.GENERIC
+        raise _UnsupportedGroupArithmeticError(
+            op=op,
+            left=cast("pint.Unit", left_q.units),
+            right=cast("pint.Unit", right_q.units),
+        )
+
+    def _fail_if_grouping_operator_is_unsupported(
+        self,
+        other: object,
+        op: str,
+    ) -> None:
+        """Reject operators for which GEP 10 defines no group-level bridge."""
+        other_q = _unwrap(other)
+        self_has_group = _has_grouping_component(cast("pint.Unit", self.q.units))
+        other_has_group = isinstance(
+            other_q, pint.Quantity
+        ) and _has_grouping_component(cast("pint.Unit", other_q.units))
+        if self_has_group or other_has_group:
+            raise _UnsupportedGroupArithmeticError(
+                op=op,
+                left=cast("pint.Unit", self.q.units),
+                right=(
+                    cast("pint.Unit", other_q.units)
+                    if isinstance(other_q, pint.Quantity)
+                    else _dimensionless_unit(self._registry)
+                ),
+            )
 
     def _fail_if_other_unit_is_not_equivalent(self, other: Any, op: str) -> None:  # noqa: ANN401
         """Reject an invalid operand of an ordering comparison or ``where``.
@@ -1072,10 +1417,14 @@ class _UnitCheckQuantity:
         return self._wrap(_unwrap(other) - self.q)
 
     def __mul__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
-        return self._wrap(self.q * _unwrap(other))
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="*")
+        result, kind = self._group_arithmetic(other, op="*")
+        return self._wrap(result, kind=kind)
 
     def __rmul__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
-        return self._wrap(_unwrap(other) * self.q)
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="*")
+        result, kind = self._group_arithmetic(other, op="*", reflected=True)
+        return self._wrap(result, kind=kind)
 
     def _nonzero_like(self, value: Any) -> Any:  # noqa: ANN401
         """A magnitude-1.0 stand-in for a division operand.
@@ -1092,20 +1441,18 @@ class _UnitCheckQuantity:
         return 1.0
 
     def __truediv__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
-        divisor = _unwrap(other)
-        try:
-            return self._wrap(self.q / divisor)
-        except ZeroDivisionError:
-            return self._wrap(self.q / self._nonzero_like(divisor))
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="/")
+        result, kind = self._group_arithmetic(other, op="/")
+        return self._wrap(result, kind=kind)
 
     def __rtruediv__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
-        dividend = _unwrap(other)
-        try:
-            return self._wrap(dividend / self.q)
-        except ZeroDivisionError:
-            return self._wrap(dividend / self._nonzero_like(self.q))
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="/")
+        result, kind = self._group_arithmetic(other, op="/", reflected=True)
+        return self._wrap(result, kind=kind)
 
     def __floordiv__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="//")
+        self._fail_if_grouping_operator_is_unsupported(other=other, op="//")
         divisor = _unwrap(other)
         try:
             return self._wrap(self.q // divisor)
@@ -1113,6 +1460,8 @@ class _UnitCheckQuantity:
             return self._wrap(self.q // self._nonzero_like(divisor))
 
     def __rfloordiv__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="//")
+        self._fail_if_grouping_operator_is_unsupported(other=other, op="//")
         dividend = _unwrap(other)
         try:
             return self._wrap(dividend // self.q)
@@ -1120,24 +1469,33 @@ class _UnitCheckQuantity:
             return self._wrap(dividend // self._nonzero_like(self.q))
 
     def __mod__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="%")
         return self._wrap(self.q % _unwrap(other))
 
     def __rmod__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="%")
         return self._wrap(_unwrap(other) % self.q)
 
     def __pow__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="**")
+        self._fail_if_grouping_operator_is_unsupported(other=other, op="**")
         return self._wrap(self.q ** _unwrap(other))
 
     def __rpow__(self, other: Any) -> _UnitCheckQuantity:  # noqa: ANN401
+        self._fail_if_calendar_ordinal_arithmetic(other=other, op="**")
+        self._fail_if_grouping_operator_is_unsupported(other=other, op="**")
         return self._wrap(_unwrap(other) ** self.q)
 
     def __neg__(self) -> _UnitCheckQuantity:
+        self._fail_if_calendar_ordinal_arithmetic(other=1, op="unary -")
         return self._wrap(-self.q)
 
     def __pos__(self) -> _UnitCheckQuantity:
+        self._fail_if_calendar_ordinal_arithmetic(other=1, op="unary +")
         return self._wrap(+self.q)
 
     def __abs__(self) -> _UnitCheckQuantity:
+        self._fail_if_calendar_ordinal_arithmetic(other=1, op="abs")
         return self._wrap(abs(self.q))
 
     def __round__(self, ndigits: int | None = None) -> _UnitCheckQuantity:
@@ -1183,6 +1541,7 @@ def _wrap_for_unit_check(
     explorer: _PathExplorer,
     unit_system: UnitSystem,
     label: str | None = None,
+    kind: QuantityKindTree = QuantityKind.GENERIC,
 ) -> Any:  # noqa: ANN401
     """Wrap unit-carrying representative values; pass framework args through.
 
@@ -1197,7 +1556,11 @@ def _wrap_for_unit_check(
     """
     if isinstance(value, pint.Quantity):
         return _UnitCheckQuantity(
-            q=value, explorer=explorer, unit_system=unit_system, label=label
+            q=value,
+            explorer=explorer,
+            unit_system=unit_system,
+            label=label,
+            kind=kind if isinstance(kind, QuantityKind) else QuantityKind.GENERIC,
         )
     if isinstance(value, _UnitCheckStructuredValue):
         return _UnitCheckStructuredValue(
@@ -1216,6 +1579,11 @@ def _wrap_for_unit_check(
                 explorer=explorer,
                 unit_system=unit_system,
                 label=f"{label}[{key!r}]" if label is not None else None,
+                kind=(
+                    kind.get(key, QuantityKind.GENERIC)
+                    if isinstance(kind, Mapping)
+                    else kind
+                ),
             )
             for key, leaf in value.items()
         }
@@ -1294,10 +1662,16 @@ class _UnitCheckStructuredValue:
         )
         resolved = (kinds or {}).get(name)
         label = f"{self._label}.{name}" if self._label is not None else None
-        if isinstance(resolved, pint.Unit):
+        if isinstance(resolved, pint.Unit | _ScalarFieldKind):
             # An annotated field's pluck is a known quantity; with the run's
             # explorer it screens and branches like any other operand.
-            quantity = self._unit_system.registry.Quantity(1.0, resolved)
+            unit = resolved.unit if isinstance(resolved, _ScalarFieldKind) else resolved
+            kind = (
+                resolved.kind
+                if isinstance(resolved, _ScalarFieldKind)
+                else QuantityKind.GENERIC
+            )
+            quantity = self._unit_system.registry.Quantity(1.0, unit)
             if self._explorer is None:
                 return quantity
             return _UnitCheckQuantity(
@@ -1305,6 +1679,7 @@ class _UnitCheckStructuredValue:
                 explorer=self._explorer,
                 unit_system=self._unit_system,
                 label=label,
+                kind=kind,
             )
         if isinstance(resolved, _ScheduleFieldKind):
             # A schedule-typed field declares both axes; the pluck yields a
@@ -1313,6 +1688,7 @@ class _UnitCheckStructuredValue:
             return _UnitCheckSchedule(
                 input_unit=resolved.input_unit,
                 output_unit=resolved.output_unit,
+                output_kind=resolved.output_kind,
                 unit_system=self._unit_system,
                 explorer_holder=self._explorer_holder,
             )
@@ -1427,17 +1803,25 @@ class _UnitCheckSchedule:
     - ``None`` — unscreened; a schedule parameter that left its input axis unset.
     """
 
-    __slots__ = ("explorer_holder", "input_unit", "output_unit", "unit_system")
+    __slots__ = (
+        "explorer_holder",
+        "input_unit",
+        "output_kind",
+        "output_unit",
+        "unit_system",
+    )
 
     def __init__(
         self,
         input_unit: pint.Unit | tuple[pint.Unit, ...] | None,
         output_unit: pint.Unit,
         unit_system: UnitSystem,
+        output_kind: QuantityKind = QuantityKind.GENERIC,
         explorer_holder: list[_PathExplorer | None] | None = None,
     ) -> None:
         self.input_unit = input_unit
         self.output_unit = output_unit
+        self.output_kind = output_kind
         self.unit_system = unit_system
         self.explorer_holder = explorer_holder
 
@@ -1493,6 +1877,7 @@ class _UnitCheckSchedule:
             q=self.unit_system.registry.Quantity(1.0, self.output_unit),
             explorer=explorer,
             unit_system=self.unit_system,
+            kind=self.output_kind,
         )
 
     def _axis_at(self, position: int) -> pint.Unit | None:
@@ -1731,11 +2116,13 @@ def _cast_ttsim_unit_for_unit_check(
     )
     quantity = unit_system.registry.Quantity(1.0, resolved)
     if isinstance(value, _UnitCheckQuantity):
-        return value._wrap(quantity)  # noqa: SLF001
+        return value._wrap(quantity, kind=token.kind)  # noqa: SLF001
     explorer = explorer_holder[0]
     if explorer is None:
         return quantity
-    return _UnitCheckQuantity(q=quantity, explorer=explorer, unit_system=unit_system)
+    return _UnitCheckQuantity(
+        q=quantity, explorer=explorer, unit_system=unit_system, kind=token.kind
+    )
 
 
 def _time_conversion_stand_ins(registry: pint.UnitRegistry) -> dict[str, Any]:
@@ -2016,7 +2403,9 @@ def _summarize_branch_errors(
 
 def _arithmetic_misuse_message(
     qname: str,
-    error: _UnitMixError
+    error: _CalendarOrdinalArithmeticError
+    | _UnsupportedGroupArithmeticError
+    | _UnitMixError
     | _StructuredValueUsedAsQuantityError
     | pint.OffsetUnitCalculusError
     | pint.DimensionalityError,
@@ -2036,6 +2425,22 @@ def _arithmetic_misuse_message(
     bugs, not un-checkable bodies, so they report as misuse rather than
     demanding ``verify_units=False``.
     """
+    if isinstance(error, _CalendarOrdinalArithmeticError):
+        return (
+            f"{qname}: uses a calendar ordinal in `{error.op}`{detail} — a quarter "
+            "of year, month of year, or day of month may only be compared with the "
+            "same calendar scale; use an explicit local unit assertion for a "
+            "policy-specific conversion (GEP 10)."
+        )
+    if isinstance(error, _UnsupportedGroupArithmeticError):
+        return (
+            f"{qname}: uses an unsupported group calculation "
+            f"'{error.left}' {error.op} '{error.right}'{detail}. TTSIM only "
+            "derives ordinary scalar scaling, a group total divided by its "
+            "matching head count, the reverse head-count multiplication, and a "
+            "same-level yes/no mask; use an aggregation or a local unit assertion "
+            "for a deliberate exception (GEP 10)."
+        )
     if isinstance(error, _UnitMixError):
         return _unit_mix_error_message(qname=qname, mix=error, detail=detail)
     if isinstance(error, _StructuredValueUsedAsQuantityError):
@@ -2148,7 +2553,13 @@ def _structured_pluck_message(
     )
 
 
-def _opt_out_required_error(qname: str, reason: str) -> str:
+class _UnsupportedBodyError(str):
+    """Diagnostic marker for a body the symbolic checker cannot evaluate."""
+
+    __slots__ = ()
+
+
+def _opt_out_required_error(qname: str, reason: str) -> _UnsupportedBodyError:
     """Message demanding an explicit opt-out for a body the unit check cannot evaluate.
 
     A body the unit check cannot evaluate is *not* waved through silently:
@@ -2157,7 +2568,7 @@ def _opt_out_required_error(qname: str, reason: str) -> str:
     stands and the body's edges are still checked — only its internal inference
     is skipped.
     """
-    return (
+    return _UnsupportedBodyError(
         f"{qname}: its body cannot be unit-checked ({reason}). "
         f"Set `verify_units=False` on its decorator to opt out of body inference "
         f"— its declared unit and its edges stay checked (GEP 10)."

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -785,15 +785,31 @@ def backend_has_changed(
                 # attributes (GETTSIM tests fail otherwise).
                 if jax is not None and isinstance(arg, jax.Array):
                     continue
-                if isinstance(arg, numpy.ndarray) or any(
-                    isinstance(getattr(arg, attr), numpy.ndarray) for attr in dir(arg)
-                ):
+                if isinstance(arg, numpy.ndarray) or _has_numpy_array_attribute(arg):
                     issues += f"    {dt.tree_path_from_qname(argname)}\n"
     if issues:
         raise ValueError(
             "Backend has changed from numpy to jax.\n\n"
             f"Found numpy arrays in:\n\n{issues}"
         )
+
+
+def _has_numpy_array_attribute(obj: Any) -> bool:  # noqa: ANN401
+    """Inspect direct attributes without assuming every name in ``dir`` is readable.
+
+    NumPy 2 scalar types retain removed methods such as ``itemset`` in ``dir(obj)``
+    but raise :class:`AttributeError` when the attribute is accessed. Those tombstone
+    names are irrelevant here; readable array-valued attributes still identify a
+    policy environment built for the NumPy backend.
+    """
+    for name in dir(obj):
+        try:
+            value = getattr(obj, name)
+        except AttributeError:
+            continue
+        if isinstance(value, numpy.ndarray):
+            return True
+    return False
 
 
 @fail_function()

--- a/src/ttsim/interface_dag_elements/unit_checks.py
+++ b/src/ttsim/interface_dag_elements/unit_checks.py
@@ -9,6 +9,7 @@ resolution — and the checks that consume it — lives in
 
 from __future__ import annotations
 
+import datetime
 from typing import (
     Any,
 )
@@ -26,6 +27,7 @@ from ttsim.typing import (
     SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
 )
 from ttsim.unit_resolution import resolve_environment_units
+from ttsim.unit_validation import UnitValidationReport, create_unit_validation_report
 
 
 @interface_function()
@@ -52,3 +54,19 @@ def declared_ttsim_units(
         for qname, obj in specialized_environment__without_tree_logic_and_with_derived_functions.items()  # noqa: E501
         if isinstance((token := getattr(obj, "unit", UNSET_UNIT)), CompositeUnit)
     }
+
+
+@interface_function()
+def validation_report(
+    specialized_environment__without_tree_logic_and_with_derived_functions: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,  # noqa: E501
+    labels__grouping_levels: OrderedQNames,
+    unit_system: UnitSystem,
+    policy_date: datetime.date,
+) -> UnitValidationReport:
+    """Auditable declaration, body, rule, cast, and opt-out coverage."""
+    return create_unit_validation_report(
+        env=specialized_environment__without_tree_logic_and_with_derived_functions,
+        grouping_levels=labels__grouping_levels,
+        unit_system=unit_system,
+        policy_dates=(policy_date,),
+    )

--- a/src/ttsim/main_target.py
+++ b/src/ttsim/main_target.py
@@ -201,6 +201,7 @@ class Templates(MainTargetABC):
 class UnitChecks(MainTargetABC):
     resolved_pint_units: str = "unit_checks__resolved_pint_units"
     declared_ttsim_units: str = "unit_checks__declared_ttsim_units"
+    validation_report: str = "unit_checks__validation_report"
 
 
 @dataclass(frozen=True)

--- a/src/ttsim/testing_utils.py
+++ b/src/ttsim/testing_utils.py
@@ -73,6 +73,72 @@ def isolated_unit_vocabulary() -> Iterator[None]:
             delattr(CompositeUnit, step)
 
 
+def get_policy_date_partition(
+    orig_policy_objects: dict[
+        str, FlatColumnObjectsParamFunctions | FlatOrigParamSpecs
+    ],
+    unit_system: UnitSystem | None = None,
+) -> list[datetime.date]:
+    """The dates a policy package must be validated at — one per structural regime.
+
+    The resolved environment changes not only where a function starts or stops, but
+    also where a parameter entry or the statutory currency does: a parameter-only
+    change opens a regime of its own even though every function stays active, and a
+    partition built from function dates alone never assembles it (GEP 10). Each
+    returned date is the left endpoint of one regime:
+
+    - every column object's and param function's start date, and the day after each
+      inclusive end date;
+    - every dated parameter entry — where a value, unit, currency, or leaf set may
+      change;
+    - every statutory-currency start date of ``unit_system``, where one is given.
+
+    Boundaries outside the package's own date domain — the span from its earliest
+    start date to the day after its latest end date — are dropped: no environment
+    exists there to validate. Rounding specifications carry the dates of the
+    function they sit on and so contribute no boundary of their own.
+
+    Args:
+        orig_policy_objects: The package's ``column_objects_and_param_functions``
+            and ``param_specs``, as returned by `main`.
+        unit_system: The package's unit system, whose statutory-currency
+            transitions are boundaries too.
+
+    Returns:
+        The regime start dates, sorted and deduplicated.
+
+    """
+    column_objects = orig_policy_objects["column_objects_and_param_functions"]
+    start_dates = {
+        obj.start_date  # ty: ignore[unresolved-attribute]
+        for obj in column_objects.values()
+    }
+    if not start_dates:
+        return []
+    end_dates = {
+        obj.end_date + datetime.timedelta(days=1)  # ty: ignore[unresolved-attribute]
+        for obj in column_objects.values()
+    }
+    param_dates = {
+        key
+        for spec in orig_policy_objects.get("param_specs", {}).values()
+        for key in spec
+        if isinstance(key, datetime.date)
+    }
+    currency_dates = (
+        {date for date, _ in unit_system.statutory_currency_by_start_date}
+        if unit_system is not None
+        else set()
+    )
+    domain_start = min(start_dates)
+    domain_end = max(end_dates)
+    return sorted(
+        date
+        for date in start_dates | end_dates | param_dates | currency_dates
+        if domain_start <= date <= domain_end
+    )
+
+
 @lru_cache(maxsize=100)
 def cached_policy_environment(
     policy_date: datetime.date,

--- a/src/ttsim/testing_utils.py
+++ b/src/ttsim/testing_utils.py
@@ -16,6 +16,7 @@ import pandas as pd
 import yaml
 
 from ttsim import main, merge_trees
+from ttsim.exceptions import UnitConsistencyError, UnitDefinitionError
 from ttsim.interface_dag_elements.data_converters import (
     nested_data_to_df_with_nested_columns,
 )
@@ -41,8 +42,9 @@ from ttsim.typing import (
     PolicyEnvironment,
 )
 from ttsim.unit_validation import (
-    fail_if_environment_units_are_inconsistent,
-    fail_if_environment_units_are_missing,
+    UnitValidationReport,
+    create_unit_validation_report,
+    merge_unit_validation_reports,
 )
 
 # Set display options to show all columns without truncation
@@ -93,10 +95,11 @@ def get_policy_date_partition(
       change;
     - every statutory-currency start date of ``unit_system``, where one is given.
 
-    Boundaries outside the package's own date domain — the span from its earliest
-    start date to the day after its latest end date — are dropped: no environment
-    exists there to validate. Rounding specifications carry the dates of the
-    function they sit on and so contribute no boundary of their own.
+    Boundaries outside the package's own date domain — from its earliest start date
+    through its latest inclusive end date — are dropped: no environment exists there
+    to validate. In particular, the day after the final active function is not itself
+    a regime. Rounding specifications carry the dates of the function they sit on and
+    so contribute no boundary of their own.
 
     Args:
         orig_policy_objects: The package's ``column_objects_and_param_functions``
@@ -135,7 +138,7 @@ def get_policy_date_partition(
     return sorted(
         date
         for date in start_dates | end_dates | param_dates | currency_dates
-        if domain_start <= date <= domain_end
+        if domain_start <= date < domain_end
     )
 
 
@@ -406,7 +409,7 @@ def check_policy_environment_units(
         str, FlatColumnObjectsParamFunctions | FlatOrigParamSpecs
     ],
     unit_system: UnitSystem,
-) -> None:
+) -> UnitValidationReport:
     """Run the unit checks over the full environment at a policy date.
 
     Builds the data-independent specialized environment (all derivable nodes
@@ -433,7 +436,43 @@ def check_policy_environment_units(
         "without_tree_logic_and_with_derived_functions"
     ]
     grouping_levels = targets["labels"]["grouping_levels"]
-    fail_if_environment_units_are_missing(env)
-    fail_if_environment_units_are_inconsistent(
-        env=env, grouping_levels=grouping_levels, unit_system=unit_system
+    report = create_unit_validation_report(
+        env=env,
+        grouping_levels=grouping_levels,
+        unit_system=unit_system,
+        policy_dates=(policy_date,),
     )
+    if report.unsupported_bodies:
+        errors = [f"{item.qname}: {item.reason}" for item in report.unsupported_bodies]
+        raise UnitConsistencyError(
+            "Environment unit-consistency check failed:\n  " + "\n  ".join(errors)
+        )
+    return report
+
+
+def check_policy_environment_unit_history(
+    orig_policy_objects: dict[
+        str, FlatColumnObjectsParamFunctions | FlatOrigParamSpecs
+    ],
+    unit_system: UnitSystem,
+) -> UnitValidationReport:
+    """Validate and summarize every structurally distinct policy-date regime."""
+    dates = get_policy_date_partition(
+        orig_policy_objects=orig_policy_objects,
+        unit_system=unit_system,
+    )
+    reports: list[UnitValidationReport] = []
+    for date in dates:
+        try:
+            reports.append(
+                check_policy_environment_units(
+                    policy_date=date,
+                    orig_policy_objects=orig_policy_objects,
+                    unit_system=unit_system,
+                )
+            )
+        except UnitConsistencyError as error:
+            raise UnitConsistencyError(f"Policy date {date}: {error}") from error
+        except UnitDefinitionError as error:
+            raise UnitDefinitionError(f"Policy date {date}: {error}") from error
+    return merge_unit_validation_reports(reports)

--- a/src/ttsim/tt/units.py
+++ b/src/ttsim/tt/units.py
@@ -32,6 +32,7 @@ import math
 import re
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, replace
+from enum import Enum, auto
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 
@@ -106,10 +107,13 @@ _PINT_NAME_TO_BASE_TOKEN = {
     if pint_name is not None
 }
 
-#: The affine calendar-point units :func:`build_registry` defines — the only
-#: offset units any TTSIM registry contains.
-_CALENDAR_POINT_UNIT_NAMES = frozenset(
-    {"calendar_year", "calendar_quarter", "calendar_month", "calendar_day"}
+#: The affine calendar-point unit :func:`build_registry` defines.
+_CALENDAR_POINT_UNIT_NAMES = frozenset({"calendar_year"})
+
+#: Calendar positions within a larger unit. They are separate dimensions so Pint
+#: cannot silently treat February as two months or day 31 as a 31-day duration.
+_CALENDAR_ORDINAL_UNIT_NAMES = frozenset(
+    {"calendar_quarter", "calendar_month", "calendar_day"}
 )
 
 #: The dimension names :func:`build_registry` mints for currency and takes from
@@ -156,6 +160,18 @@ _REL_TOL = 1e-9
 _CastValueT = TypeVar("_CastValueT")
 
 
+class QuantityKind(Enum):
+    """Record the restricted meaning of a dimensionless declaration.
+
+    These labels do not add dimensions to Pint. They distinguish a head count
+    and a yes/no indicator where group arithmetic needs that information.
+    """
+
+    GENERIC = auto()
+    COUNT = auto()
+    INDICATOR = auto()
+
+
 @dataclass(frozen=True)
 class CompositeUnit:
     """A fully-spelled TTSIM unit — *the* declaration type.
@@ -179,6 +195,8 @@ class CompositeUnit:
     hours: str | None = None
     period: str | None = None
     level: str | None = None
+    kind: QuantityKind = QuantityKind.GENERIC
+    """Restricted semantic meaning carried alongside the normalized Pint unit."""
 
     if TYPE_CHECKING:
         # Per-level builder steps are added at runtime, so tell `ty` any builder
@@ -187,7 +205,10 @@ class CompositeUnit:
         def __getattr__(self, name: str) -> CompositeUnit: ...
 
     def __str__(self) -> str:
-        parts = [self.base, self.area, self.hours, self.period, self.level]
+        display_base = (
+            self.kind.name if self.kind is not QuantityKind.GENERIC else self.base
+        )
+        parts = [display_base, self.area, self.hours, self.period, self.level]
         return _PER.join(part for part in parts if part is not None)
 
     def __repr__(self) -> str:
@@ -198,7 +219,16 @@ class CompositeUnit:
         """Whether this unit is a flow — i.e. has a period denominator."""
         return self.period is not None
 
+    def _fail_if_semantic_denominator_is_invalid(self, denominator: str) -> None:
+        if self.kind is not QuantityKind.GENERIC:
+            raise UnitDefinitionError(
+                f"Cannot add {denominator} to '{self}': {self.kind.name} is a "
+                "dimensionless declaration with an optional group denominator, "
+                "not a physical unit or period."
+            )
+
     def _with_area(self, area: str) -> CompositeUnit:
+        self._fail_if_semantic_denominator_is_invalid(f"area '{area}'")
         if self.hours is not None:
             raise UnitDefinitionError(
                 f"Cannot add the area '{area}' to '{self}': a unit is denominated "
@@ -213,6 +243,7 @@ class CompositeUnit:
         return replace(self, area=area)
 
     def _with_hours(self, hours: str) -> CompositeUnit:
+        self._fail_if_semantic_denominator_is_invalid(f"working hours '{hours}'")
         if self.area is not None:
             raise UnitDefinitionError(
                 f"Cannot add working hours '{hours}' to '{self}': a unit is "
@@ -227,6 +258,7 @@ class CompositeUnit:
         return replace(self, hours=hours)
 
     def _with_period(self, period: str) -> CompositeUnit:
+        self._fail_if_semantic_denominator_is_invalid(f"period '{period}'")
         if self.period is not None or self.level is not None:
             raise UnitDefinitionError(
                 f"Cannot add period '{period}' to '{self}': a period must precede "
@@ -310,7 +342,13 @@ class TTSIMUnit(metaclass=_UnitNamespaceMeta):
     """An amount of currency (agnostic): wages, claims, benefits, wealth."""
 
     DIMENSIONLESS = CompositeUnit(base="DIMENSIONLESS")
-    """A plain dimensionless number: a share, a rate, a head count, a boolean."""
+    """A plain dimensionless number: a share, rate, identifier, or category."""
+
+    COUNT = CompositeUnit(base="DIMENSIONLESS", kind=QuantityKind.COUNT)
+    """A head count, normalized to a dimensionless unit plus count evidence."""
+
+    INDICATOR = CompositeUnit(base="DIMENSIONLESS", kind=QuantityKind.INDICATOR)
+    """A yes/no value, normalized to a dimensionless unit plus indicator evidence."""
 
     HOURS = CompositeUnit(base="HOURS")
     """Working hours (the isolated ``[hours]`` dimension). Not a member of the [time]
@@ -445,13 +483,20 @@ def ttsim_unit_from_string(spelling: str) -> CompositeUnit:
     if not spelling:
         raise UnitDefinitionError("Empty compositional unit spelling (GEP 10).")
     base, *denominators = spelling.split(_PER)
-    if base not in _TTSIM_UNIT_BASE_TO_PINT and not _is_currency_base(base):
-        raise UnitDefinitionError(
-            f"Unknown compositional base {base!r} in {spelling!r}. A base is the "
-            f"agnostic '{CURRENCY_TOKEN}', a registered currency, or one of "
-            f"{', '.join(sorted(_TTSIM_UNIT_BASE_TO_PINT))} (GEP 10)."
-        )
-    unit = CompositeUnit(base=base)
+    semantic_kind = {
+        "COUNT": QuantityKind.COUNT,
+        "INDICATOR": QuantityKind.INDICATOR,
+    }.get(base)
+    if semantic_kind is None:
+        if base not in _TTSIM_UNIT_BASE_TO_PINT and not _is_currency_base(base):
+            raise UnitDefinitionError(
+                f"Unknown compositional base {base!r} in {spelling!r}. A base is the "
+                f"agnostic '{CURRENCY_TOKEN}', a registered currency, or one of "
+                f"{', '.join(sorted(_TTSIM_UNIT_BASE_TO_PINT))} (GEP 10)."
+            )
+        unit = CompositeUnit(base=base)
+    else:
+        unit = CompositeUnit(base="DIMENSIONLESS", kind=semantic_kind)
     for token in denominators:
         kind = _classify_denominator(token)
         if kind == "area":
@@ -934,17 +979,16 @@ def units_are_equivalent(
 def is_calendar_point_unit(unit: pint.Unit, registry: pint.UnitRegistry) -> bool:
     """Whether a resolved unit is an affine calendar *point*.
 
-    A calendar point (``calendar_year`` and its month/day siblings) is a pint
-    offset unit: it obeys affine algebra, not the magnitude algebra of a
-    duration. pint raises an :class:`pint.OffsetUnitCalculusError` on any illegal
-    operation, so:
+    A calendar year is a Pint offset unit: it obeys affine algebra, not the
+    magnitude algebra of a duration. Pint raises an
+    :class:`pint.OffsetUnitCalculusError` on an illegal operation, so:
 
     - two points *subtract* to a duration, and a duration *shifts* a point;
     - two points cannot be added, a point cannot be scaled, and points on
       different calendar axes cannot be combined.
 
     Detection is by the property that defines an offset unit: it cannot be divided
-    by itself. Only the three :data:`_CALENDAR_POINT_UNIT_NAMES` are offset units,
+    by itself. Only :data:`_CALENDAR_POINT_UNIT_NAMES` contains offset units,
     so a unit spelling none of them skips the pint probe.
     """
     if _CALENDAR_POINT_UNIT_NAMES.isdisjoint(to_units_container(unit)):
@@ -955,6 +999,11 @@ def is_calendar_point_unit(unit: pint.Unit, registry: pint.UnitRegistry) -> bool
     except pint.OffsetUnitCalculusError:
         return True
     return False
+
+
+def is_calendar_ordinal_unit(unit: pint.Unit) -> bool:
+    """Whether ``unit`` is a quarter-, month-, or day-within-period ordinal."""
+    return not _CALENDAR_ORDINAL_UNIT_NAMES.isdisjoint(to_units_container(unit))
 
 
 def input_column_in_data_currency(
@@ -1026,14 +1075,11 @@ def build_registry() -> pint.UnitRegistry:
       re-basing the *period* denominator.
     - ``quarter_year`` for the ``_q`` suffix (pint's built-in ``quarter`` is a unit of
       mass);
-    - ``calendar_year`` / ``calendar_month`` / ``calendar_day`` as affine *point* units.
-      Subtracting two points yields pint's companion ``delta_calendar_*`` *duration*
-      unit, which :attr:`TTSIMUnit.YEARS` / :attr:`TTSIMUnit.MONTHS` /
-      :attr:`TTSIMUnit.DAYS` resolve to (each is ratio 1 against ``year`` / ``month`` /
-      ``day``).
-    - ``calendar_quarter`` as an affine point unit on a separate quarter axis, with
-      ``delta_calendar_quarter`` as its companion duration. This axis is separate so
-      calendar quarters are not automatically converted to months or years.
+    - ``calendar_year`` as an affine *point* unit. Subtracting two years yields
+      the companion ``delta_calendar_year`` duration;
+    - ``calendar_quarter`` / ``calendar_month`` / ``calendar_day`` as independent
+      ordinal dimensions. They can be ordered on the same scale, but are not
+      durations and support no general arithmetic.
 
     pint's remaining built-ins parse, but :func:`pint_unit_from_string` rejects every
     token outside :data:`_ALLOWED_UNIT_TOKENS`, so none can appear in a declaration.
@@ -1042,16 +1088,16 @@ def build_registry() -> pint.UnitRegistry:
     ureg.define(f"{CURRENCY_TOKEN} = [currency]")
     ureg.define("working_hour = [hours]")
     ureg.define("quarter_year = year / 4 = quarter_of_year")
-    ureg.define(
-        "calendar_quarter_duration = [calendar_quarter_axis] = delta_calendar_quarter"
-    )
+    ureg.define("calendar_quarter_duration = year / 4 = delta_calendar_quarter")
+    ureg.define("delta_calendar_month = month")
+    ureg.define("delta_calendar_day = day")
     # Pint needs a nonzero offset to distinguish calendar points, such as year 1999,
     # from durations, such as 3 years. TTSIM never uses the offset's numeric value,
     # so use 1 consistently for all calendar units.
-    ureg.define("calendar_quarter = calendar_quarter_duration; offset: 1")
     ureg.define("calendar_year = year; offset: 1")
-    ureg.define("calendar_month = month; offset: 1")
-    ureg.define("calendar_day = day; offset: 1")
+    ureg.define("calendar_quarter = [calendar_quarter_ordinal]")
+    ureg.define("calendar_month = [calendar_month_ordinal]")
+    ureg.define("calendar_day = [calendar_day_ordinal]")
     return ureg
 
 
@@ -1165,9 +1211,7 @@ def unit_for_aggregation(
       source's physical token and take the target level — spelled for a group
       (``CURRENCY_PER_MONTH_PER_FAM``, ``MONTHS_PER_FG`` for an ``_fg`` extreme of
       a bare duration), and **bare** for an individual ``agg_by_p_id`` result;
-    - ``MEAN`` is a per-head average that belongs to the **individual**
-      (``MEAN = SUM / COUNT`` cancels the group), so its result is **bare** — the
-      source's group level, if any, is dropped;
+    - ``MEAN`` is a statistic of the **target group**, like ``MIN`` and ``MAX``;
     - ``ANY`` / ``ALL`` yield a boolean, a dimensionless quantity at the target
       level (``DIMENSIONLESS_PER_<target_level>``); bare at an individual target.
 
@@ -1187,8 +1231,8 @@ def unit_for_aggregation(
     Returns:
         The auto-assigned unit. ``DIMENSIONLESS`` (per target) for a ``COUNT``
         head count and for a boolean ``ANY`` / ``ALL`` result; otherwise the
-        source token at the target (``SUM`` / ``MIN`` / ``MAX``) or bare
-        (``MEAN``, and any individual ``agg_by_p_id``)
+        source token at the target (``SUM`` / ``MEAN`` / ``MIN`` / ``MAX``) or
+        bare for an individual ``agg_by_p_id``
         (:data:`UNSET_UNIT` when the source itself lacks a declaration, which the
         mandatory-units check then reports against the source).
     """
@@ -1200,9 +1244,8 @@ def unit_for_aggregation(
         return base if target_level is None else base.PER_LEVEL(target_level)
     if isinstance(source_unit, UnsetUnit):
         return source_unit
-    if agg_type is AggType.MEAN or target_level is None:
-        # A MEAN is a per-head average, and an agg_by_p_id result is an individual
-        # property: both are bare, so the source's group level is dropped.
+    if target_level is None:
+        # An agg_by_p_id result is an individual property and therefore bare.
         return replace(source_unit, level=None)
     return replace(source_unit, level=target_level.upper())
 
@@ -1230,10 +1273,7 @@ def resolved_unit_for_aggregation(
       for the target and a bare source *acquires* it — an ``_hh`` sum of a person
       income is ``CURRENCY/[hh]``, an ``_fg`` min of a bare age is ``MONTHS/[fg]``.
       At an individual target (an ``agg_by_p_id`` node) the result is **bare**.
-    - ``MEAN`` is a per-head average that belongs to the **individual**
-      (``MEAN = SUM / COUNT``, and leveling it to the target would break
-      ``mean · count = sum``), so the result is **bare** — the source level, if
-      any, is dropped.
+    - ``MEAN`` is a statistic of the **target group**, like ``MIN`` and ``MAX``.
     - ``COUNT`` mints a head count ``1 / [target]`` — persons per target group —
       independent of the source; bare at an individual target.
     - ``ANY`` / ``ALL`` yield a boolean *at the target level* — ``1 / [target]``
@@ -1280,9 +1320,8 @@ def resolved_unit_for_aggregation(
         if source_level is None
         else source_unit * _grouping_level_unit(name=source_level, registry=registry)
     )
-    # A MEAN is bare (individual), and an agg_by_p_id result (``target_level is
-    # None``) is bare too: the level-stripped source stands as-is.
-    if agg_type is AggType.MEAN or target_level is None:
+    # An agg_by_p_id result (``target_level is None``) is bare.
+    if target_level is None:
         return stripped
     return divide_by_grouping_level(
         unit=stripped, level=target_level, registry=registry

--- a/src/ttsim/unit_resolution.py
+++ b/src/ttsim/unit_resolution.py
@@ -25,6 +25,7 @@ import dags.tree as dt
 import pint
 from dags import get_annotations
 
+from ttsim._quantity_kinds import quantity_kind_for_scalar_type
 from ttsim.exceptions import UnitDefinitionError
 from ttsim.interface_dag_elements.shared import (
     FRAMEWORK_PARTIAL_ARGUMENTS,
@@ -56,6 +57,7 @@ from ttsim.tt.units import (
     UNSET_UNIT,
     CompositeUnit,
     InputOutputUnits,
+    QuantityKind,
     UnitDeclaration,
     UnitSystem,
     UnsetUnit,
@@ -240,11 +242,11 @@ def _schedule_axis_errors(
 
 FRAMEWORK_DATE_NODE_UNITS: Mapping[str, str] = {
     "policy_year": "calendar_year",
-    "policy_month": "dimensionless",
-    "policy_day": "dimensionless",
+    "policy_month": "calendar_month",
+    "policy_day": "calendar_day",
     "evaluation_year": "calendar_year",
-    "evaluation_month": "dimensionless",
-    "evaluation_day": "dimensionless",
+    "evaluation_month": "calendar_month",
+    "evaluation_day": "calendar_day",
 }
 
 
@@ -298,9 +300,8 @@ def _resolve_agg_by_group_unit(
 
     - a **head count** — ``COUNT``, or a ``SUM`` over a *boolean* source (counting
       the persons the indicator is true for) — mints ``1 / [target]``;
-    - ``SUM`` / ``MIN`` / ``MAX`` resolve to the **target** level whatever the
-      source (a bare source acquires it); ``MEAN`` resolves to **bare** — a
-      per-head average belongs to the individual;
+    - ``SUM`` / ``MEAN`` / ``MIN`` / ``MAX`` resolve to the **target** level
+      whatever the source (a bare source acquires it);
     - ``ANY`` / ``ALL`` yield a dimensionless boolean at the target level.
 
     The value source is the function's summed/averaged argument, read off the
@@ -581,12 +582,13 @@ def _resolve_structured_field_annotations(
 
 def _structured_field_kinds(
     cls: type, unit_system: UnitSystem
-) -> dict[str, pint.Unit | type | _ScheduleFieldKind] | None:
+) -> dict[str, pint.Unit | type | _ScalarFieldKind | _ScheduleFieldKind] | None:
     """Resolve a parameter dataclass's field annotations for the unit check.
 
     Maps each field to what its pluck yields:
 
-    - an ``Annotated[<scalar>, TTSIMUnit…]`` field → the resolved unit;
+    - an ``Annotated[<scalar>, TTSIMUnit…]`` field → the resolved unit and any
+      explicit count/indicator evidence;
     - an ``Annotated[<schedule type>, InputOutputUnits(...)]`` field → a
       :class:`_ScheduleFieldKind` carrying the schedule's input and output axes;
     - a nested-dataclass field → its class (whose plucks resolve recursively);
@@ -607,7 +609,7 @@ def _structured_field_kinds(
     hints = _resolvable_type_hints(cls=cls)
     if not hints:
         return None
-    kinds: dict[str, pint.Unit | type | _ScheduleFieldKind] = {}
+    kinds: dict[str, pint.Unit | type | _ScalarFieldKind | _ScheduleFieldKind] = {}
     for field in dataclasses.fields(cast("Any", cls)):
         hint = hints.get(field.name, field.type)
         metadata = getattr(hint, "__metadata__", ())
@@ -647,7 +649,14 @@ def _structured_field_kinds(
                 registry=unit_system.registry,
             )
             if base in (int, float, bool):
-                kinds[field.name] = resolved
+                semantic_kind = quantity_kind_for_scalar_type(
+                    declaration=composite_tokens[0], scalar_type=base
+                )
+                kinds[field.name] = (
+                    _ScalarFieldKind(unit=resolved, kind=semantic_kind)
+                    if semantic_kind is not QuantityKind.GENERIC
+                    else resolved
+                )
             else:
                 raise UnitDefinitionError(
                     f"{where}: a single unit annotation must sit on a scalar field "
@@ -657,6 +666,14 @@ def _structured_field_kinds(
         elif isinstance(base, type) and dataclasses.is_dataclass(base):
             kinds[field.name] = base
     return kinds
+
+
+@dataclasses.dataclass(frozen=True)
+class _ScalarFieldKind:
+    """A structured scalar field physical unit and narrow semantic evidence."""
+
+    unit: pint.Unit
+    kind: QuantityKind
 
 
 @dataclasses.dataclass(frozen=True)
@@ -676,6 +693,8 @@ class _ScheduleFieldKind:
     screened against."""
     output_unit: pint.Unit
     """The resolved unit the schedule produces."""
+    output_kind: QuantityKind
+    """Narrow semantic evidence carried by the produced quantity."""
 
 
 def _schedule_field_kind(
@@ -735,6 +754,7 @@ def _schedule_field_kind(
             where=where,
             registry=unit_system.registry,
         ),
+        output_kind=io_token.output_unit.kind,
     )
 
 

--- a/src/ttsim/unit_validation.py
+++ b/src/ttsim/unit_validation.py
@@ -2,22 +2,41 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import dataclasses
+import datetime
+import inspect
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from typing import (
     Any,
     cast,
+    get_args,
 )
 
 import dags.tree as dt
 import pint
 
-from ttsim._unit_inference import body_verification_errors
+from ttsim._quantity_kinds import (
+    quantity_kind,
+    quantity_kind_for_leaf,
+    quantity_kind_for_scalar_type,
+)
+from ttsim._unit_inference import (
+    body_error_is_unsupported,
+    body_verification_errors,
+    function_uses_local_cast,
+)
 from ttsim.exceptions import UnitConsistencyError
+from ttsim.interface_dag_elements.shared import FRAMEWORK_PARTIAL_ARGUMENTS
 from ttsim.tt.column_objects_param_function import (
     AggByGroupFunction,
+    AggByPIDFunction,
     ColumnFunction,
     ColumnObject,
+    GroupCreationFunction,
     ParamFunction,
+    PolicyFunction,
+    TimeConversionFunction,
 )
 from ttsim.tt.param_objects import (
     ParamMappingObject,
@@ -28,6 +47,7 @@ from ttsim.tt.units import (
     UNSET_UNIT,
     CompositeUnit,
     InputOutputUnits,
+    QuantityKind,
     UnitAnnotatedColumn,
     UnitDeclaration,
     UnitSystem,
@@ -55,7 +75,10 @@ from ttsim.unit_resolution import (
     FRAMEWORK_DATE_NODE_UNITS,
     _composite_token_level,
     _fail_if_structured_field_annotations_are_invalid,
+    _resolvable_type_hints,
+    _resolved_return_structure,
     _return_annotation_name,
+    _returns_a_schedule,
     _schedule_axis_errors,
     _spell_ttsim_unit,
     resolve_environment_units,
@@ -178,18 +201,16 @@ def fail_if_environment_units_are_inconsistent(
         UnitDefinitionError: If an ``InputOutputUnits`` axis or a
             parameter-dataclass field annotation is invalid.
     """
-    _fail_if_structured_field_annotations_are_invalid(env=env, unit_system=unit_system)
     if resolved_pint_units is None:
         resolved_pint_units = resolve_environment_units(
             env=env, grouping_levels=grouping_levels, unit_system=unit_system
         )
-    errors: list[str] = _aggregation_declaration_errors(
+    _fail_if_structured_field_annotations_are_invalid(env=env, unit_system=unit_system)
+    errors = _non_body_consistency_errors(
         env=env,
         resolved_pint_units=resolved_pint_units,
         registry=unit_system.registry,
     )
-    errors.extend(_rounding_spec_declaration_errors(env=env))
-    errors.extend(_schedule_param_function_contract_errors(env=env))
     errors.extend(
         body_verification_errors(
             env=env,
@@ -201,6 +222,475 @@ def fail_if_environment_units_are_inconsistent(
         raise UnitConsistencyError(
             "Environment unit-consistency check failed:\n  " + "\n  ".join(errors)
         )
+
+
+@dataclass(frozen=True)
+class UncheckedBody:
+    """A function body omitted from inference, together with the exact reason."""
+
+    qname: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class UnitValidationReport:
+    """Auditable coverage of one or more policy-environment unit checks."""
+
+    resolved_declarations: tuple[str, ...]
+    checked_function_bodies: tuple[str, ...]
+    checked_aggregations: tuple[str, ...]
+    generated_rules: tuple[str, ...]
+    local_casts: tuple[str, ...]
+    body_opt_outs: tuple[str, ...]
+    unsupported_bodies: tuple[UncheckedBody, ...]
+    other_unchecked_bodies: tuple[UncheckedBody, ...]
+    policy_date_regimes: tuple[datetime.date, ...]
+
+    def summary(self) -> str:
+        """Return a compact CI-oriented coverage summary with named exceptions."""
+        lines = [
+            f"Declarations resolved: {len(self.resolved_declarations)}",
+            f"Bodies checked: {len(self.checked_function_bodies)}",
+            f"Aggregations checked: {len(self.checked_aggregations)}",
+            f"Generated rules: {len(self.generated_rules)}",
+            f"Casts: {len(self.local_casts)}",
+            f"Body opt-outs: {len(self.body_opt_outs)}",
+            f"Unsupported bodies: {len(self.unsupported_bodies)}",
+            f"Other unchecked bodies: {len(self.other_unchecked_bodies)}",
+            f"Date regimes: {len(self.policy_date_regimes)}",
+        ]
+        if self.local_casts:
+            lines.append("Cast functions: " + ", ".join(self.local_casts))
+        if self.body_opt_outs:
+            lines.append("Body opt-outs: " + ", ".join(self.body_opt_outs))
+        lines.extend(
+            f"Unsupported body {item.qname}: {item.reason}"
+            for item in self.unsupported_bodies
+        )
+        lines.extend(
+            f"Unchecked body {item.qname}: {item.reason}"
+            for item in self.other_unchecked_bodies
+        )
+        return "\n".join(lines)
+
+
+def create_unit_validation_report(
+    env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+    grouping_levels: OrderedQNames,
+    unit_system: UnitSystem,
+    policy_dates: tuple[datetime.date, ...] = (),
+) -> UnitValidationReport:
+    """Validate an environment and report what provided each kind of evidence.
+
+    The report deliberately keeps declarations, inferred bodies, generated rules,
+    local assertions, and whole-body opt-outs separate. Invalid declarations still
+    raise immediately. Concrete body inconsistencies also raise; only a body that the
+    symbolic evaluator genuinely cannot execute is returned under
+    ``unsupported_bodies`` so diagnostic callers can inspect the coverage gap. Ordinary
+    environment assembly and :func:`check_policy_environment_units` remain fail closed.
+    """
+    fail_if_environment_units_are_missing(env)
+    resolved = resolve_environment_units(
+        env=env, grouping_levels=grouping_levels, unit_system=unit_system
+    )
+    _fail_if_structured_field_annotations_are_invalid(env=env, unit_system=unit_system)
+    declaration_errors = _non_body_consistency_errors(
+        env=env,
+        resolved_pint_units=resolved,
+        registry=unit_system.registry,
+    )
+    if declaration_errors:
+        raise UnitConsistencyError(
+            "Environment unit-consistency check failed:\n  "
+            + "\n  ".join(declaration_errors)
+        )
+    body_errors = body_verification_errors(
+        env=env,
+        resolved_pint_units=resolved,
+        unit_system=unit_system,
+    )
+    invalid_body_errors = [
+        error for error in body_errors if not body_error_is_unsupported(error)
+    ]
+    if invalid_body_errors:
+        raise UnitConsistencyError(
+            "Environment unit-consistency check failed:\n  "
+            + "\n  ".join(invalid_body_errors)
+        )
+    unsupported = tuple(
+        UncheckedBody(*_split_body_error(error))
+        for error in body_errors
+        if body_error_is_unsupported(error)
+    )
+    unsupported_qnames = {item.qname for item in unsupported}
+
+    generated_rules = tuple(
+        sorted(
+            qname
+            for qname, obj in env.items()
+            if isinstance(obj, GroupCreationFunction | TimeConversionFunction)
+            or (
+                isinstance(obj, AggByGroupFunction | AggByPIDFunction)
+                and obj.orig_location == "automatically generated"
+            )
+        )
+    )
+    casts = tuple(
+        sorted(
+            qname
+            for qname, obj in env.items()
+            if isinstance(obj, PolicyFunction | ParamFunction)
+            and function_uses_local_cast(obj.function)
+        )
+    )
+
+    checked, checked_aggregations, opt_outs, other = _classify_body_coverage(
+        env=env,
+        resolved=resolved,
+        unsupported_qnames=unsupported_qnames,
+    )
+
+    return UnitValidationReport(
+        resolved_declarations=tuple(sorted(resolved)),
+        checked_function_bodies=tuple(sorted(checked)),
+        checked_aggregations=tuple(sorted(checked_aggregations)),
+        generated_rules=generated_rules,
+        local_casts=casts,
+        body_opt_outs=tuple(sorted(opt_outs)),
+        unsupported_bodies=unsupported,
+        other_unchecked_bodies=tuple(sorted(other, key=lambda item: item.qname)),
+        policy_date_regimes=tuple(sorted(set(policy_dates))),
+    )
+
+
+def _classify_body_coverage(
+    env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+    resolved: Mapping[str, pint.Unit | dict[str | int, Any]],
+    unsupported_qnames: set[str],
+) -> tuple[list[str], list[str], list[str], list[UncheckedBody]]:
+    """Classify every human-written function body in the report."""
+    checked: list[str] = []
+    checked_aggregations: list[str] = []
+    opt_outs: list[str] = []
+    other: list[UncheckedBody] = []
+    for qname, obj in env.items():
+        if isinstance(obj, AggByGroupFunction | AggByPIDFunction):
+            if obj.orig_location != "automatically generated":
+                if obj.verify_units:
+                    checked_aggregations.append(qname)
+                else:
+                    opt_outs.append(qname)
+            continue
+        if not isinstance(obj, PolicyFunction | ParamFunction):
+            continue
+        category, unchecked = _classify_policy_body(
+            qname=qname,
+            obj=obj,
+            resolved=resolved,
+            unsupported_qnames=unsupported_qnames,
+            env=env,
+        )
+        if category == "checked":
+            checked.append(qname)
+        elif category == "opt-out":
+            opt_outs.append(qname)
+        elif unchecked is not None:
+            other.append(unchecked)
+    return checked, checked_aggregations, opt_outs, other
+
+
+def _classify_policy_body(
+    qname: str,
+    obj: PolicyFunction | ParamFunction,
+    resolved: Mapping[str, pint.Unit | dict[str | int, Any]],
+    unsupported_qnames: set[str],
+    env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+) -> tuple[str, UncheckedBody | None]:
+    """Return the report category for one ordinary policy or parameter body."""
+    if getattr(obj, "fail_msg_if_included", None) is not None:
+        category = "other"
+        unchecked = UncheckedBody(qname, "unimplemented-period failure stub")
+    elif not obj.verify_units:
+        category, unchecked = "opt-out", None
+    elif isinstance(obj, ParamFunction) and _returns_a_schedule(obj):
+        category = "other"
+        unchecked = UncheckedBody(
+            qname,
+            "schedule-construction body; its declared input/output axes are checked "
+            "at consumers",
+        )
+    elif qname not in resolved:
+        category = "other"
+        unchecked = UncheckedBody(qname, "no resolved scalar declaration")
+    elif isinstance(resolved[qname], dict):
+        category = "other"
+        unchecked = UncheckedBody(qname, "structured return value")
+    elif qname in unsupported_qnames:
+        category, unchecked = "unsupported", None
+    elif _body_has_unresolved_producer(obj=obj, resolved=resolved, env=env):
+        category = "other"
+        unchecked = UncheckedBody(qname, "at least one producer has no resolved unit")
+    else:
+        category, unchecked = "checked", None
+    return category, unchecked
+
+
+def merge_unit_validation_reports(
+    reports: Iterable[UnitValidationReport],
+) -> UnitValidationReport:
+    """Combine per-regime reports into one policy-history coverage report."""
+    materialized = tuple(reports)
+
+    def merged_strings(attribute: str) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                {
+                    item
+                    for report in materialized
+                    for item in cast("tuple[str, ...]", getattr(report, attribute))
+                }
+            )
+        )
+
+    def merged_unchecked(attribute: str) -> tuple[UncheckedBody, ...]:
+        return tuple(
+            sorted(
+                {
+                    item
+                    for report in materialized
+                    for item in cast(
+                        "tuple[UncheckedBody, ...]", getattr(report, attribute)
+                    )
+                },
+                key=lambda item: (item.qname, item.reason),
+            )
+        )
+
+    return UnitValidationReport(
+        resolved_declarations=merged_strings("resolved_declarations"),
+        checked_function_bodies=merged_strings("checked_function_bodies"),
+        checked_aggregations=merged_strings("checked_aggregations"),
+        generated_rules=merged_strings("generated_rules"),
+        local_casts=merged_strings("local_casts"),
+        body_opt_outs=merged_strings("body_opt_outs"),
+        unsupported_bodies=merged_unchecked("unsupported_bodies"),
+        other_unchecked_bodies=merged_unchecked("other_unchecked_bodies"),
+        policy_date_regimes=tuple(
+            sorted(
+                {date for report in materialized for date in report.policy_date_regimes}
+            )
+        ),
+    )
+
+
+def _split_body_error(error: str) -> tuple[str, str]:
+    """Split the checker's stable ``<qname>: <reason>`` diagnostic shape."""
+    qname, separator, reason = error.partition(": ")
+    if not separator:
+        return "<unknown>", error
+    return qname, reason
+
+
+def _non_body_consistency_errors(
+    env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+    resolved_pint_units: dict[str, pint.Unit | dict[str | int, Any]],
+    registry: pint.UnitRegistry,
+) -> list[str]:
+    """Return declaration, aggregation, rounding, and schedule-contract errors."""
+    errors: list[str] = _dimensionless_group_declaration_errors(env=env)
+    errors.extend(
+        _aggregation_declaration_errors(
+            env=env,
+            resolved_pint_units=resolved_pint_units,
+            registry=registry,
+        )
+    )
+    errors.extend(_rounding_spec_declaration_errors(env=env))
+    errors.extend(_schedule_param_function_contract_errors(env=env))
+    return errors
+
+
+def _body_has_unresolved_producer(
+    obj: PolicyFunction | ParamFunction,
+    resolved: Mapping[str, pint.Unit | dict[str | int, Any]],
+    env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+) -> bool:
+    return any(
+        name not in FRAMEWORK_PARTIAL_ARGUMENTS
+        and name not in resolved
+        and not (
+            isinstance((producer := env.get(name)), ParamFunction)
+            and isinstance(producer.unit, UnsetUnit)
+        )
+        for name in inspect.signature(obj.function).parameters
+    )
+
+
+def _dimensionless_group_declaration_errors(
+    env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+) -> list[str]:
+    """Reject group markers on dimensionless shares, rates, ids, and categories.
+
+    A direct ``DIMENSIONLESS.PER_<LEVEL>`` declaration must carry explicit
+    ``COUNT`` or ``INDICATOR`` evidence. Generated counts and indicators
+    provide that evidence by rule.
+    """
+    errors: list[str] = []
+    for qname, obj in env.items():
+        # Aggregations derive their grouping level from their operation and source.
+        # Their declarations are checked independently below against that derivation,
+        # so they are not direct assertions about a dimensionless quantity's kind.
+        if isinstance(obj, AggByGroupFunction | TimeConversionFunction):
+            continue
+        errors.extend(
+            f"{declaration.where}: declares `{declaration.token}`, but a group marker "
+            "on a "
+            "dimensionless value is reserved for a known count or yes/no "
+            "indicator. Shares, rates, identifiers, and categories stay "
+            "bare `DIMENSIONLESS`; declare a count as `COUNT.PER_<GROUP>` "
+            "(GEP 10)."
+            for declaration in _declared_quantities(qname=qname, obj=obj, env=env)
+            if (
+                declaration.token.base == "DIMENSIONLESS"
+                and declaration.token.level is not None
+                and declaration.kind not in (QuantityKind.COUNT, QuantityKind.INDICATOR)
+            )
+        )
+    return errors
+
+
+@dataclass(frozen=True)
+class _DeclaredQuantity:
+    """One declaration token and the evidence belonging to exactly that token."""
+
+    where: str
+    token: CompositeUnit
+    kind: QuantityKind
+
+
+def _declared_quantities(
+    qname: str,
+    obj: Any,  # noqa: ANN401
+    env: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+) -> list[_DeclaredQuantity]:
+    """Return scalar, mapping-leaf, structured-field, and schedule-axis evidence."""
+    declaration = getattr(obj, "unit", UNSET_UNIT)
+    if isinstance(declaration, InputOutputUnits):
+        return _schedule_axis_declarations(where=qname, declaration=declaration)
+    if isinstance(declaration, CompositeUnit):
+        return [
+            _DeclaredQuantity(
+                where=qname,
+                token=declaration,
+                kind=quantity_kind(qname=qname, obj=obj, env=env),
+            )
+        ]
+    if isinstance(declaration, Mapping):
+        values = dt.flatten_to_qnames(
+            cast("Mapping[str, Any]", getattr(obj, "value", {}))
+        )
+        return [
+            _DeclaredQuantity(
+                where=f"{qname}[{leaf}]",
+                token=token,
+                kind=quantity_kind_for_leaf(declaration=token, value=values.get(leaf)),
+            )
+            for leaf, token in dt.flatten_to_qnames(
+                cast("Mapping[str, Any]", declaration)
+            ).items()
+            if isinstance(token, CompositeUnit)
+        ]
+
+    out: list[_DeclaredQuantity] = []
+    if isinstance(obj, ParamMappingObject | RawParam):
+        for axis_name in ("input_unit", "output_unit"):
+            token = getattr(obj, axis_name, UNSET_UNIT)
+            if isinstance(token, CompositeUnit):
+                out.append(
+                    _DeclaredQuantity(
+                        where=f"{qname} ({axis_name})",
+                        token=token,
+                        kind=token.kind,
+                    )
+                )
+    if isinstance(obj, ParamFunction) and isinstance(declaration, UnsetUnit):
+        cls, item_cls = _resolved_return_structure(obj.function)
+        for structured_cls in (cls, item_cls):
+            if structured_cls is not None:
+                out.extend(
+                    _structured_declarations(
+                        qname=qname, cls=structured_cls, visited=set()
+                    )
+                )
+    return out
+
+
+def _schedule_axis_declarations(
+    where: str, declaration: InputOutputUnits
+) -> list[_DeclaredQuantity]:
+    """Return one evidence record per schedule input/output axis."""
+    input_units: tuple[CompositeUnit, ...] = (
+        cast("tuple[CompositeUnit, ...]", declaration.input_unit)
+        if isinstance(declaration.input_unit, tuple)
+        else (declaration.input_unit,)
+    )
+    out = [
+        _DeclaredQuantity(
+            where=f"{where} (input axis {position})",
+            token=unit,
+            kind=unit.kind,
+        )
+        for position, unit in enumerate(input_units, start=1)
+    ]
+    out.append(
+        _DeclaredQuantity(
+            where=f"{where} (output axis)",
+            token=declaration.output_unit,
+            kind=declaration.output_unit.kind,
+        )
+    )
+    return out
+
+
+def _structured_declarations(
+    qname: str,
+    cls: type,
+    visited: set[type],
+) -> list[_DeclaredQuantity]:
+    """Return exact evidence for every annotated scalar/schedule field."""
+    if cls in visited:
+        return []
+    visited.add(cls)
+    hints = _resolvable_type_hints(cls=cls)
+    out: list[_DeclaredQuantity] = []
+    for field in dataclasses.fields(cast("Any", cls)):
+        hint = hints.get(field.name, field.type)
+        metadata = getattr(hint, "__metadata__", ())
+        base = get_args(hint)[0] if hasattr(hint, "__metadata__") else hint
+        field_qname = f"{qname}__{field.name}"
+        out.extend(
+            _DeclaredQuantity(
+                where=f"Field '{cls.__name__}.{field.name}'",
+                token=token,
+                kind=quantity_kind_for_scalar_type(declaration=token, scalar_type=base),
+            )
+            for token in metadata
+            if isinstance(token, CompositeUnit)
+        )
+        for io_token in (
+            token for token in metadata if isinstance(token, InputOutputUnits)
+        ):
+            out.extend(
+                _schedule_axis_declarations(
+                    where=f"Field '{cls.__name__}.{field.name}'",
+                    declaration=io_token,
+                )
+            )
+        if isinstance(base, type) and dataclasses.is_dataclass(base):
+            out.extend(
+                _structured_declarations(qname=field_qname, cls=base, visited=visited)
+            )
+    return out
 
 
 def fail_if_input_units_are_inconsistent(

--- a/src_mettsim/mettsim/middle_earth/demographics.py
+++ b/src_mettsim/mettsim/middle_earth/demographics.py
@@ -50,13 +50,11 @@ def coming_of_age_celebration(age: int) -> bool:
     ) or age == cast_ttsim_unit(value=111, unit=TTSIMUnit.YEARS)
 
 
-@policy_function(
-    vectorization_strategy="vectorize", unit=TTSIMUnit.DIMENSIONLESS.PER_KIN
-)
+@policy_function(vectorization_strategy="vectorize", unit=TTSIMUnit.COUNT.PER_KIN)
 def number_of_dependants_kin(number_of_individuals_kin: int) -> int:
     """The kinstead's members other than its head."""
     # The one head subtracted here is a head count of the kinstead, like the
     # count it is subtracted from.
     return number_of_individuals_kin - cast_ttsim_unit(
-        value=1, unit=TTSIMUnit.DIMENSIONLESS.PER_KIN
+        value=1, unit=TTSIMUnit.COUNT.PER_KIN
     )

--- a/src_mettsim/mettsim/middle_earth/housing_benefits/eligibility/eligibility.py
+++ b/src_mettsim/mettsim/middle_earth/housing_benefits/eligibility/eligibility.py
@@ -63,7 +63,7 @@ def requirement_fulfilled_fam_considering_children(
 @policy_function(
     start_date="2020-01-01",
     vectorization_strategy="vectorize",
-    unit=TTSIMUnit.DIMENSIONLESS.PER_FAM,
+    unit=TTSIMUnit.COUNT.PER_FAM,
 )
 def number_of_family_members_considered_fam(
     number_of_individuals_fam: int,

--- a/src_mettsim/mettsim/middle_earth/housing_benefits/eligibility/eligibility.yaml
+++ b/src_mettsim/mettsim/middle_earth/housing_benefits/eligibility/eligibility.yaml
@@ -28,7 +28,7 @@ max_number_of_family_members:
   description:
     de: Erst nach Reform 2020 relevant.
     en: Only relevant after 2020 reform.
-  unit: DIMENSIONLESS_PER_FAM
+  unit: COUNT_PER_FAM
   type: scalar
   2020-01-01:
     value: 4

--- a/src_mettsim/mettsim/middle_earth/inputs.py
+++ b/src_mettsim/mettsim/middle_earth/inputs.py
@@ -39,7 +39,7 @@ def birth_year() -> int:
     """Calendar year the person was born in."""
 
 
-@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.CALENDAR_MONTH)
 def birth_month() -> int:
     """Month of birth (1-12)."""
 

--- a/src_mettsim/mettsim/middle_earth/kings_levy/kings_levy.py
+++ b/src_mettsim/mettsim/middle_earth/kings_levy/kings_levy.py
@@ -72,7 +72,7 @@ def amount_y(
 
 @param_function(
     unit=InputOutputUnits(
-        input_unit=TTSIMUnit.DIMENSIONLESS.PER_KIN,
+        input_unit=TTSIMUnit.COUNT.PER_KIN,
         output_unit=TTSIMUnit.CURRENCY.PER_YEAR.PER_KIN,
     ),
     # See `kings_levy_schedule` above.

--- a/src_mettsim/mettsim/middle_earth/payroll_tax/child_tax_credit/annotation_bug_reproducer.py
+++ b/src_mettsim/mettsim/middle_earth/payroll_tax/child_tax_credit/annotation_bug_reproducer.py
@@ -25,18 +25,17 @@ def child_in_household_for_bug_reproducer(p_id: int) -> bool:
 
 
 @policy_function(
-    leaf_name="net_income_parents_m",
+    leaf_name="net_wealth_parents",
     end_date="2019-12-31",
     rounding_spec=RoundingSpec(
         base=1,
         direction="down",
         reference="Python 3.14 bug reproducer",
-        unit=TTSIMUnit.SILVER_PENNY.PER_MONTH,
+        unit=TTSIMUnit.SILVER_PENNY,
     ),
-    unit=TTSIMUnit.CURRENCY.PER_MONTH,
-    verify_units=False,
+    unit=TTSIMUnit.CURRENCY,
 )
-def net_income_parents_m_before_currency_reform(
+def net_wealth_parents_before_currency_reform(
     wealth: float,  # Use an existing input
     # This annotation extraction fails in Python 3.14
     payroll_tax__child_tax_credit__child_in_household_for_bug_reproducer: bool,
@@ -50,18 +49,17 @@ def net_income_parents_m_before_currency_reform(
 
 
 @policy_function(
-    leaf_name="net_income_parents_m",
+    leaf_name="net_wealth_parents",
     start_date="2020-01-01",
     rounding_spec=RoundingSpec(
         base=0.25,
         direction="down",
         reference="Python 3.14 bug reproducer",
-        unit=TTSIMUnit.CASTAR.PER_MONTH,
+        unit=TTSIMUnit.CASTAR,
     ),
-    unit=TTSIMUnit.CURRENCY.PER_MONTH,
-    verify_units=False,
+    unit=TTSIMUnit.CURRENCY,
 )
-def net_income_parents_m_after_currency_reform(
+def net_wealth_parents_after_currency_reform(
     wealth: float,  # Use an existing input
     # This annotation extraction fails in Python 3.14
     payroll_tax__child_tax_credit__child_in_household_for_bug_reproducer: bool,

--- a/src_mettsim/mettsim/middle_earth/wealth_tax/wealth_tax.py
+++ b/src_mettsim/mettsim/middle_earth/wealth_tax/wealth_tax.py
@@ -15,10 +15,6 @@ def amount_y(
 @agg_by_group_function(
     agg_type=AggType.MEAN,
     unit=TTSIMUnit.CURRENCY.PER_KIN,
-    # A MEAN derives as the person's, but the average kin wealth reads as a
-    # property of the kinstead; the declaration states that and skips the
-    # declared-vs-derived check (GEP 10).
-    verify_units=False,
 )
 def average_wealth_kin(kin_id: int, wealth: float) -> float:
     """The average wealth of the kinstead."""

--- a/src_mettsim/tests_middle_earth/policy_cases/payroll_tax/2025-01-01/annotation_bug_reproducer.yaml
+++ b/src_mettsim/tests_middle_earth/policy_cases/payroll_tax/2025-01-01/annotation_bug_reproducer.yaml
@@ -17,7 +17,7 @@ inputs:
 outputs:
   payroll_tax:
     child_tax_credit:
-      net_income_parents_m:
+      net_wealth_parents:
         - 800.0
         - 1000.0
         - 800.0

--- a/src_mettsim/tests_middle_earth/test_mettsim.py
+++ b/src_mettsim/tests_middle_earth/test_mettsim.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy
@@ -15,6 +14,7 @@ from ttsim.testing_utils import (
     check_env_completeness,
     check_policy_environment_units,
     execute_test,
+    get_policy_date_partition,
     load_policy_cases,
 )
 from ttsim.tt.units import TTSIMUnit, UnitAnnotatedColumn
@@ -51,16 +51,11 @@ def get_orig_mettsim_objects() -> dict[
 
 
 def dates_in_orig_mettsim_objects() -> list[datetime.date]:
-    orig_objects = get_orig_mettsim_objects()
-    start_dates = {
-        v.start_date  # ty: ignore[unresolved-attribute]
-        for v in orig_objects["column_objects_and_param_functions"].values()
-    }
-    end_dates = {
-        v.end_date + timedelta(days=1)  # ty: ignore[unresolved-attribute]
-        for v in orig_objects["column_objects_and_param_functions"].values()
-    }
-    return sorted(start_dates | end_dates)
+    """One date per structural regime of METTSIM, parameter-only changes included."""
+    return get_policy_date_partition(
+        orig_policy_objects=get_orig_mettsim_objects(),
+        unit_system=middle_earth.UNIT_SYSTEM,
+    )
 
 
 @pytest.fixture

--- a/tests/test_run_currency.py
+++ b/tests/test_run_currency.py
@@ -882,20 +882,19 @@ def test_registered_currency_token_round_trips_through_the_parser():
 
 
 def test_annotated_results_label_a_declarationless_dimensionless_target_as_such():
-    """A dimensionless target with no declared token (a framework date node such as
-    ``policy_month``) is labelled ``DIMENSIONLESS`` (GEP 10)."""
+    """A framework month target is labelled as a calendar ordinal (GEP 10)."""
     system = _fresh_system()
     annotated = tree_with_unit_annotations(
         tree={"policy_month": np.array([6, 7])},
         raw_results__params={},
         unit_checks__resolved_pint_units={
-            "policy_month": system.registry.dimensionless
+            "policy_month": system.registry.parse_units("calendar_month")
         },
         data_currency="CASTAR",
         computation_currency="SILVER_PENNY",
         unit_system=system,
     )
-    assert annotated["policy_month"].unit == TTSIMUnit.DIMENSIONLESS
+    assert annotated["policy_month"].unit == TTSIMUnit.CALENDAR_MONTH
 
 
 def test_definition_referencing_no_system_currency_is_rejected():

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -1,0 +1,86 @@
+"""Tests for the helpers a policy package's own test suite builds on."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from tests.test_unit_fixtures import UNIT_SYSTEM
+from ttsim.testing_utils import get_policy_date_partition
+from ttsim.tt import TTSIMUnit, policy_function
+
+
+@policy_function(
+    leaf_name="amount_m",
+    start_date="2020-01-01",
+    end_date="2029-12-31",
+    unit=TTSIMUnit.CURRENCY.PER_MONTH,
+)
+def amount_m(rate_m: float) -> float:
+    return rate_m
+
+
+@policy_function(
+    leaf_name="early_amount_m",
+    start_date="2010-01-01",
+    end_date="2029-12-31",
+    unit=TTSIMUnit.CURRENCY.PER_MONTH,
+)
+def early_amount_m(rate_m: float) -> float:
+    """Active across the test unit system's 2020 statutory-currency transition."""
+    return rate_m
+
+
+def _orig_objects(
+    param_spec: dict[Any, Any],
+    function: Any = amount_m,
+) -> dict[str, Any]:
+    return {
+        "column_objects_and_param_functions": {("amount_m",): function},
+        "param_specs": {("rate_m",): param_spec},
+    }
+
+
+def test_policy_date_partition_covers_function_start_and_end():
+    """A function's start date and the day after its inclusive end date each begin a
+    regime the environment must be validated at."""
+    assert get_policy_date_partition(
+        orig_policy_objects=_orig_objects(
+            {"name": "Rate", datetime.date(2020, 1, 1): 1}
+        )
+    ) == [datetime.date(2020, 1, 1), datetime.date(2030, 1, 1)]
+
+
+def test_policy_date_partition_includes_a_parameter_only_change():
+    """A parameter changing mid-interval starts a regime of its own — every function
+    stays active, so a partition built from function dates alone never assembles the
+    new parameter regime (GEP 10)."""
+    assert datetime.date(2022, 7, 1) in get_policy_date_partition(
+        orig_policy_objects=_orig_objects(
+            {
+                "name": "Rate",
+                datetime.date(2020, 1, 1): 1,
+                datetime.date(2022, 7, 1): 2,
+            }
+        )
+    )
+
+
+def test_policy_date_partition_includes_a_statutory_currency_change():
+    """A statutory-currency transition changes what the environment's amounts are
+    denominated in, so it starts a regime too — even where no function or parameter
+    boundary falls on it (GEP 10)."""
+    assert datetime.date(2020, 1, 1) in get_policy_date_partition(
+        orig_policy_objects=_orig_objects({"name": "Rate"}, function=early_amount_m),
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_policy_date_partition_drops_boundaries_outside_the_date_domain():
+    """A boundary before the package's earliest start date names no environment, so
+    it is not a regime to validate — the year-1 start of a statutory currency is the
+    common case."""
+    assert datetime.date(1, 1, 1) not in get_policy_date_partition(
+        orig_policy_objects=_orig_objects({"name": "Rate"}),
+        unit_system=UNIT_SYSTEM,
+    )

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -31,6 +31,17 @@ def early_amount_m(rate_m: float) -> float:
     return rate_m
 
 
+@policy_function(
+    leaf_name="short_amount_m",
+    start_date="2020-01-01",
+    end_date="2024-12-31",
+    unit=TTSIMUnit.CURRENCY.PER_MONTH,
+)
+def short_amount_m(rate_m: float) -> float:
+    """End while another policy function remains active."""
+    return rate_m
+
+
 def _orig_objects(
     param_spec: dict[Any, Any],
     function: Any = amount_m,
@@ -42,13 +53,16 @@ def _orig_objects(
 
 
 def test_policy_date_partition_covers_function_start_and_end():
-    """A function's start date and the day after its inclusive end date each begin a
-    regime the environment must be validated at."""
-    assert get_policy_date_partition(
-        orig_policy_objects=_orig_objects(
-            {"name": "Rate", datetime.date(2020, 1, 1): 1}
-        )
-    ) == [datetime.date(2020, 1, 1), datetime.date(2030, 1, 1)]
+    """An end boundary is included only while the package remains supported."""
+    orig_objects = _orig_objects({"name": "Rate", datetime.date(2020, 1, 1): 1})
+    orig_objects["column_objects_and_param_functions"][("short_amount_m",)] = (
+        short_amount_m
+    )
+
+    assert get_policy_date_partition(orig_policy_objects=orig_objects) == [
+        datetime.date(2020, 1, 1),
+        datetime.date(2025, 1, 1),
+    ]
 
 
 def test_policy_date_partition_includes_a_parameter_only_change():

--- a/tests/test_unit_inference.py
+++ b/tests/test_unit_inference.py
@@ -993,6 +993,69 @@ def test_not_of_a_non_boolean_quantity_is_caught():
         )
 
 
+def test_dimensioned_value_as_a_branch_condition_is_caught():
+    """Only a boolean may control a branch: an `if` on a currency stock is a bug
+    the unit check reports, exactly as `not` on a currency is (GEP 10)."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY)
+    def remaining_wealth(wealth: float) -> float:
+        if wealth:  # bug: a stock is not a truth value
+            return wealth
+        return 0.0
+
+    with pytest.raises(UnitConsistencyError, match="truth value"):
+        fail_if_environment_units_are_inconsistent(
+            env={"wealth": wealth, "remaining_wealth": remaining_wealth},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_dimensioned_value_as_a_conditional_expression_condition_is_caught():
+    """A conditional expression's condition is a truth context like any other, so
+    a dimensioned selector is caught there too (GEP 10)."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def gated_income_m(income_m: float, wealth: float) -> float:
+        return income_m if wealth else 0.0  # bug: a stock is not a truth value
+
+    with pytest.raises(UnitConsistencyError, match="truth value"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "income_m": income_m,
+                "wealth": wealth,
+                "gated_income_m": gated_income_m,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_leveled_boolean_as_a_branch_condition_passes():
+    """A group-level indicator is a truth value, so it may control a branch — the
+    truth-context screen rejects physical content, not a grouping level (GEP 10)."""
+
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def is_exempt_fam() -> bool:
+        """A fam-level indicator."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def gated_income_m(income_m: float, is_exempt_fam: bool) -> float:
+        if is_exempt_fam:
+            return 0.0
+        return income_m
+
+    fail_if_environment_units_are_inconsistent(
+        env={
+            "income_m": income_m,
+            "is_exempt_fam": is_exempt_fam,
+            "gated_income_m": gated_income_m,
+        },
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
 def test_boolean_body_at_correct_group_level_passes():
     """A fam-level predicate comparing fam-level quantities infers ``1 / [fam]``,
     matching its ``_fam`` name (GEP 10)."""
@@ -1970,6 +2033,36 @@ def test_where_arms_are_screened_for_equivalence():
         )
 
 
+def test_where_condition_must_be_a_boolean():
+    """`xnp.where` screens its condition before unifying its arms, so the
+    vectorized spelling rejects a dimensioned selector exactly as the scalar `if`
+    does (GEP 10)."""
+
+    @policy_function(
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+    )
+    def gated_m(
+        wealth: FloatColumn,
+        income_m: FloatColumn,
+        other_income_m: FloatColumn,
+        xnp: ModuleType,
+    ) -> FloatColumn:
+        # bug: a stock selects, the arms are fine
+        return xnp.where(wealth, income_m, other_income_m)
+
+    with pytest.raises(UnitConsistencyError, match="truth value"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "wealth": wealth,
+                "income_m": income_m,
+                "other_income_m": other_income_m,
+                "gated_m": gated_m,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
 def test_where_mixing_a_calendar_point_and_a_duration_is_caught():
     """``xnp.where`` runs no forward pint op, so a calendar-point arm gets no
     delegate-to-pint dispensation: an arm mix of a point and a duration is
@@ -2256,6 +2349,95 @@ def test_schedule_with_a_dimensionful_input_axis_rejects_a_bare_literal_index():
     with pytest.raises(UnitConsistencyError, match="verify_units=False"):
         fail_if_environment_units_are_inconsistent(
             env={"schedule": schedule, "levy_y": levy_y},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_join_with_a_dimensioned_key_is_caught():
+    """A gather's keys are identifiers, so a dimensioned column used as a key is a
+    bug — a currency never identifies a row (GEP 10)."""
+
+    @policy_function(
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+    )
+    def recipient_income_m(
+        p_id: IntColumn,
+        wealth: FloatColumn,
+        income_m: FloatColumn,
+        xnp: ModuleType,
+    ) -> FloatColumn:
+        return join(
+            foreign_key=wealth,  # bug: a stock is not an identifier
+            primary_key=p_id,
+            target=income_m,
+            value_if_foreign_key_is_missing=0.0,
+            xnp=xnp,
+        )
+
+    with pytest.raises(UnitConsistencyError, match="identifier"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "p_id": p_id,
+                "wealth": wealth,
+                "income_m": income_m,
+                "recipient_income_m": recipient_income_m,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_join_fallback_not_in_the_targets_unit_is_caught():
+    """The missing-key fallback becomes part of the gathered column, so it must
+    carry the target's unit; a yearly fallback under a monthly target is a bug
+    that only unmatched keys would ever expose (GEP 10)."""
+
+    @policy_function(
+        unit=TTSIMUnit.CURRENCY.PER_MONTH, vectorization_strategy="not_required"
+    )
+    def recipient_income_m(
+        p_id: IntColumn,
+        p_id_recipient: IntColumn,
+        income_m: FloatColumn,
+        xnp: ModuleType,
+    ) -> FloatColumn:
+        return join(
+            foreign_key=p_id_recipient,
+            primary_key=p_id,
+            target=income_m,
+            # bug: a yearly amount fills the unmatched rows of a monthly column
+            value_if_foreign_key_is_missing=cast_ttsim_unit(
+                100.0, TTSIMUnit.CURRENCY.PER_YEAR
+            ),
+            xnp=xnp,
+        )
+
+    with pytest.raises(UnitConsistencyError, match="missing-key fallback"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "p_id": p_id,
+                "p_id_recipient": p_id_recipient,
+                "income_m": income_m,
+                "recipient_income_m": recipient_income_m,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_in_body_reduction_requires_an_opt_out():
+    """A reduction changes which rows a value belongs to, and the unit check has no
+    array-axis metadata to derive that from, so it demands an explicit opt-out
+    rather than passing the operand's unit through (GEP 10)."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY, vectorization_strategy="not_required")
+    def total_wealth(wealth: FloatColumn, xnp: ModuleType) -> FloatColumn:
+        return xnp.sum(wealth)
+
+    with pytest.raises(UnitConsistencyError, match="verify_units=False"):
+        fail_if_environment_units_are_inconsistent(
+            env={"wealth": wealth, "total_wealth": total_wealth},
             grouping_levels=GROUPING_LEVELS,
             unit_system=UNIT_SYSTEM,
         )

--- a/tests/test_unit_inference.py
+++ b/tests/test_unit_inference.py
@@ -102,9 +102,9 @@ def other_income_m() -> float:
     """A second monthly flow of currency (CURRENCY / month)."""
 
 
-@policy_input(unit=TTSIMUnit.DIMENSIONLESS)
+@policy_input(unit=TTSIMUnit.CALENDAR_MONTH)
 def geburtsmonat() -> int:
-    """A month-of-year (1-12): a cyclic ordinal, not a calendar point (GEP 10)."""
+    """A month-of-year (1-12): a calendar ordinal (GEP 10)."""
 
 
 @policy_input(unit=TTSIMUnit.MONTHS)
@@ -146,6 +146,81 @@ def test_stock_times_rate_without_time_component_is_caught():
                 "is_exempt": is_exempt,
                 "tax_rate": make_dimensionless_rate(),
                 "amount_buggy_y": amount_buggy_y,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_reflected_reciprocal_cannot_launder_a_group_marker():
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def costs_m_fam() -> float:
+        """The family's monthly costs."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def income_m_fam() -> float:
+        """The family's monthly income."""
+
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
+    def ratio(costs_m_fam: float, income_m_fam: float) -> float:
+        return (1 / costs_m_fam) * income_m_fam
+
+    with pytest.raises(UnitConsistencyError, match="unsupported group calculation"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "costs_m_fam": costs_m_fam,
+                "income_m_fam": income_m_fam,
+                "ratio": ratio,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_power_cannot_hide_group_marker_cancellation():
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def costs_m_fam() -> float:
+        """The family's monthly costs."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def income_m_fam() -> float:
+        """The family's monthly income."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def powered_income_m_fam(costs_m_fam: float, income_m_fam: float) -> float:
+        return (income_m_fam**2) * (1 / costs_m_fam)
+
+    with pytest.raises(UnitConsistencyError, match="unsupported group calculation"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "costs_m_fam": costs_m_fam,
+                "income_m_fam": income_m_fam,
+                "powered_income_m_fam": powered_income_m_fam,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_floor_division_is_not_a_group_level_ratio_bridge():
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def costs_m_fam() -> float:
+        """The family's monthly costs."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def income_m_fam() -> float:
+        """The family's monthly income."""
+
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
+    def floored_ratio(costs_m_fam: float, income_m_fam: float) -> float:
+        return income_m_fam // costs_m_fam
+
+    with pytest.raises(UnitConsistencyError, match="unsupported group calculation"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "costs_m_fam": costs_m_fam,
+                "income_m_fam": income_m_fam,
+                "floored_ratio": floored_ratio,
             },
             grouping_levels=GROUPING_LEVELS,
             unit_system=UNIT_SYSTEM,
@@ -505,7 +580,7 @@ def _policy_year() -> ScalarParam:
 
 def _policy_month() -> ScalarParam:
     # A framework date node carrying a month-of-year (1-12): a cyclic ordinal,
-    # resolved to dimensionless via FRAMEWORK_DATE_NODE_UNITS (GEP 10).
+    # resolved to CALENDAR_MONTH via FRAMEWORK_DATE_NODE_UNITS (GEP 10).
     return ScalarParam(value=1, start_date=_START, end_date=_END)
 
 
@@ -681,7 +756,7 @@ def test_subtracting_calendar_points_of_different_axes_is_caught():
     def nonsense(some_calendar_month: int, geburtsjahr: int) -> int:
         return some_calendar_month - geburtsjahr  # bug: subtract points across axes
 
-    with pytest.raises(UnitConsistencyError, match="non-equivalent"):
+    with pytest.raises(UnitConsistencyError, match="calendar ordinal"):
         fail_if_environment_units_are_inconsistent(
             env={
                 "some_calendar_month": some_calendar_month,
@@ -782,9 +857,7 @@ def test_wrong_direction_time_converter_is_caught():
 
 
 def test_month_date_nodes_are_cyclic_ordinals():
-    """``policy_month`` carries a month-of-year (1-12): a cyclic ordinal, hence
-    ``DIMENSIONLESS`` (GEP 10), so comparing it to another ordinal is plain
-    dimensionless arithmetic."""
+    """Month ordinals may be ordered against the same calendar scale."""
 
     @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
     def had_birthday(policy_month: int, geburtsmonat: int) -> bool:
@@ -804,9 +877,9 @@ def test_month_date_nodes_are_cyclic_ordinals():
 def test_month_date_node_shifted_by_a_duration_is_caught():
     """Shifting the cyclic ``policy_month`` by a months duration wraps at run
     time — the silent fold the ordinal/point split exists to catch. As a
-    dimensionless ordinal it does not add to a ``MONTHS`` duration (GEP 10)."""
+    calendar ordinal it does not add to a ``MONTHS`` duration (GEP 10)."""
 
-    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
+    @policy_function(unit=TTSIMUnit.CALENDAR_MONTH)
     def nonsense(policy_month: int, months_paid: int) -> int:
         return policy_month + months_paid  # bug: an ordinal shifted like a point
 
@@ -815,6 +888,25 @@ def test_month_date_node_shifted_by_a_duration_is_caught():
             env={
                 "policy_month": _policy_month(),
                 "months_paid": months_paid,
+                "nonsense": nonsense,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_month_ordinals_do_not_support_general_subtraction():
+    """Subtracting two month-of-year values is not a defined duration."""
+
+    @policy_function(unit=TTSIMUnit.MONTHS)
+    def nonsense(policy_month: int, geburtsmonat: int) -> int:
+        return policy_month - geburtsmonat
+
+    with pytest.raises(UnitConsistencyError, match="calendar ordinal"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "policy_month": _policy_month(),
+                "geburtsmonat": geburtsmonat,
                 "nonsense": nonsense,
             },
             grouping_levels=GROUPING_LEVELS,
@@ -1273,12 +1365,8 @@ def test_terminal_cross_level_division_passes_with_an_explicit_opt_out():
     )
 
 
-def test_bedarfsanteilsmethode_cross_level_share_consumed_by_multiplication_passes():
-    """The GETTSIM idiom: a person's share of a group claim,
-    ``(bedarf_m / bedarf_m_fam) * anspruch_m_fam``. The cross-level result
-    ``[fam]`` is consumed by the multiply, landing on a bare per-person flow that
-    matches the declaration — no exemption needed, and unchanged by the
-    cross-level rule (GEP 10)."""
+def test_bedarfsanteilsmethode_requires_a_local_assertion():
+    """A bare amount divided by a non-count group amount is not inferred."""
 
     @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
     def bedarf_m() -> float:
@@ -1296,16 +1384,95 @@ def test_bedarfsanteilsmethode_cross_level_share_consumed_by_multiplication_pass
     def betrag_m(bedarf_m: float, bedarf_m_fam: float, anspruch_m_fam: float) -> float:
         return (bedarf_m / bedarf_m_fam) * anspruch_m_fam
 
+    with pytest.raises(UnitConsistencyError, match="group calculation"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "bedarf_m": bedarf_m,
+                "bedarf_m_fam": bedarf_m_fam,
+                "anspruch_m_fam": anspruch_m_fam,
+                "betrag_m": betrag_m,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_same_group_total_ratio_is_rejected():
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def housing_costs_m_fam() -> float:
+        """Monthly housing costs of the family."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def income_m_fam() -> float:
+        """Monthly income of the family."""
+
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
+    def housing_cost_share(housing_costs_m_fam: float, income_m_fam: float) -> float:
+        return housing_costs_m_fam / income_m_fam
+
+    with pytest.raises(UnitConsistencyError, match="group calculation"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "housing_costs_m_fam": housing_costs_m_fam,
+                "income_m_fam": income_m_fam,
+                "housing_cost_share": housing_cost_share,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_same_group_indicator_may_mask_a_group_total():
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def eligible_fam() -> bool:
+        """Whether the family is eligible."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def benefit_m_fam() -> float:
+        """Monthly benefit of the family."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def paid_benefit_m_fam(eligible_fam: bool, benefit_m_fam: float) -> float:
+        return eligible_fam * benefit_m_fam
+
     fail_if_environment_units_are_inconsistent(
         env={
-            "bedarf_m": bedarf_m,
-            "bedarf_m_fam": bedarf_m_fam,
-            "anspruch_m_fam": anspruch_m_fam,
-            "betrag_m": betrag_m,
+            "eligible_fam": eligible_fam,
+            "benefit_m_fam": benefit_m_fam,
+            "paid_benefit_m_fam": paid_benefit_m_fam,
         },
         grouping_levels=GROUPING_LEVELS,
         unit_system=UNIT_SYSTEM,
     )
+
+
+def test_arithmetic_on_a_head_count_does_not_keep_head_count_evidence():
+    """Only an independently known head count enables group-total allocation."""
+
+    @policy_input(unit=TTSIMUnit.COUNT.PER_FAM)
+    def number_of_people_fam() -> int:
+        """Number of people in the family."""
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def benefit_m_fam() -> float:
+        """Monthly benefit of the family."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def wrongly_scaled_benefit_m(
+        number_of_people_fam: int, benefit_m_fam: float
+    ) -> float:
+        return benefit_m_fam / (2 * number_of_people_fam)
+
+    with pytest.raises(UnitConsistencyError, match="group calculation"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "number_of_people_fam": number_of_people_fam,
+                "benefit_m_fam": benefit_m_fam,
+                "wrongly_scaled_benefit_m": wrongly_scaled_benefit_m,
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
 
 
 def test_cross_level_share_declared_with_concrete_content_is_caught():
@@ -1493,7 +1660,7 @@ def test_group_share_times_group_total_squares_the_level_and_is_caught():
     def parents_need_m_fam(parents_share_fam: float, need_m_fam: float) -> float:
         return parents_share_fam * need_m_fam
 
-    with pytest.raises(UnitConsistencyError, match="cast_ttsim_unit"):
+    with pytest.raises(UnitConsistencyError, match="count or yes/no"):
         fail_if_environment_units_are_inconsistent(
             env={
                 "parents_share_fam": parents_share_fam,
@@ -1505,11 +1672,10 @@ def test_group_share_times_group_total_squares_the_level_and_is_caught():
         )
 
 
-def test_group_share_times_group_total_passes_with_cast():
-    """Where the law mandates the group-share product, the cast states the
-    intended result at the site (GEP 10)."""
+def test_bare_share_times_group_total_passes():
+    """A share stays bare and scales a group total by ordinary arithmetic."""
 
-    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
     def parents_share_fam() -> float:
         """The parents' share of the family's need — the family's property."""
 
@@ -1519,10 +1685,7 @@ def test_group_share_times_group_total_passes_with_cast():
 
     @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
     def parents_need_m_fam(parents_share_fam: float, need_m_fam: float) -> float:
-        return cast_ttsim_unit(
-            value=parents_share_fam * need_m_fam,
-            unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM,
-        )
+        return parents_share_fam * need_m_fam
 
     fail_if_environment_units_are_inconsistent(
         env={
@@ -3536,7 +3699,7 @@ def _two_axis_lookup(xnp: ModuleType) -> ConsecutiveIntLookupTableParamValue:
 
 @param_function(
     unit=InputOutputUnits(
-        input_unit=(TTSIMUnit.DIMENSIONLESS, TTSIMUnit.YEARS),
+        input_unit=(TTSIMUnit.CALENDAR_MONTH, TTSIMUnit.YEARS),
         output_unit=TTSIMUnit.CURRENCY.PER_MONTH,
     ),
     verify_units=False,
@@ -3700,7 +3863,7 @@ class _TwoAxisFieldRate:
     table: Annotated[
         ConsecutiveIntLookupTableParamValue,
         InputOutputUnits(
-            input_unit=(TTSIMUnit.DIMENSIONLESS, TTSIMUnit.YEARS),
+            input_unit=(TTSIMUnit.CALENDAR_MONTH, TTSIMUnit.YEARS),
             output_unit=TTSIMUnit.CURRENCY.PER_MONTH,
         ),
     ]

--- a/tests/test_unit_validation.py
+++ b/tests/test_unit_validation.py
@@ -30,6 +30,7 @@ from tests.test_unit_fixtures import (
     unannotated_income_y,
     wealth,
 )
+from ttsim import tt
 from ttsim.exceptions import (
     AggregationDefinitionError,
     UnitConsistencyError,
@@ -41,14 +42,17 @@ from ttsim.interface_dag_elements.automatically_added_functions import (
 from ttsim.tt import (
     UNSET_UNIT,
     AggType,
+    InputOutputUnits,
     RoundingSpec,
     TTSIMUnit,
     agg_by_group_function,
+    cast_ttsim_unit,
     param_function,
     policy_function,
     policy_input,
 )
 from ttsim.tt.param_objects import (
+    ConsecutiveIntLookupTableParamValue,
     DictParam,
     PiecewisePolynomialParam,
     PiecewisePolynomialParamValue,
@@ -65,9 +69,21 @@ from ttsim.unit_resolution import (
     resolve_environment_units,
 )
 from ttsim.unit_validation import (
+    create_unit_validation_report,
     fail_if_environment_units_are_inconsistent,
     fail_if_environment_units_are_missing,
 )
+
+
+@dataclass(frozen=True)
+class _BadGroupShareStructured:
+    housing_cost_share_fam: Annotated[float, TTSIMUnit.DIMENSIONLESS.PER_FAM]
+
+
+@dataclass(frozen=True)
+class _CountStructured:
+    number_of_people_fam: Annotated[int, TTSIMUnit.COUNT.PER_FAM]
+
 
 # Mandatory units, no exemptions: identifiers and booleans declare
 # DIMENSIONLESS; group-creation group ids are auto-assigned DIMENSIONLESS;
@@ -77,6 +93,414 @@ from ttsim.unit_validation import (
 def test_boolean_nodes_are_detected():
     assert node_is_boolean(qname="is_exempt", obj=is_exempt)
     assert not node_is_boolean(qname="wealth", obj=wealth)
+
+
+def test_group_marker_on_a_float_share_is_rejected():
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def housing_cost_share_fam() -> float:
+        """The household's housing-cost share."""
+
+    with pytest.raises(UnitConsistencyError, match=r"share|count or yes/no"):
+        fail_if_environment_units_are_inconsistent(
+            env={"housing_cost_share_fam": housing_cost_share_fam},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_group_marker_on_an_integer_category_is_rejected():
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def rent_class_fam() -> int:
+        """The municipality's rent classification."""
+
+    with pytest.raises(UnitConsistencyError, match="count or yes/no"):
+        fail_if_environment_units_are_inconsistent(
+            env={"rent_class_fam": rent_class_fam},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_explicit_integer_count_may_carry_a_group_marker():
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def number_of_children_fam() -> int:
+        """Number of children in the family."""
+
+    with pytest.raises(UnitConsistencyError, match="COUNT"):
+        fail_if_environment_units_are_inconsistent(
+            env={"number_of_children_fam": number_of_children_fam},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+    @policy_input(unit=TTSIMUnit.COUNT.PER_FAM)
+    def explicitly_declared_children_fam() -> int:
+        """Number of children in the family."""
+
+    fail_if_environment_units_are_inconsistent(
+        env={"explicitly_declared_children_fam": explicitly_declared_children_fam},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_german_documentation_does_not_replace_an_explicit_count_declaration():
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def kinderzahl_fam() -> int:
+        """Zahl der Kinder in der Familie."""
+
+    with pytest.raises(UnitConsistencyError, match="COUNT"):
+        fail_if_environment_units_are_inconsistent(
+            env={"kinderzahl_fam": kinderzahl_fam},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_negated_count_wording_does_not_authorize_a_category():
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def category_for_number_of_children_fam() -> int:
+        """Category for the number of children, not a head count."""
+
+    with pytest.raises(UnitConsistencyError, match="category_for_number"):
+        fail_if_environment_units_are_inconsistent(
+            env={
+                "category_for_number_of_children_fam": (
+                    category_for_number_of_children_fam
+                )
+            },
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_count_evidence_is_local_to_one_mapping_leaf():
+    mixed = DictParam(
+        value={"number_of_children": 2, "rent_class": 3},
+        unit={
+            "number_of_children": TTSIMUnit.COUNT.PER_FAM,
+            "rent_class": TTSIMUnit.DIMENSIONLESS.PER_FAM,
+        },
+        name={"en": "Number of children and rent class", "de": "Kinder und Miete"},
+        description={
+            "en": "Number of children and the municipality rent category.",
+            "de": "Anzahl der Kinder und kommunale Mietstufe.",
+        },
+        start_date=_START,
+        end_date=_END,
+    )
+    with pytest.raises(UnitConsistencyError, match=r"rent_class.*group marker"):
+        fail_if_environment_units_are_inconsistent(
+            env={"number_of_children_and_rent_class": mixed},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_group_marked_schedule_axis_requires_its_own_count_evidence():
+    @param_function(
+        unit=InputOutputUnits(
+            input_unit=TTSIMUnit.DIMENSIONLESS.PER_FAM,
+            output_unit=TTSIMUnit.CURRENCY.PER_MONTH,
+        ),
+        verify_units=False,
+    )
+    def rent_class_schedule() -> ConsecutiveIntLookupTableParamValue:
+        """A schedule indexed by a rent category, not a count."""
+        raise NotImplementedError
+
+    with pytest.raises(UnitConsistencyError, match="input axis"):
+        fail_if_environment_units_are_inconsistent(
+            env={"rent_class_schedule": rent_class_schedule},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_group_marked_schedule_axis_accepts_explicit_count_evidence():
+    @param_function(
+        unit=InputOutputUnits(
+            input_unit=TTSIMUnit.COUNT.PER_FAM,
+            output_unit=TTSIMUnit.CURRENCY.PER_MONTH,
+        ),
+        verify_units=False,
+    )
+    def amount_by_number_of_children_m() -> ConsecutiveIntLookupTableParamValue:
+        """A schedule indexed by the number of children."""
+        raise NotImplementedError
+
+    fail_if_environment_units_are_inconsistent(
+        env={"amount_by_number_of_children_m": amount_by_number_of_children_m},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_group_marked_structured_float_share_is_rejected():
+    @param_function(unit=UNSET_UNIT)
+    def bad_structured() -> _BadGroupShareStructured:
+        return _BadGroupShareStructured(housing_cost_share_fam=0.5)
+
+    with pytest.raises(UnitConsistencyError, match="housing_cost_share_fam"):
+        fail_if_environment_units_are_inconsistent(
+            env={"bad_structured": bad_structured},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_structured_count_field_allocates_a_group_total_per_person():
+    @param_function(unit=UNSET_UNIT)
+    def group_statistics() -> _CountStructured:
+        return _CountStructured(number_of_people_fam=2)
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def rent_m_fam() -> float:
+        """Monthly rent of the family."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def rent_per_head_m(
+        rent_m_fam: float,
+        group_statistics: _CountStructured,
+    ) -> float:
+        return rent_m_fam / group_statistics.number_of_people_fam
+
+    fail_if_environment_units_are_inconsistent(
+        env={
+            "group_statistics": group_statistics,
+            "rent_m_fam": rent_m_fam,
+            "rent_per_head_m": rent_per_head_m,
+        },
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_mapping_count_leaf_allocates_a_group_total_per_person():
+    group_statistics = DictParam(
+        value={"number_of_people_fam": 2},
+        unit={"number_of_people_fam": TTSIMUnit.COUNT.PER_FAM},
+        start_date=_START,
+        end_date=_END,
+    )
+
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def rent_m_fam() -> float:
+        """Monthly rent of the family."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def rent_per_head_m(
+        rent_m_fam: float,
+        group_statistics: dict[str, int],
+    ) -> float:
+        return rent_m_fam / group_statistics["number_of_people_fam"]
+
+    fail_if_environment_units_are_inconsistent(
+        env={
+            "group_statistics": group_statistics,
+            "rent_m_fam": rent_m_fam,
+            "rent_per_head_m": rent_per_head_m,
+        },
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_explicit_count_cast_allocates_a_group_total_per_person():
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_FAM)
+    def rent_m_fam() -> float:
+        """Monthly rent of the family."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def rent_per_head_m(rent_m_fam: float) -> float:
+        return rent_m_fam / cast_ttsim_unit(2, unit=TTSIMUnit.COUNT.PER_FAM)
+
+    fail_if_environment_units_are_inconsistent(
+        env={"rent_m_fam": rent_m_fam, "rent_per_head_m": rent_per_head_m},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_validation_report_rejects_group_marked_structured_float_share():
+    @param_function(unit=UNSET_UNIT)
+    def bad_structured() -> _BadGroupShareStructured:
+        return _BadGroupShareStructured(housing_cost_share_fam=0.5)
+
+    with pytest.raises(UnitConsistencyError, match="housing_cost_share_fam"):
+        create_unit_validation_report(
+            env={"bad_structured": bad_structured},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
+
+
+def test_boolean_may_carry_a_group_marker():
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def eligible_fam() -> bool:
+        """Whether the family is eligible."""
+
+    fail_if_environment_units_are_inconsistent(
+        env={"eligible_fam": eligible_fam},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_validation_report_separates_evidence_and_exceptions():
+    @policy_input(unit=TTSIMUnit.CURRENCY)
+    def assets() -> float:
+        """Financial assets."""
+
+    @policy_function(unit=TTSIMUnit.CURRENCY)
+    def checked_assets(assets: float) -> float:
+        return assets
+
+    @policy_function(unit=TTSIMUnit.CURRENCY)
+    def locally_asserted_assets(assets: float) -> float:
+        return cast_ttsim_unit(assets, unit=TTSIMUnit.CURRENCY)
+
+    @policy_function(unit=TTSIMUnit.CURRENCY, verify_units=False)
+    def opted_out_assets(assets: float) -> float:
+        return assets
+
+    @agg_by_group_function(agg_type=AggType.COUNT, unit=TTSIMUnit.DIMENSIONLESS.PER_FAM)
+    def number_of_people_fam(fam_id: int) -> int: ...
+
+    env = {
+        "assets": assets,
+        "checked_assets": checked_assets,
+        "locally_asserted_assets": locally_asserted_assets,
+        "opted_out_assets": opted_out_assets,
+        "number_of_people_fam": number_of_people_fam,
+    }
+    report = create_unit_validation_report(
+        env=env,
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+        policy_dates=(_START,),
+    )
+
+    assert report.resolved_declarations == tuple(sorted(env))
+    assert report.checked_function_bodies == (
+        "checked_assets",
+        "locally_asserted_assets",
+    )
+    assert report.checked_aggregations == ("number_of_people_fam",)
+    assert report.generated_rules == ()
+    assert report.local_casts == ("locally_asserted_assets",)
+    assert report.body_opt_outs == ("opted_out_assets",)
+    assert report.unsupported_bodies == ()
+    assert report.other_unchecked_bodies == ()
+    assert report.policy_date_regimes == (_START,)
+
+
+def test_validation_report_classifies_manual_aggregation_opt_out():
+    @policy_input(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def source_m() -> float:
+        """A monthly amount."""
+
+    @agg_by_group_function(
+        agg_type=AggType.SUM,
+        unit=TTSIMUnit.YEARS,
+        verify_units=False,
+    )
+    def aggregate_fam(source_m: float, fam_id: int) -> float: ...
+
+    report = create_unit_validation_report(
+        env={"source_m": source_m, "aggregate_fam": aggregate_fam},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+    assert report.body_opt_outs == ("aggregate_fam",)
+    assert report.generated_rules == ()
+
+
+def test_validation_report_classifies_schedule_builder_opt_out():
+    @param_function(
+        unit=InputOutputUnits(
+            input_unit=TTSIMUnit.DIMENSIONLESS,
+            output_unit=TTSIMUnit.CURRENCY.PER_MONTH,
+        ),
+        verify_units=False,
+    )
+    def amount_by_category_m() -> ConsecutiveIntLookupTableParamValue:
+        raise NotImplementedError
+
+    report = create_unit_validation_report(
+        env={"amount_by_category_m": amount_by_category_m},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+    assert report.body_opt_outs == ("amount_by_category_m",)
+    assert report.other_unchecked_bodies == ()
+
+
+def test_validation_report_recognizes_cast_aliases_by_identity():
+    imported_alias = cast_ttsim_unit
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def imported_alias_m() -> float:
+        return imported_alias(1.0, TTSIMUnit.CURRENCY.PER_MONTH)
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def local_alias_m() -> float:
+        alias = cast_ttsim_unit
+        return alias(1.0, TTSIMUnit.CURRENCY.PER_MONTH)
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def module_alias_m() -> float:
+        return tt.cast_ttsim_unit(1.0, TTSIMUnit.CURRENCY.PER_MONTH)
+
+    closure_alias = cast_ttsim_unit
+
+    @policy_function(unit=TTSIMUnit.CURRENCY.PER_MONTH)
+    def closure_alias_m() -> float:
+        return closure_alias(1.0, TTSIMUnit.CURRENCY.PER_MONTH)
+
+    env = {
+        "imported_alias_m": imported_alias_m,
+        "local_alias_m": local_alias_m,
+        "module_alias_m": module_alias_m,
+        "closure_alias_m": closure_alias_m,
+    }
+    report = create_unit_validation_report(
+        env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
+    )
+    assert report.local_casts == tuple(sorted(env))
+
+
+def test_validation_report_does_not_treat_same_spelling_as_a_cast():
+    def cast_ttsim_unit(value: float, unit: Any) -> float:  # noqa: ARG001
+        return value
+
+    @policy_function(unit=TTSIMUnit.DIMENSIONLESS)
+    def coincidental_name() -> float:
+        return cast_ttsim_unit(1.0, TTSIMUnit.CURRENCY)
+
+    report = create_unit_validation_report(
+        env={"coincidental_name": coincidental_name},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+    assert report.local_casts == ()
+
+
+def test_validation_report_rejects_a_body_with_a_wrong_inferred_unit():
+    @policy_input(unit=TTSIMUnit.CURRENCY)
+    def assets() -> float:
+        """Financial assets."""
+
+    @policy_function(unit=TTSIMUnit.YEARS)
+    def wrong_unit(assets: float) -> float:
+        return assets
+
+    with pytest.raises(UnitConsistencyError, match=r"wrong_unit.*declares"):
+        create_unit_validation_report(
+            env={"assets": assets, "wrong_unit": wrong_unit},
+            grouping_levels=GROUPING_LEVELS,
+            unit_system=UNIT_SYSTEM,
+        )
 
 
 def test_missing_check_passes_for_declared_and_group_creation_nodes():
@@ -699,17 +1123,13 @@ def test_auto_generated_boolean_group_aggregate_passes_the_build():
     )
 
 
-def test_opted_out_aggregation_declares_its_own_level():
-    """``verify_units=False`` on an aggregation skips the declared-vs-derived check
-    and resolves the *declared* unit, so a MEAN can be stated ``PER_KIN`` (a kin
-    property) even though the algebra derives it as the person's (GEP 10)."""
+def test_group_mean_derives_the_target_level_without_an_opt_out():
+    """A group mean is a statistic of the target group (GEP 10)."""
 
     @policy_input(unit=TTSIMUnit.CURRENCY)
     def wealth() -> float: ...
 
-    @agg_by_group_function(
-        agg_type=AggType.MEAN, unit=TTSIMUnit.CURRENCY.PER_KIN, verify_units=False
-    )
+    @agg_by_group_function(agg_type=AggType.MEAN, unit=TTSIMUnit.CURRENCY.PER_KIN)
     def average_wealth_kin(kin_id: int, wealth: float) -> float: ...
 
     env = {"wealth": wealth, "average_wealth_kin": average_wealth_kin}
@@ -723,20 +1143,37 @@ def test_opted_out_aggregation_declares_its_own_level():
         ),
         registry=REGISTRY,
     )
-    # No declared-vs-derived rejection: the MEAN derives the bare individual unit.
     fail_if_environment_units_are_inconsistent(
         env=env, grouping_levels=GROUPING_LEVELS, unit_system=UNIT_SYSTEM
     )
 
 
-def test_aggregation_without_opt_out_still_rejects_a_wrong_level():
-    """Without the opt-out, the same ``PER_KIN`` declaration on a MEAN is rejected —
-    the opt-out is the only way to override the derivation (GEP 10)."""
+def test_dimensionless_group_mean_is_validated_as_an_aggregation():
+    """A derived group statistic is not a direct group-quantity declaration."""
+
+    @policy_input(unit=TTSIMUnit.DIMENSIONLESS)
+    def share() -> float: ...
+
+    @agg_by_group_function(
+        agg_type=AggType.MEAN,
+        unit=TTSIMUnit.DIMENSIONLESS.PER_KIN,
+    )
+    def average_share_kin(kin_id: int, share: float) -> float: ...
+
+    fail_if_environment_units_are_inconsistent(
+        env={"share": share, "average_share_kin": average_share_kin},
+        grouping_levels=GROUPING_LEVELS,
+        unit_system=UNIT_SYSTEM,
+    )
+
+
+def test_group_mean_declared_bare_is_rejected():
+    """A group mean cannot be declared as a person-level result (GEP 10)."""
 
     @policy_input(unit=TTSIMUnit.CURRENCY)
     def wealth() -> float: ...
 
-    @agg_by_group_function(agg_type=AggType.MEAN, unit=TTSIMUnit.CURRENCY.PER_KIN)
+    @agg_by_group_function(agg_type=AggType.MEAN, unit=TTSIMUnit.CURRENCY)
     def average_wealth_kin(kin_id: int, wealth: float) -> float: ...
 
     with pytest.raises(UnitConsistencyError, match="average_wealth_kin"):

--- a/tests/tt/test_grouping_levels.py
+++ b/tests/tt/test_grouping_levels.py
@@ -3,7 +3,7 @@
 These exercise the core level mechanics directly on the unit primitives:
 levels as non-convertible base dimensions, the level-as-denominator
 resolution, the dimensionless head-count bridge, cross-level rejection, and the
-level-aware aggregation (SUM/MIN/MAX take the target level, MEAN goes bare,
+level-aware aggregation (SUM/MEAN/MIN/MAX take the target level,
 COUNT mints ``1/[target]``, ANY/ALL a boolean at the target).
 
 An individual quantity is bare, carrying no grouping level, and a head count is
@@ -445,10 +445,8 @@ def test_resolved_aggregation_any_all_are_boolean_at_target_level(agg_type):
     )
 
 
-def test_resolved_aggregation_mean_resolves_to_bare():
-    # A per-head average belongs to the individual, whatever the target (GEP 10):
-    # leveling it to the target would break ``mean · count = sum``. The source
-    # level is dropped, leaving a bare per-person amount.
+def test_resolved_aggregation_mean_resolves_to_target_level():
+    # A mean calculated by target group is a statistic of that target group.
     source = divide_by_grouping_level(
         unit=pint_unit_from_string(unit_str=CURRENCY_TOKEN, registry=REGISTRY),
         level="hh",
@@ -461,13 +459,15 @@ def test_resolved_aggregation_mean_resolves_to_bare():
         source_level="hh",
         registry=REGISTRY,
     )
-    expected = pint_unit_from_string(unit_str=CURRENCY_TOKEN, registry=REGISTRY)
+    expected = divide_by_grouping_level(
+        unit=pint_unit_from_string(unit_str=CURRENCY_TOKEN, registry=REGISTRY),
+        level="sn",
+        registry=REGISTRY,
+    )
     assert units_are_equivalent(left=result, right=expected, registry=REGISTRY)
 
 
-def test_resolved_aggregation_mean_over_bare_source_stays_bare():
-    # The individual reading of an intensive base is bare, so an age's mean stays
-    # comparable to bare thresholds.
+def test_resolved_aggregation_mean_over_bare_source_takes_target_level():
     source = pint_unit_from_string(unit_str="delta_calendar_month", registry=REGISTRY)
     result = resolved_unit_for_aggregation(
         source_unit=source,
@@ -476,12 +476,15 @@ def test_resolved_aggregation_mean_over_bare_source_stays_bare():
         source_level=None,
         registry=REGISTRY,
     )
-    assert units_are_equivalent(left=result, right=source, registry=REGISTRY)
+    assert units_are_equivalent(
+        left=result,
+        right=divide_by_grouping_level(unit=source, level="hh", registry=REGISTRY),
+        registry=REGISTRY,
+    )
 
 
-def test_resolved_aggregation_mean_over_boolean_source_is_a_bare_share():
-    # The mean of an indicator is a share: stripping the boolean's level leaves a
-    # bare dimensionless number.
+def test_resolved_aggregation_mean_over_boolean_source_is_at_target_level():
+    # A mean of an indicator is a group statistic, not a head count.
     source = divide_by_grouping_level(
         unit=REGISTRY.dimensionless, level="hh", registry=REGISTRY
     )
@@ -493,7 +496,11 @@ def test_resolved_aggregation_mean_over_boolean_source_is_a_bare_share():
         registry=REGISTRY,
     )
     assert units_are_equivalent(
-        left=result, right=REGISTRY.dimensionless, registry=REGISTRY
+        left=result,
+        right=divide_by_grouping_level(
+            unit=REGISTRY.dimensionless, level="hh", registry=REGISTRY
+        ),
+        registry=REGISTRY,
     )
 
 
@@ -603,26 +610,23 @@ def test_min_aggregation_token_over_a_bare_base_takes_the_target_level():
     )
 
 
-def test_mean_aggregation_token_drops_a_leveled_source_to_bare():
-    # A per-head average belongs to the individual: a leveled source drops its
-    # group level, leaving a bare per-person amount.
+def test_mean_aggregation_token_takes_the_target_level():
     assert (
         unit_for_aggregation(
             source_unit=TTSIMUnit.CURRENCY.PER_MONTH.PER_HH,
             agg_type=AggType.MEAN,
             target_level="hh",
         )
-        == TTSIMUnit.CURRENCY.PER_MONTH
+        == TTSIMUnit.CURRENCY.PER_MONTH.PER_HH
     )
 
 
-def test_mean_aggregation_token_of_a_boolean_is_bare():
-    # A share — the mean of a boolean — is bare.
+def test_mean_aggregation_token_of_a_boolean_takes_the_target_level():
     assert (
         unit_for_aggregation(
             source_unit=TTSIMUnit.DIMENSIONLESS.PER_HH,
             agg_type=AggType.MEAN,
             target_level="hh",
         )
-        == TTSIMUnit.DIMENSIONLESS
+        == TTSIMUnit.DIMENSIONLESS.PER_HH
     )

--- a/tests/tt/test_units.py
+++ b/tests/tt/test_units.py
@@ -9,6 +9,7 @@ import pickle
 # makes the tracer-bullet policy function importable.
 import mettsim.middle_earth  # noqa: F401
 import numpy as np
+import pint
 import pytest
 from beartype.roar import BeartypeCallHintViolation
 
@@ -39,9 +40,11 @@ from ttsim.tt import (
 )
 from ttsim.tt.units import (
     CURRENCY_TOKEN,
+    QuantityKind,
     _name_suffixes,
     fail_if_units_are_missing,
     input_column_in_data_currency,
+    is_calendar_ordinal_unit,
     is_calendar_point_unit,
     pint_unit_from_string,
     pint_unit_from_ttsim_unit,
@@ -129,6 +132,8 @@ def test_hectare_is_an_area():
 _BASE_SPELLINGS = [
     "CURRENCY",
     "DIMENSIONLESS",
+    "COUNT",
+    "INDICATOR",
     "HOURS",
     "SQUARE_METER",
     "HECTARE",
@@ -149,6 +154,8 @@ _BASE_SPELLINGS = [
         *_BASE_SPELLINGS,
         "CURRENCY_PER_MONTH",
         "CURRENCY_PER_MONTH_PER_BG",
+        "COUNT_PER_BG",
+        "INDICATOR_PER_BG",
         "DIMENSIONLESS_PER_BG",
         "DIMENSIONLESS_PER_YEAR",
         "HOURS_PER_WEEK",
@@ -158,6 +165,33 @@ def test_ttsim_unit_from_yaml_value_round_trips_spellings(spelling):
     token = ttsim_unit_from_yaml_value(value=spelling, where="test")
     assert isinstance(token, CompositeUnit)
     assert str(token) == spelling
+
+
+@pytest.mark.parametrize(
+    ("declaration", "kind"),
+    [
+        (TTSIMUnit.COUNT.PER_LEVEL("bg"), QuantityKind.COUNT),
+        (TTSIMUnit.INDICATOR.PER_LEVEL("bg"), QuantityKind.INDICATOR),
+    ],
+)
+def test_semantic_declaration_normalizes_to_dimensionless_unit(declaration, kind):
+    assert declaration.base == "DIMENSIONLESS"
+    assert declaration.kind is kind
+
+
+@pytest.mark.parametrize(
+    "build_invalid_declaration",
+    [
+        lambda: TTSIMUnit.COUNT.PER_MONTH,
+        lambda: TTSIMUnit.COUNT.PER_HOURS,
+        lambda: TTSIMUnit.INDICATOR.PER_SQUARE_METER,
+    ],
+)
+def test_semantic_declaration_only_accepts_a_group_denominator(
+    build_invalid_declaration,
+):
+    with pytest.raises(UnitDefinitionError, match=r"COUNT|INDICATOR"):
+        build_invalid_declaration()
 
 
 def test_ttsim_unit_from_yaml_value_rejects_none():
@@ -381,18 +415,6 @@ def test_is_calendar_point_unit():
         unit=pint_unit_from_string(unit_str="calendar_year", registry=REGISTRY),
         registry=REGISTRY,
     )
-    assert is_calendar_point_unit(
-        unit=pint_unit_from_string(unit_str="calendar_quarter", registry=REGISTRY),
-        registry=REGISTRY,
-    )
-    assert is_calendar_point_unit(
-        unit=pint_unit_from_string(unit_str="calendar_month", registry=REGISTRY),
-        registry=REGISTRY,
-    )
-    assert is_calendar_point_unit(
-        unit=pint_unit_from_string(unit_str="calendar_day", registry=REGISTRY),
-        registry=REGISTRY,
-    )
     # Durations and ordinary units are not points.
     assert not is_calendar_point_unit(
         unit=pint_unit_from_string(unit_str="delta_calendar_year", registry=REGISTRY),
@@ -406,6 +428,15 @@ def test_is_calendar_point_unit():
         unit=pint_unit_from_string(unit_str="CURRENCY / month", registry=REGISTRY),
         registry=REGISTRY,
     )
+
+
+@pytest.mark.parametrize(
+    "unit_name", ["calendar_quarter", "calendar_month", "calendar_day"]
+)
+def test_calendar_ordinals_are_not_affine_points(unit_name):
+    unit = pint_unit_from_string(unit_str=unit_name, registry=REGISTRY)
+    assert is_calendar_ordinal_unit(unit)
+    assert not is_calendar_point_unit(unit=unit, registry=REGISTRY)
 
 
 def test_policy_function_stores_unit():
@@ -511,15 +542,9 @@ def test_duration_conversion_year_to_month():
     assert months.magnitude == pytest.approx(24.0)
 
 
-def test_calendar_quarter_point_algebra():
-    quarter = REGISTRY.Quantity(2, "calendar_quarter")
-
-    assert quarter - REGISTRY.Quantity(1, "calendar_quarter") == REGISTRY.Quantity(
-        1, "delta_calendar_quarter"
-    )
-    assert quarter + REGISTRY.Quantity(
-        1, "delta_calendar_quarter"
-    ) == REGISTRY.Quantity(3, "calendar_quarter")
+def test_calendar_quarter_ordinal_is_not_a_duration():
+    with pytest.raises(pint.DimensionalityError):
+        REGISTRY.Quantity(2, "calendar_quarter").to("delta_calendar_quarter")
 
 
 def test_fail_if_units_are_missing_reports_unannotated_nodes():


### PR DESCRIPTION
Based on #141. Tightens the GEP 10 unit check where it accepted constructs it claims to
reject, and makes the METTSIM worked example declare what it computes.

Each defect below is a common policy-language construct rather than an exotic one, so the
check certified bodies it had not actually checked.

## A dimensioned value could control a branch

`_UnitCheckQuantity.__bool__` went straight to the path explorer, so every truth context
accepted every unit:

```python
@policy_function(unit=TTSIMUnit.CURRENCY)
def f(wealth: float) -> float:
    return wealth if wealth else 0.0   # accepted
```

`__bool__` now screens first, through the same boolean test the logical operators already
used, so `if wealth` and `x if wealth else y` are rejected exactly as `~wealth` was. A
group-level indicator (`1 / [fam]`) is a truth value and still passes.

## `xnp.where` ignored its condition

The stand-in took `condition`, marked it unused, and validated only the two arms, so
`xnp.where(wealth, amount_a_m, amount_b_m)` passed and refactoring a scalar `if` into a
vectorized `where` silently dropped the check. It now runs the same screen as the scalar
branch — which is what GEP 10 requires of it in as many words: "the scalar and vectorized
implementations MUST call the same rule. In particular, `xnp.where` MUST validate its
condition before unifying its result arms."

## `join` ignored three of its five operands

Keys and the missing-key fallback were assumed rather than checked, and the target's unit
came back regardless. Now neither key may carry physical content — a currency never
identifies a row — and the fallback is screened against the target as an arm of `where`
is, since a fallback in the wrong period is a bug only unmatched keys would ever expose. A
bare sentinel next to a dimensionless target (`-1` for a group id) stays admissible. Nominal
key domains and cardinality need the typed relations of GEP 10's later phases and are not
attempted here.

## In-body reductions were grain-blind

`xnp.sum`/`amin`/`amax` discarded every axis argument and passed the operand's unit
through, so a person-axis sum kept a per-person unit while having become a group total.
They now demand an explicit `verify_units=False`: a reduction changes which rows the result
belongs to, and there is no array-axis metadata to derive that from. This is the disposition
GEP 10 prescribes — "a stand-in that discards `axis` … is nonconforming"; "if an axis has no
static metadata, the reduction is rejected".

## METTSIM declared a stock as monthly income

Both `net_income_parents_m_*` functions declared `CURRENCY.PER_MONTH`, opted out of body
verification, and returned `wealth` or `0.8 * wealth`. No division by a period or other
flow-generating operation occurred; the declaration was simply false, and it propagated
into downstream edges and rounding as if proven.

The reproducer now returns the stock it computes — `net_wealth_parents`, `unit=CURRENCY`,
rounding in `SILVER_PENNY`/`CASTAR` — and **both `verify_units=False` opt-outs are gone**,
so its body is verified like any other. It still reproduces what it was written for: a
`bool` parameter plus rounding plus vectorization through `concatenate_functions`.

## The "all policy dates" sweep omitted parameter-only regimes

`dates_in_orig_mettsim_objects` loaded `param_specs` but built its dates only from function
boundaries, so a parameter whose value, unit, or currency changes inside a stable function
interval was never assembled.

New public `ttsim.testing_utils.get_policy_date_partition` builds the partition from
function start and end+1 dates, **every dated parameter entry**, and statutory-currency
transitions, clipped to the package's own date domain; METTSIM's sweep calls it and GETTSIM
can reuse it. Worth knowing: METTSIM's parameter dates currently all coincide with function
dates, so its partition is unchanged today — the gap was latent, and it is the new tests,
not METTSIM, that pin a parameter-only and a currency-only boundary each opening a regime.

## Calendar month and day: no change

Framework `policy_month`/`policy_day` nodes stay dimensionless. The accepted GEP text calls
month-of-year and day-of-month cyclic ordinals rather than affine points and gives them no
point-plus-duration algebra, so the dimensionless nodes agree with it; retagging them as
calendar coordinates would not.

## Tests

Eleven new tests, each written first and confirmed failing (`DID NOT RAISE` /
`ImportError`) before the implementation:

- truth contexts: `if`, conditional expression, and the leveled-boolean case that must keep
  passing;
- `xnp.where` with a dimensioned selector;
- `join` with a dimensioned key, and with a fallback in the wrong period;
- an in-body reduction demanding an opt-out;
- the date partition: function boundaries, a parameter-only change, a currency-only change,
  and boundaries dropped outside the date domain.

## Verification

`pixi run -e py314 tests ttsim/` → 1679 passed, 51 skipped. `pixi run -e py314-jax
tests-jax ttsim/` → 1707 passed, 23 skipped. `prek run --all-files` clean, both `ty`
backends included. All three were re-run on this branch rather than inherited from where
the work was developed.

## Deliberately out of scope

These need the canonical value type of GEP 10's later phases rather than a fix to the
present model, and are left for that work:

- a per-node evidence status (verified / derived by construction / cast / opt-out /
  unsupported), so users can tell proven nodes from trusted ones;
- environment-local unit vocabulary — `UnitSystem` still publishes currencies and grouping
  levels into process-global state, with `isolated_unit_vocabulary` as the test-level
  workaround;
- governance metadata on casts and whole-body opt-outs, and unit-blind equality;
- the group-indexed mean, storage grain, and inverse-unit coefficients in METTSIM, each of
  which still needs an opt-out or a cast because grain is modelled as a physical
  denominator.
