### PR TITLE
Bump gh-action-pypi-publish to v1.14.2 (metadata 2.5 support)

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -28,6 +28,6 @@ jobs:
           --outdir dist/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           attestations: true


### PR DESCRIPTION
The `v1.3.0` tag push built fine but failed at the upload gate:

```
Checking dist/ttsim_backend-1.3.0-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

(https://github.com/ttsim-dev/ttsim/actions/runs/32375860674)

The workflow installs `build` unpinned, so it picks up a current hatchling, which emits `Metadata-Version: 2.5`. The Twine bundled in `gh-action-pypi-publish@v1.14.0` only knows up to 2.4. `v1.14.2` ships Twine 7, which accepts 2.5 (pypa/gh-action-pypi-publish#416).

No repo code caused this — it is floating-dependency drift, which is why 1.2.1 published fine on the identical workflow.

**Follow-up needed:** 1.3.0 is still not on PyPI (latest is 1.2.1). Once this merges, the `v1.3.0` tag has to be moved to the fixed commit (or re-created) to re-trigger the publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)